### PR TITLE
Fix de Bruijn -> Symbol conversion; fixes #9

### DIFF
--- a/examples/polyI.vcl
+++ b/examples/polyI.vcl
@@ -1,0 +1,17 @@
+polyId : forall t. t -> t
+polyId = \{t} -> \x -> x
+
+realId : Real -> Real
+realId = polyId {Real}
+
+intId : Int -> Int
+intId = polyId {Int}
+
+real : Real
+real = polyId {Real} 0.0
+
+int : Int
+int = polyId {Int} 0
+
+tensorId : forall t. Tensor t [2] -> Tensor t [2]
+tensorId {t} = polyId {Tensor t [2]}

--- a/examples/polyK.vcl
+++ b/examples/polyK.vcl
@@ -1,0 +1,8 @@
+k : forall s. forall t. s -> t -> s
+k {s} {t} x y = x
+
+k2 : forall b. forall a. a -> b -> a
+k2 {b} {a} = k {a} {b}
+
+kRealInt : Real -> Int -> Real
+kRealInt = k {Real} {Int}

--- a/examples/polyK.vcl
+++ b/examples/polyK.vcl
@@ -1,6 +1,9 @@
 k : forall s. forall t. s -> t -> s
 k {s} {t} x y = x
 
+k1 : forall t. Real -> t -> Real
+k1 = k {Real}
+
 k2 : forall b. forall a. a -> b -> a
 k2 {b} {a} = k {a} {b}
 

--- a/src/hs/Vehicle/Core/Compile/Dataflow.hs
+++ b/src/hs/Vehicle/Core/Compile/Dataflow.hs
@@ -131,7 +131,7 @@ tellData ::
   forall sort s m.
   (KnownSort sort, sort `In` ['TARG, 'EARG], Monoid s, Monad m) =>
   s -> DataflowT sort s m ()
-tellData s = fromStateT $ modify (<>s)
+tellData s = fromStateT $ modify (s<>)
 
 
 -- * Cast |DataflowT| to specific monad transformers

--- a/src/hs/Vehicle/Core/Compile/Type.hs
+++ b/src/hs/Vehicle/Core/Compile/Type.hs
@@ -248,7 +248,7 @@ checkInferF = case sortSing @sort of
   STARG -> \case
     TArgF p n -> fromCheck p $ do
       k <- ask
-      tell $ singletonCtx STYPE (Info . unInfo $ k)
+      lift (tellData $ singletonCtx STYPE (Info . unInfo $ k))
       return (TArg (k :*: p) n)
 
   -- Expressions
@@ -381,7 +381,7 @@ checkInferF = case sortSing @sort of
   SEARG -> \case
     EArgF p n -> fromCheck p $ do
       t <- ask
-      tell $ singletonCtx SEXPR (coerce t)
+      lift (tellData $ singletonCtx SEXPR (coerce t))
       return (EArg (t :*: p) n)
 
   -- Declarations


### PR DESCRIPTION
Fixes the conversion from deBruijn to Symbols, via Names. The original problem was described in issue #9. The fix is to convert the main AST and the ASTs in the annotations in a single pass. This required modifying the `DataflowT` monad to treat allow for context information to always flow down the tree (specifically, into type and expression arguments).

This update makes the polymorphic identity examples in `examples/polyI.vcl` type check. However, there seems to still be some bug that prevents polymorphic functions with multiple arguments from working -- see the file `examples/polyK.vcl`. I suspect that there is something wrong with the substitution implementation.