### PR TITLE
Fix #246 by improving the error message for invalid property types

### DIFF
--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -120,7 +120,7 @@ data CompileError
   | InferableParameterContradictory      Identifier (DeclProvenance, Resource, Int) (DeclProvenance, Resource, Int)
   | InferableParameterUninferrable       DeclProvenance
 
-  | PropertyTypeUnsupported         DeclProvenance CheckedType
+  | PropertyTypeUnsupported DeclProvenance GluedType
 
   -- Backend errors
   | NoPropertiesFound

--- a/vehicle/src/Vehicle/Language/AST.hs
+++ b/vehicle/src/Vehicle/Language/AST.hs
@@ -1,6 +1,5 @@
 module Vehicle.Language.AST
   ( module X
-  , pattern InferableOption
   ) where
 
 import Vehicle.Language.AST.Arg as X
@@ -17,11 +16,3 @@ import Vehicle.Language.AST.Prog as X
 import Vehicle.Language.AST.Provenance as X
 import Vehicle.Language.AST.Relevance as X
 import Vehicle.Language.AST.Visibility as X
-
-import Data.Text
-
---------------------------------------------------------------------------------
--- Resource options
-
-pattern InferableOption :: Text
-pattern InferableOption = "infer"

--- a/vehicle/src/Vehicle/Language/AST/Decl.hs
+++ b/vehicle/src/Vehicle/Language/AST/Decl.hs
@@ -7,6 +7,8 @@ import Vehicle.Language.AST.Binder (HasType (..))
 import Vehicle.Language.AST.Name (HasIdentifier (..), Identifier)
 import Vehicle.Language.AST.Provenance
 import Vehicle.Resource (Resource)
+import Data.Text (Text)
+import Vehicle.Prelude
 
 --------------------------------------------------------------------------------
 -- Declarations
@@ -62,3 +64,19 @@ traverseDeclType f = \case
   DefResource p r n t -> DefResource p r n <$> f t
   DefFunction p n t e -> DefFunction p n <$> f t <*> pure e
   DefPostulate p n t  -> DefPostulate p n <$> f t
+
+
+--------------------------------------------------------------------------------
+-- Annotations options
+
+pattern InferableOption :: Text
+pattern InferableOption = "infer"
+
+data Annotation
+  = PropertyAnnotation
+  | ResourceAnnotation Resource
+
+instance Pretty Annotation where
+  pretty annotation = "@" <> case annotation of
+    PropertyAnnotation -> "property"
+    ResourceAnnotation resource -> pretty resource

--- a/vehicle/tests/golden/error/dataset/invalidContainerType/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/dataset/invalidContainerType/TypeCheck.err.golden
@@ -1,4 +1,4 @@
-Error at Line 2, Columns 1-16: The type of dataset 'trainingDataset':
+Error at Line 2, Columns 1-16: The type of @dataset 'trainingDataset':
   Nat
 is not supported. Only the following types are allowed for datasets:
   List, Vector, Tensor

--- a/vehicle/tests/golden/error/dataset/invalidElementType/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/dataset/invalidElementType/TypeCheck.err.golden
@@ -1,4 +1,4 @@
-Error at Line 2, Columns 1-16: The type of dataset 'trainingDataset':
+Error at Line 2, Columns 1-16: The type of @dataset 'trainingDataset':
   List (Nat -> Nat)
 is not supported as it has elements of an unsupported type:
   Nat -> Nat

--- a/vehicle/tests/golden/error/dataset/variableDimensions/Marabou.err.golden
+++ b/vehicle/tests/golden/error/dataset/variableDimensions/Marabou.err.golden
@@ -1,4 +1,4 @@
-Error at Line 5, Columns 1-16: The type of parameter 'trainingDataset':
+Error at Line 5, Columns 1-16: The type of @parameter 'trainingDataset':
   Tensor Nat ((if f [0] ! 0 > 0 then 2 else 3) :: nil)
 which reduces to:
   Vector Nat (if f [0.0] ! 0 > 0.0 then 2 else 3)

--- a/vehicle/tests/golden/error/network/notAFunction/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/network/notAFunction/TypeCheck.err.golden
@@ -1,4 +1,4 @@
-Error at Line 2, Columns 5-8: The type of network 'f':
+Error at Line 2, Columns 5-8: The type of @network 'f':
   Rat
 is not supported as it is not a function.
 Fix: Only networks of the following types are allowed:

--- a/vehicle/tests/golden/error/parameter/unsupportedType/Marabou.err.golden
+++ b/vehicle/tests/golden/error/parameter/unsupportedType/Marabou.err.golden
@@ -1,4 +1,4 @@
-Error at Line 2, Columns 1-2: The type of parameter 'n':
+Error at Line 2, Columns 1-2: The type of @parameter 'n':
   Nat -> Nat
 is not supported. Only the following types are allowed for parameters:
   Bool, Index, Nat, Int, Rat

--- a/vehicle/tests/golden/error/property/invalidType/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/property/invalidType/TypeCheck.err.golden
@@ -1,2 +1,5 @@
-Error at Line 2, Columns 1-2: Invalid type 'Rat' for property 'p'.
-Fix: change the type of 'p' to one of `Bool`, `Vector Bool n` or `Tensor Bool n`.
+Error at Line 2, Columns 1-2: The type of @property 'p':
+  Rat
+is not supported. Only the following types are allowed for '@property's:
+  Bool, Vector Bool n, Tensor Bool ns
+Fix: either change the type of 'p' to a supported type or remove the '@property' annotation.


### PR DESCRIPTION
The error message is now:
```
Error at Line 13, Columns 1-13: The type of @property 'isOneOrOther':
  Label -> Label -> Bool
is not supported. Only the following types are allowed for '@property's:
  Bool, Vector Bool n, Tensor Bool ns
Fix: either change the type of 'p' to a supported type or remove the '@property' annotation.
```
@ndslusarz better?