### PR TITLE
Add interface files to Vehicle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ __pycache__/
 
 # Examples folder
 examples/**/*.vclp
+examples/**/*.vcli
 examples/windController/agdaProof/WindControllerSpec.agda

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ __pycache__/
 
 # Examples folder
 examples/**/*.vclp
-examples/**/*.vcli
+examples/**/*.vclo
 examples/windController/agdaProof/WindControllerSpec.agda

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 * Added tested support for GHC 8.10, 9.2 and 9.4
 
-* Vehile now generates interface files with the `.vcli` extension that cache
+* Vehile now generates interface files with the `.vclo` extension that cache
   the results of type-checking. If the interface file exists and the hash matches
   then it won't re-type check the original file.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 * Added tested support for GHC 8.10, 9.2 and 9.4
 
+* Vehile now generates interface files with the `.vcli` extension that cache
+  the results of type-checking. If the interface file exists and the hash matches
+  then it won't re-type check the original file.
+
 * Improved the performance of type-checking by a factor of ~2.
 
 * Improved error messages which involved type-synonyms, which now display

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Arg.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Arg.hs
@@ -2,6 +2,7 @@ module Vehicle.Syntax.AST.Arg where
 
 import Control.DeepSeq (NFData)
 import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, FromJSON)
 
 import Vehicle.Syntax.AST.Binder
 import Vehicle.Syntax.AST.Provenance
@@ -24,7 +25,9 @@ data GenericArg expr = Arg
     -- ^ The argument expression
   } deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
-instance (NFData expr) => NFData (GenericArg expr)
+instance NFData   expr => NFData   (GenericArg expr)
+instance ToJSON   expr => ToJSON   (GenericArg expr)
+instance FromJSON expr => FromJSON (GenericArg expr)
 
 instance HasProvenance (GenericArg expr) where
   provenanceOf = argProvenance

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
@@ -2,6 +2,7 @@ module Vehicle.Syntax.AST.Binder where
 
 import Control.DeepSeq (NFData)
 import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, FromJSON)
 
 import Vehicle.Syntax.AST.Name
 import Vehicle.Syntax.AST.Provenance
@@ -29,7 +30,9 @@ data GenericBinder binder expr = Binder
   -- The type of the bound variable
   } deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
-instance (NFData binder, NFData expr) => NFData (GenericBinder binder expr)
+instance (NFData   binder, NFData   expr) => NFData   (GenericBinder binder expr)
+instance (ToJSON   binder, ToJSON   expr) => ToJSON   (GenericBinder binder expr)
+instance (FromJSON binder, FromJSON expr) => FromJSON (GenericBinder binder expr)
 
 instance HasProvenance (GenericBinder binder expr) where
   provenanceOf = binderProvenance

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin.hs
@@ -17,6 +17,8 @@ import Vehicle.Syntax.AST.Builtin.Core as X
 import Vehicle.Syntax.AST.Builtin.Linearity as X
 import Vehicle.Syntax.AST.Builtin.Polarity as X
 import Vehicle.Syntax.AST.Builtin.TypeClass as X
+import Data.Aeson (FromJSON)
+import Data.Aeson.Types (ToJSON)
 
 --------------------------------------------------------------------------------
 -- Constructors
@@ -48,6 +50,8 @@ data BuiltinConstructor
 
 instance NFData   BuiltinConstructor
 instance Hashable BuiltinConstructor
+instance ToJSON   BuiltinConstructor
+instance FromJSON BuiltinConstructor
 
 instance Pretty BuiltinConstructor where
   pretty = \case
@@ -78,6 +82,9 @@ data NegDomain
 
 instance NFData   NegDomain
 instance Hashable NegDomain
+instance ToJSON   NegDomain
+instance FromJSON NegDomain
+
 
 instance Pretty NegDomain where
   pretty = \case
@@ -97,6 +104,8 @@ data AddDomain
 
 instance NFData   AddDomain
 instance Hashable AddDomain
+instance ToJSON   AddDomain
+instance FromJSON AddDomain
 
 instance Pretty AddDomain where
   pretty = \case
@@ -111,6 +120,8 @@ data SubDomain
 
 instance NFData   SubDomain
 instance Hashable SubDomain
+instance ToJSON   SubDomain
+instance FromJSON SubDomain
 
 instance Pretty SubDomain where
   pretty = \case
@@ -135,6 +146,8 @@ data MulDomain
 
 instance NFData   MulDomain
 instance Hashable MulDomain
+instance ToJSON   MulDomain
+instance FromJSON MulDomain
 
 instance Pretty MulDomain where
   pretty = \case
@@ -148,6 +161,8 @@ data DivDomain
 
 instance NFData   DivDomain
 instance Hashable DivDomain
+instance ToJSON   DivDomain
+instance FromJSON DivDomain
 
 instance Pretty DivDomain where
   pretty = \case
@@ -169,6 +184,8 @@ instance Pretty FromNatDomain where
 
 instance NFData   FromNatDomain
 instance Hashable FromNatDomain
+instance ToJSON   FromNatDomain
+instance FromJSON FromNatDomain
 
 data FromRatDomain
   = FromRatToRat
@@ -180,6 +197,8 @@ instance Pretty FromRatDomain where
 
 instance NFData   FromRatDomain
 instance Hashable FromRatDomain
+instance ToJSON   FromRatDomain
+instance FromJSON FromRatDomain
 
 data FromVecDomain
   = FromVecToVec
@@ -193,6 +212,8 @@ instance Pretty FromVecDomain where
 
 instance NFData   FromVecDomain
 instance Hashable FromVecDomain
+instance ToJSON   FromVecDomain
+instance FromJSON FromVecDomain
 
 data FoldDomain
   = FoldList
@@ -206,6 +227,8 @@ instance Pretty FoldDomain where
 
 instance NFData   FoldDomain
 instance Hashable FoldDomain
+instance ToJSON   FoldDomain
+instance FromJSON FoldDomain
 
 data MapDomain
   = MapList
@@ -219,6 +242,8 @@ instance Pretty MapDomain where
 
 instance NFData   MapDomain
 instance Hashable MapDomain
+instance ToJSON   MapDomain
+instance FromJSON MapDomain
 
 
 -- |Builtins in the Vehicle language
@@ -260,6 +285,8 @@ data Builtin
 
 instance NFData   Builtin
 instance Hashable Builtin
+instance ToJSON   Builtin
+instance FromJSON Builtin
 
 -- TODO all the show instances should really be obtainable from the grammar
 -- somehow.

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Core.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Core.hs
@@ -20,6 +20,7 @@ module Vehicle.Syntax.AST.Builtin.Core
 import Control.DeepSeq (NFData (..))
 import Data.Hashable (Hashable (..))
 import Data.Text (Text)
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 import Prettyprinter (Doc, Pretty (..))
 
@@ -34,6 +35,8 @@ data FunctionPosition
 
 instance NFData   FunctionPosition
 instance Hashable FunctionPosition
+instance ToJSON   FunctionPosition
+instance FromJSON FunctionPosition
 
 instance Pretty FunctionPosition where
   pretty = \case
@@ -50,6 +53,8 @@ data EqualityOp
 
 instance NFData   EqualityOp
 instance Hashable EqualityOp
+instance ToJSON   EqualityOp
+instance FromJSON EqualityOp
 
 instance Pretty EqualityOp where
   pretty = \case
@@ -74,6 +79,8 @@ data EqualityDomain
 
 instance NFData   EqualityDomain
 instance Hashable EqualityDomain
+instance ToJSON   EqualityDomain
+instance FromJSON EqualityDomain
 
 instance Pretty EqualityDomain where
   pretty = \case
@@ -94,6 +101,8 @@ data OrderOp
 
 instance NFData   OrderOp
 instance Hashable OrderOp
+instance ToJSON   OrderOp
+instance FromJSON OrderOp
 
 instance Pretty OrderOp where
   pretty = \case
@@ -144,6 +153,8 @@ data OrderDomain
 
 instance NFData   OrderDomain
 instance Hashable OrderDomain
+instance ToJSON   OrderDomain
+instance FromJSON OrderDomain
 
 instance Pretty OrderDomain where
   pretty = \case
@@ -162,6 +173,8 @@ data Quantifier
 
 instance NFData   Quantifier
 instance Hashable Quantifier
+instance ToJSON   Quantifier
+instance FromJSON Quantifier
 
 instance Pretty Quantifier where
   pretty = \case

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Linearity.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Linearity.hs
@@ -3,6 +3,7 @@ module Vehicle.Syntax.AST.Builtin.Linearity where
 import Control.DeepSeq (NFData (..))
 import Data.Hashable (Hashable (..))
 import Data.Text (Text)
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
 
@@ -20,6 +21,9 @@ data LinearityProvenance
   | NetworkOutputProvenance      Provenance Text
   | LinFunctionProvenance        Provenance LinearityProvenance FunctionPosition
   deriving (Generic)
+
+instance ToJSON   LinearityProvenance
+instance FromJSON LinearityProvenance
 
 instance Show LinearityProvenance where
   show _x = ""
@@ -53,6 +57,8 @@ instance Ord Linearity where
 
 instance NFData   Linearity
 instance Hashable Linearity
+instance ToJSON   Linearity
+instance FromJSON Linearity
 
 instance Pretty Linearity where
   pretty = \case
@@ -78,6 +84,8 @@ data LinearityTypeClass
   | IfCondLinearity
   deriving (Eq, Generic, Show)
 
+instance ToJSON   LinearityTypeClass
+instance FromJSON LinearityTypeClass
 instance NFData   LinearityTypeClass
 instance Hashable LinearityTypeClass
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Polarity.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Polarity.hs
@@ -2,6 +2,7 @@ module Vehicle.Syntax.AST.Builtin.Polarity where
 
 import Control.DeepSeq (NFData (..))
 import Data.Hashable (Hashable (..))
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), (<+>))
 
@@ -19,6 +20,9 @@ data PolarityProvenance
   | EqProvenance             Provenance PolarityProvenance EqualityOp
   | PolFunctionProvenance    Provenance PolarityProvenance FunctionPosition
   deriving (Generic)
+
+instance ToJSON   PolarityProvenance
+instance FromJSON PolarityProvenance
 
 instance Show PolarityProvenance where
   show _x = ""
@@ -46,8 +50,10 @@ data Polarity
   | MixedSequential Quantifier Provenance PolarityProvenance
   deriving (Eq, Generic, Show)
 
-instance NFData Polarity
+instance NFData   Polarity
 instance Hashable Polarity
+instance ToJSON   Polarity
+instance FromJSON Polarity
 
 instance Pretty Polarity where
   pretty = \case
@@ -78,6 +84,8 @@ data PolarityTypeClass
   | IfCondPolarity
   deriving (Eq, Generic, Show)
 
+instance ToJSON   PolarityTypeClass
+instance FromJSON PolarityTypeClass
 instance NFData   PolarityTypeClass
 instance Hashable PolarityTypeClass
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/TypeClass.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/TypeClass.hs
@@ -2,6 +2,7 @@
 module Vehicle.Syntax.AST.Builtin.TypeClass where
 
 import Control.DeepSeq (NFData (..))
+import Data.Aeson (ToJSON, FromJSON)
 import Data.Hashable (Hashable (..))
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), (<+>))
@@ -56,6 +57,8 @@ data TypeClass
 
 instance NFData   TypeClass
 instance Hashable TypeClass
+instance ToJSON   TypeClass
+instance FromJSON TypeClass
 
 instance Pretty TypeClass where
   pretty = \case
@@ -115,6 +118,8 @@ data TypeClassOp
 
 instance NFData   TypeClassOp
 instance Hashable TypeClassOp
+instance ToJSON   TypeClassOp
+instance FromJSON TypeClassOp
 
 instance Pretty TypeClassOp where
   pretty = \case

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -7,6 +7,7 @@ import Data.Text (Text)
 import Prettyprinter (Pretty (..))
 import Vehicle.Syntax.AST.Name (HasIdentifier (..), Identifier)
 import Vehicle.Syntax.AST.Provenance
+import Data.Aeson (ToJSON, FromJSON)
 
 --------------------------------------------------------------------------------
 -- Declarations
@@ -31,7 +32,9 @@ data GenericDecl expr
     expr
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
-instance NFData expr => NFData (GenericDecl expr)
+instance NFData   expr => NFData   (GenericDecl expr)
+instance ToJSON   expr => ToJSON   (GenericDecl expr)
+instance FromJSON expr => FromJSON (GenericDecl expr)
 
 instance HasProvenance (GenericDecl expr) where
   provenanceOf = \case
@@ -83,7 +86,9 @@ data Resource
   | InferableParameter
   deriving (Eq, Show, Generic)
 
-instance NFData Resource
+instance NFData   Resource
+instance ToJSON   Resource
+instance FromJSON Resource
 
 instance Pretty Resource where
   pretty = \case

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -7,6 +7,7 @@ import Control.DeepSeq (NFData)
 import Data.Functor.Foldable.TH (makeBaseFunctor)
 import Data.Hashable (Hashable)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), (<+>))
 
@@ -32,6 +33,8 @@ data Universe
 
 instance NFData   Universe
 instance Hashable Universe
+instance ToJSON   Universe
+instance FromJSON Universe
 
 instance Pretty Universe where
   pretty = \case
@@ -56,6 +59,8 @@ data Literal
 
 instance NFData   Literal
 instance Hashable Literal
+instance ToJSON   Literal
+instance FromJSON Literal
 
 instance Pretty Literal where
   pretty = \case
@@ -154,7 +159,9 @@ data Expr binder var
 
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
-instance (NFData binder, NFData var) => NFData (Expr binder var)
+instance (NFData   binder, NFData   var) => NFData   (Expr binder var)
+instance (ToJSON   binder, ToJSON   var) => ToJSON   (Expr binder var)
+instance (FromJSON binder, FromJSON var) => FromJSON (Expr binder var)
 
 type Type = Expr
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Meta.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Meta.hs
@@ -3,6 +3,7 @@ module Vehicle.Syntax.AST.Meta where
 
 import Control.DeepSeq (NFData)
 import Data.Hashable (Hashable)
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
 
@@ -14,6 +15,8 @@ newtype MetaID = MetaID Int
 
 instance NFData   MetaID
 instance Hashable MetaID
+instance ToJSON   MetaID
+instance FromJSON MetaID
 
 instance Pretty MetaID where
   pretty (MetaID m) = "?" <> pretty m

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Prog.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Prog.hs
@@ -2,6 +2,7 @@ module Vehicle.Syntax.AST.Prog where
 
 import Control.DeepSeq (NFData)
 import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, FromJSON)
 
 import Vehicle.Syntax.AST.Decl (GenericDecl)
 
@@ -13,7 +14,9 @@ newtype GenericProg expr
   = Main [GenericDecl expr] -- ^ List of declarations.
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
-instance NFData expr => NFData (GenericProg expr)
+instance NFData   expr => NFData   (GenericProg expr)
+instance ToJSON   expr => ToJSON   (GenericProg expr)
+instance FromJSON expr => FromJSON (GenericProg expr)
 
 traverseDecls :: Monad m
               => (GenericDecl expr1 -> m (GenericDecl expr2))

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Provenance.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Provenance.hs
@@ -18,10 +18,11 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (maybeToList)
 import Data.Range hiding (joinRanges)
 import Data.Text (Text)
-import GHC.Generics (Generic)
+import GHC.Generics (Generic(..))
 import Prettyprinter (Pretty (..), concatWith, squotes, (<+>))
 
 import Vehicle.Syntax.Parse.Token
+import Data.Aeson (FromJSON(..), ToJSON (..))
 
 --------------------------------------------------------------------------------
 -- Position
@@ -34,13 +35,16 @@ import Vehicle.Syntax.Parse.Token
 data Position = Position
   { posLine   :: Int
   , posColumn :: Int
-  } deriving (Eq, Ord)
+  } deriving (Eq, Ord, Generic)
 
 instance Show Position where
   show (Position l c) = show (l, c)
 
 instance Pretty Position where
   pretty (Position l c) = "Line" <+> pretty l <+> "Column" <+> pretty c
+
+instance ToJSON   Position
+instance FromJSON Position
 
 -- |Get the starting position of a token.
 tkPosition :: IsToken a => a -> Position
@@ -139,6 +143,10 @@ instance Semigroup Owner where
 instance Monoid Owner where
   mempty = TheMachine
 
+instance ToJSON   Owner
+instance FromJSON Owner
+
+
 --------------------------------------------------------------------------------
 -- Origin
 
@@ -183,6 +191,12 @@ instance Show Provenance where
 
 instance NFData Provenance where
   rnf _ = ()
+
+instance ToJSON   Provenance where
+  toJSON _ = toJSON ()
+
+instance FromJSON Provenance where
+  parseJSON _ = return mempty
 
 instance Eq Provenance where
   _x == _y = True

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Relevance.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Relevance.hs
@@ -3,6 +3,7 @@ module Vehicle.Syntax.AST.Relevance where
 import Control.DeepSeq (NFData)
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, FromJSON)
 
 import Vehicle.Syntax.AST.Builtin
 
@@ -11,8 +12,10 @@ data Relevance
   | Irrelevant
   deriving (Eq, Ord, Show, Generic)
 
-instance NFData Relevance
+instance NFData   Relevance
 instance Hashable Relevance
+instance ToJSON   Relevance
+instance FromJSON Relevance
 
 class HasRelevance a where
   relevanceOf :: a -> Relevance

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Visibility.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Visibility.hs
@@ -2,6 +2,7 @@ module Vehicle.Syntax.AST.Visibility where
 
 import Control.DeepSeq (NFData)
 import Data.Hashable (Hashable)
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
 
@@ -20,8 +21,10 @@ data Visibility
   -- ^ Inferred via instance search/type class resolution
   deriving (Eq, Ord, Show, Generic)
 
-instance NFData Visibility
+instance NFData   Visibility
 instance Hashable Visibility
+instance ToJSON   Visibility
+instance FromJSON Visibility
 
 instance Pretty Visibility where
   pretty = \case

--- a/vehicle/src/Vehicle/Backend/Agda/Interact.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Interact.hs
@@ -5,5 +5,7 @@ module Vehicle.Backend.Agda.Interact
 import Vehicle.Backend.Prelude
 import Vehicle.Prelude
 
-writeAgdaFile :: Maybe FilePath -> Doc a -> IO ()
+import Control.Monad.IO.Class (MonadIO)
+
+writeAgdaFile :: MonadIO m => Maybe FilePath -> Doc a -> m ()
 writeAgdaFile = writeResultToFile AgdaBackend

--- a/vehicle/src/Vehicle/Backend/LossFunction/Interact.hs
+++ b/vehicle/src/Vehicle/Backend/LossFunction/Interact.hs
@@ -2,8 +2,10 @@ module Vehicle.Backend.LossFunction.Interact
   ( writeLossFunctionFiles
   ) where
 
+import Control.Monad.IO.Class
 import Data.Aeson.Encode.Pretty
 import Data.ByteString.Lazy.Char8
+
 import Vehicle.Backend.LossFunction.Compile
 import Vehicle.Backend.Prelude
 import Vehicle.Prelude
@@ -17,6 +19,10 @@ encode e = unpack $ flip encodePretty' e $ Config
   , confTrailingNewline = False
   }
 
-writeLossFunctionFiles :: Maybe FilePath -> DifferentiableLogic -> [LDecl] -> IO ()
+writeLossFunctionFiles :: MonadIO m
+                       => Maybe FilePath
+                       -> DifferentiableLogic
+                       -> [LDecl]
+                       -> m ()
 writeLossFunctionFiles filepath t functions =
   writeResultToFile (LossFunction t) filepath (pretty (encode functions))

--- a/vehicle/src/Vehicle/Backend/Prelude.hs
+++ b/vehicle/src/Vehicle/Backend/Prelude.hs
@@ -1,5 +1,6 @@
 module Vehicle.Backend.Prelude where
 
+import Control.Monad.IO.Class
 import Data.Text.IO qualified as TIO
 import Data.Version (Version, makeVersion)
 import System.Directory (createDirectoryIfMissing)
@@ -111,10 +112,10 @@ prependfileHeader doc target = case commentTokenOf target of
     ]) <> line <> line <> doc
   where targetVersion = maybe "N/A" pretty (versionOf target)
 
-writeResultToFile :: Backend -> Maybe FilePath -> Doc a -> IO ()
+writeResultToFile :: MonadIO m => Backend -> Maybe FilePath -> Doc a -> m ()
 writeResultToFile target filepath doc = do
   let text = layoutAsText $ prependfileHeader doc target
-  case filepath of
+  liftIO $ case filepath of
     Nothing             -> TIO.putStrLn text
     Just outputFilePath -> do
       createDirectoryIfMissing True (takeDirectory outputFilePath)

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -20,7 +20,7 @@ import Vehicle.Check (CheckOptions (..))
 import Vehicle.Compile (CompileOptions (..))
 import Vehicle.Export (ExportOptions (..))
 import Vehicle.Prelude (LoggingLevel, defaultLoggingLevel, enumerate,
-                        loggingLevelHelp, supportedOptions)
+                        loggingLevelHelp, supportedOptions, vehicleFileExtension)
 import Vehicle.Verify (VerifierIdentifier, VerifyOptions (..))
 
 --------------------------------------------------------------------------------
@@ -91,7 +91,8 @@ modeOptionsParser = optional $ hsubparser $
 -- Compile mode
 
 compileDescription :: InfoMod ModeOptions
-compileDescription = progDesc "Compile a .vcl file to an output target"
+compileDescription = progDesc $
+  "Compile a " <> vehicleFileExtension <> " file to an output target"
 
 compileParser :: Parser CompileOptions
 compileParser = CompileOptions
@@ -200,7 +201,7 @@ specificationParser = strOption $
   long    "specification" <>
   short   's' <>
   metavar "FILE" <>
-  help    "The .vcl file containing the specification."
+  help    ("The " <> vehicleFileExtension <> " file containing the specification.")
 
 networkParser :: Parser (Map Text FilePath)
 networkParser = resourceOption $

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -37,7 +37,7 @@ import Vehicle.Verify.Specification
 import Vehicle.Verify.Specification.IO
 import Vehicle.Verify.Verifier (verifiers)
 import Vehicle.Verify.Core
-import Vehicle.Compile.InterfaceFile
+import Vehicle.Compile.ObjectFile
 
 data CompileOptions = CompileOptions
   { target                :: Backend
@@ -158,12 +158,12 @@ typeCheckOrLoadProg :: (MonadIO m, MonadCompile m)
                     -> m TypeCheckingResult
 typeCheckOrLoadProg specificationFile declarationsToCompile = do
   spec <- readSpecification specificationFile
-  interfaceFileResult <- readInterfaceFile specificationFile spec
+  interfaceFileResult <- readObjectFile specificationFile spec
   case interfaceFileResult of
     Just result -> return result
     Nothing     -> do
       result <- typeCheckProg spec declarationsToCompile
-      writeInterfaceFile specificationFile spec result
+      writeObjectFile specificationFile spec result
       return result
 
 parseExprText :: MonadCompile m => Text -> m InputExpr

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -16,6 +16,12 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Data.Set (Set)
 import Data.Text as T (Text)
 import Data.Text.IO qualified as TIO
+<<<<<<< HEAD
+=======
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn)
+import System.FilePath (takeExtension, dropExtension)
+>>>>>>> Add interface files to cache type-checking
 
 import Vehicle.Backend.Agda
 import Vehicle.Backend.LossFunction (LDecl, writeLossFunctionFiles)
@@ -51,7 +57,12 @@ data CompileOptions = CompileOptions
 compile :: LoggingSettings -> CompileOptions -> IO ()
 compile loggingSettings CompileOptions{..} = do
   let resources = Resources networkLocations datasetLocations parameterValues
+<<<<<<< HEAD
   spec <- readSpecification specification
+=======
+  spec <- readSpecification loggingOptions specification
+  specInterface <- readSpecificationInterface loggingOptions specification
+>>>>>>> Add interface files to cache type-checking
   case target of
     TypeCheck -> do
       _ <- runCompileMonad loggingSettings $ typeCheckProg spec declarationsToCompile
@@ -116,11 +127,36 @@ compileToAgda loggingSettings agdaOptions spec properties _resources =
 --------------------------------------------------------------------------------
 -- Useful functions that apply multiple compiler passes
 
+<<<<<<< HEAD
 readSpecification :: MonadIO m => FilePath -> m SpecificationText
 readSpecification inputFile = do
   liftIO $ TIO.readFile inputFile `catch` \ (e :: IOException) ->
     fatalError $ "Error occured while reading input file:" <+> line <>
       indent 2 (pretty (show e))
+=======
+readSpecification :: MonadIO m => VehicleIOSettings -> FilePath -> m SpecificationText
+readSpecification VehicleIOSettings{..} inputFile
+  | takeExtension inputFile == vehicleFileExtension = liftIO $ do
+    hPutStrLn errorHandle $
+      "Specification file does not have the correct extension (" <> vehicleFileExtension <> ")"
+    exitFailure
+  | otherwise = liftIO $
+    TIO.readFile inputFile `catch` \ (e :: IOException) -> do
+      hPutStrLn errorHandle $
+        "Error occured while reading specification file: \n  " <> show e
+      exitFailure
+
+readSpecificationInterface :: MonadIO m
+                           => VehicleIOSettings
+                           -> FilePath
+                           -> m (Maybe CheckedProg)
+readSpecificationInterface VehicleIOSettings{..} inputFile = do
+  let interfaceFile = dropExtension inputFile <> vehicleInterfaceFileExtension
+  interfaceContent <- liftIO $ do
+    (Just <$> TIO.readFile interfaceFile) `catch` \ (_ :: IOException) -> return Nothing
+
+  return _
+>>>>>>> Add interface files to cache type-checking
 
 parseAndTypeCheckExpr :: MonadCompile m => Text -> m CheckedExpr
 parseAndTypeCheckExpr expr = do
@@ -136,11 +172,37 @@ typeCheckProg :: MonadCompile m
               -> DeclarationNames
               -> m (GluedProg, PropertyContext)
 typeCheckProg spec declarationsToCompile = do
+<<<<<<< HEAD
   (vehicleProg, uncheckedPropertyCtx) <- parseProgText spec
   (scopedProg, dependencyGraph) <- scopeCheck vehicleProg
   prunedProg <- analyseDependenciesAndPrune scopedProg uncheckedPropertyCtx dependencyGraph declarationsToCompile
   (typedProg, propertyContext) <- typeCheck prunedProg uncheckedPropertyCtx
   return (typedProg, propertyContext)
+=======
+  interfaceFileResult <- _
+  case interfaceFileResult of
+    Just _  -> _
+    Nothing -> do
+      (vehicleProg, uncheckedPropertyCtx) <- parseProgText spec
+      (scopedProg, dependencyGraph) <- scopeCheck vehicleProg
+      prunedProg <- analyseDependenciesAndPrune scopedProg uncheckedPropertyCtx dependencyGraph declarationsToCompile
+      (typedProg, propertyContext) <- typeCheck prunedProg uncheckedPropertyCtx
+      _
+      return (typedProg, propertyContext, dependencyGraph)
+
+-- | Parses, expands parameters and datasets, type-checks and then
+-- checks the network types from disk. Used during compilation to
+-- verification queries.
+typeCheckProgAndLoadResources :: (MonadIO m, MonadCompile m)
+                              => SpecificationText
+                              -> DeclarationNames
+                              -> Resources
+                              -> m (CheckedProg, PropertyContext, NetworkContext, DependencyGraph)
+typeCheckProgAndLoadResources spec declarationsToCompile resources = do
+  (typedProg, propertyCtx, depGraph) <- typeCheckProg spec declarationsToCompile
+  (networkCtx, finalProg) <- expandResources resources True typedProg
+  return (finalProg, propertyCtx, networkCtx, depGraph)
+>>>>>>> Add interface files to cache type-checking
 
 parseExprText :: MonadCompile m => Text -> m InputExpr
 parseExprText txt =

--- a/vehicle/src/Vehicle/Compile/InterfaceFile.hs
+++ b/vehicle/src/Vehicle/Compile/InterfaceFile.hs
@@ -1,0 +1,14 @@
+
+module Vehicle.Compile.InterfaceFile where
+
+import Data.Text (Text)
+
+import Vehicle.Compile.Prelude
+
+data InterfaceFile = InterfaceFile
+  { fileHash   :: Int
+  , serialised :: CheckedExpr
+  }
+
+loadInterfaceFile :: Text -> Maybe CheckedProg
+loadInterfaceFile interfaceContent = _

--- a/vehicle/src/Vehicle/Compile/InterfaceFile.hs
+++ b/vehicle/src/Vehicle/Compile/InterfaceFile.hs
@@ -1,14 +1,67 @@
 
-module Vehicle.Compile.InterfaceFile where
+module Vehicle.Compile.InterfaceFile
+  ( readInterfaceFile
+  , writeInterfaceFile
+  ) where
 
-import Data.Text (Text)
+import Control.Monad.IO.Class
+import Data.Aeson (ToJSON (..), FromJSON, encode, decode)
+import Data.ByteString.Lazy qualified as BIO
+import Control.Exception
+import System.FilePath (dropExtension)
+import GHC.Generics (Generic)
 
 import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type (TypeCheckingResult(..))
+import Data.Hashable (Hashable(..))
 
-data InterfaceFile = InterfaceFile
-  { fileHash   :: Int
-  , serialised :: CheckedExpr
-  }
+data InterfaceContents = InterfaceContents
+  { _fileHash   :: Int
+  , _typeResult :: TypeCheckingResult
+  } deriving (Generic)
 
-loadInterfaceFile :: Text -> Maybe CheckedProg
-loadInterfaceFile interfaceContent = _
+instance ToJSON   InterfaceContents
+instance FromJSON InterfaceContents
+
+getInterfaceFileFromSpecificationFile :: FilePath -> FilePath
+getInterfaceFileFromSpecificationFile specFile =
+  dropExtension specFile <> vehicleInterfaceFileExtension
+
+readInterfaceFile :: (MonadLogger m, MonadIO m)
+                  => FilePath
+                  -> SpecificationText
+                  -> m (Maybe TypeCheckingResult)
+readInterfaceFile specificationFile spec = do
+  let interfaceFile = getInterfaceFileFromSpecificationFile specificationFile
+  errorOrContents <- liftIO $ do
+    (Right <$> BIO.readFile interfaceFile) `catch` \ (e :: IOException) -> return (Left e)
+
+  case errorOrContents of
+    Left _error -> do
+      logDebug MinDetail $ "No interface file found for" <+> quotePretty specificationFile
+      return Nothing
+
+    Right contents -> case decode contents of
+      Nothing -> do
+        logDebug MinDetail $ "Unable to restore found interface file for" <+> quotePretty specificationFile
+        return Nothing
+
+      Just (InterfaceContents specHash result)
+        | specHash /= hash spec -> do
+          logDebug MinDetail $ "Outdated interface file found for" <+> quotePretty specificationFile
+          return Nothing
+
+        | otherwise -> do
+          logDebug MinDetail $ "Loaded interface file for" <+> quotePretty specificationFile
+          return $ Just result
+
+writeInterfaceFile :: MonadIO m
+                   => FilePath
+                   -> SpecificationText
+                   -> TypeCheckingResult
+                   -> m ()
+writeInterfaceFile specificationFile spec result = do
+  let interfaceFile = getInterfaceFileFromSpecificationFile specificationFile
+  let specHash = hash spec
+  let contents = InterfaceContents specHash result
+  liftIO $ BIO.writeFile interfaceFile (encode contents)

--- a/vehicle/src/Vehicle/Compile/Prelude.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude.hs
@@ -6,6 +6,7 @@ module Vehicle.Compile.Prelude
 import Control.DeepSeq (NFData)
 import Data.Map (Map)
 import Data.Set (Set)
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 
 import Vehicle.Compile.Dependency.Graph as X
@@ -112,7 +113,9 @@ data PropertyInfo
   = PropertyInfo Linearity Polarity
   deriving (Show, Eq, Generic)
 
-instance NFData PropertyInfo
+instance NFData   PropertyInfo
+instance ToJSON   PropertyInfo
+instance FromJSON PropertyInfo
 
 instance Pretty PropertyInfo where
   pretty (PropertyInfo lin pol) = pretty lin <+> pretty pol

--- a/vehicle/src/Vehicle/Export.hs
+++ b/vehicle/src/Vehicle/Export.hs
@@ -3,7 +3,7 @@ module Vehicle.Export where
 
 import System.Directory (makeAbsolute)
 
-import Vehicle.Backend.Agda (AgdaOptions (..), writeAgdaFile)
+import Vehicle.Backend.Agda (AgdaOptions (..))
 import Vehicle.Backend.Prelude
 import Vehicle.Compile
 import Vehicle.Prelude
@@ -22,11 +22,12 @@ export loggingSettings ExportOptions{..} = do
   proofCache <- readProofCache proofCacheLocation
   let spec = originalSpec proofCache
   let properties = originalProperties proofCache
-  let resources = reparseResources (resourceSummaries proofCache)
+  let _resources = reparseResources (resourceSummaries proofCache)
 
   absoluteProofCacheLocation <- Just <$> makeAbsolute proofCacheLocation
   case target of
-    Agda -> do
+    Agda -> runCompileMonad loggingSettings $ do
       let agdaOptions = AgdaOptions absoluteProofCacheLocation outputFile moduleName
-      agdaCode <- compileToAgda loggingSettings agdaOptions spec properties resources
-      writeAgdaFile outputFile agdaCode
+      typingCheckingResult <-  typeCheckProg spec properties
+      _ <- compileToAgda agdaOptions typingCheckingResult outputFile
+      return ()

--- a/vehicle/src/Vehicle/Expr/DeBruijn.hs
+++ b/vehicle/src/Vehicle/Expr/DeBruijn.hs
@@ -23,6 +23,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad.Reader (MonadReader (..), local, runReader)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Hashable (Hashable (..))
+import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics (Generic)
 
 import Vehicle.Syntax.AST
@@ -39,9 +40,10 @@ data DBVar
   | Bound DBIndex
   deriving (Eq, Ord, Show, Generic)
 
-instance NFData DBVar
-
+instance NFData   DBVar
 instance Hashable DBVar
+instance ToJSON   DBVar
+instance FromJSON DBVar
 
 -- |The type of the data DeBruijn notation stores at binding sites.
 type DBBinding = Maybe Name

--- a/vehicle/src/Vehicle/Expr/Normalised.hs
+++ b/vehicle/src/Vehicle/Expr/Normalised.hs
@@ -1,5 +1,8 @@
 module Vehicle.Expr.Normalised where
 
+import Data.Aeson (ToJSON, FromJSON)
+import GHC.Generics (Generic)
+
 import Vehicle.Compile.Prelude (CheckedExpr)
 import Vehicle.Expr.DeBruijn
 import Vehicle.Syntax.AST
@@ -20,7 +23,10 @@ data NormExpr
   | VMeta     Provenance MetaID Spine
   | VVar      Provenance DBVar Spine
   | VBuiltin  Provenance Builtin Spine
-  deriving (Show)
+  deriving (Show, Generic)
+
+instance ToJSON   NormExpr
+instance FromJSON NormExpr
 
 instance HasProvenance NormExpr where
   provenanceOf = \case
@@ -209,7 +215,10 @@ isBoundVar _                    = False
 data GluedExpr = Glued
   { unnormalised :: CheckedExpr
   , normalised   :: NormExpr
-  } deriving (Show)
+  } deriving (Show, Generic)
+
+instance ToJSON   GluedExpr
+instance FromJSON GluedExpr
 
 instance HasProvenance GluedExpr where
   provenanceOf = provenanceOf . unnormalised

--- a/vehicle/src/Vehicle/Prelude/IO.hs
+++ b/vehicle/src/Vehicle/Prelude/IO.hs
@@ -1,5 +1,16 @@
 module Vehicle.Prelude.IO
+<<<<<<< HEAD
   ( removeFileIfExists
+=======
+  ( vehicleFileExtension
+  , vehicleInterfaceFileExtension
+  , vehicleProofCacheFileExtension
+  , VehicleIOSettings(..)
+  , fromLoggedIO
+  , fromLoggerTIO
+  , outputErrorAndQuit
+  , removeFileIfExists
+>>>>>>> Add interface files to cache type-checking
   , fatalError
   , programOutput
   ) where
@@ -13,10 +24,35 @@ import System.Exit (exitFailure)
 import System.IO (hPrint, stderr)
 import System.IO.Error (isDoesNotExistError)
 
+<<<<<<< HEAD
 {-
 fromLoggerTIO :: LoggingSettings -> ImmediateLogger a -> IO a
 fromLoggerTIO options@LoggingSettings{..} logger = do
   (v, messages) <- runLogger loggingLevel logger
+=======
+vehicleFileExtension :: String
+vehicleFileExtension = ".vcl"
+
+vehicleInterfaceFileExtension :: String
+vehicleInterfaceFileExtension = vehicleFileExtension <> "i"
+
+vehicleProofCacheFileExtension :: String
+vehicleProofCacheFileExtension = vehicleFileExtension <> "p"
+
+data VehicleIOSettings = VehicleIOSettings
+  { errorHandle  :: Handle
+  , outputHandle :: Handle
+  , logHandle    :: Handle
+  , loggingLevel :: LoggingLevel
+  }
+
+fromLoggedIO :: MonadIO m => VehicleIOSettings -> LoggerT m a -> m a
+fromLoggedIO VehicleIOSettings{..} = flushLogger loggingLevel logHandle
+
+fromLoggerTIO :: VehicleIOSettings -> LoggerT IO a -> IO a
+fromLoggerTIO options@VehicleIOSettings{..} logger = do
+  (v, messages) <- runLoggerT loggingLevel logger
+>>>>>>> Add interface files to cache type-checking
   fromLoggedIO options $ do
     forM_ messages logMessage
     return v

--- a/vehicle/src/Vehicle/Prelude/IO.hs
+++ b/vehicle/src/Vehicle/Prelude/IO.hs
@@ -1,6 +1,6 @@
 module Vehicle.Prelude.IO
   ( vehicleFileExtension
-  , vehicleInterfaceFileExtension
+  , vehicleObjectFileExtension
   , vehicleProofCacheFileExtension
   , removeFileIfExists
   , fatalError
@@ -19,8 +19,8 @@ import System.IO.Error (isDoesNotExistError)
 vehicleFileExtension :: String
 vehicleFileExtension = ".vcl"
 
-vehicleInterfaceFileExtension :: String
-vehicleInterfaceFileExtension = vehicleFileExtension <> "i"
+vehicleObjectFileExtension :: String
+vehicleObjectFileExtension = vehicleFileExtension <> "o"
 
 vehicleProofCacheFileExtension :: String
 vehicleProofCacheFileExtension = vehicleFileExtension <> "p"

--- a/vehicle/src/Vehicle/Prelude/IO.hs
+++ b/vehicle/src/Vehicle/Prelude/IO.hs
@@ -1,16 +1,8 @@
 module Vehicle.Prelude.IO
-<<<<<<< HEAD
-  ( removeFileIfExists
-=======
   ( vehicleFileExtension
   , vehicleInterfaceFileExtension
   , vehicleProofCacheFileExtension
-  , VehicleIOSettings(..)
-  , fromLoggedIO
-  , fromLoggerTIO
-  , outputErrorAndQuit
   , removeFileIfExists
->>>>>>> Add interface files to cache type-checking
   , fatalError
   , programOutput
   ) where
@@ -24,12 +16,6 @@ import System.Exit (exitFailure)
 import System.IO (hPrint, stderr)
 import System.IO.Error (isDoesNotExistError)
 
-<<<<<<< HEAD
-{-
-fromLoggerTIO :: LoggingSettings -> ImmediateLogger a -> IO a
-fromLoggerTIO options@LoggingSettings{..} logger = do
-  (v, messages) <- runLogger loggingLevel logger
-=======
 vehicleFileExtension :: String
 vehicleFileExtension = ".vcl"
 
@@ -38,34 +24,6 @@ vehicleInterfaceFileExtension = vehicleFileExtension <> "i"
 
 vehicleProofCacheFileExtension :: String
 vehicleProofCacheFileExtension = vehicleFileExtension <> "p"
-
-data VehicleIOSettings = VehicleIOSettings
-  { errorHandle  :: Handle
-  , outputHandle :: Handle
-  , logHandle    :: Handle
-  , loggingLevel :: LoggingLevel
-  }
-
-fromLoggedIO :: MonadIO m => VehicleIOSettings -> LoggerT m a -> m a
-fromLoggedIO VehicleIOSettings{..} = flushLogger loggingLevel logHandle
-
-fromLoggerTIO :: VehicleIOSettings -> LoggerT IO a -> IO a
-fromLoggerTIO options@VehicleIOSettings{..} logger = do
-  (v, messages) <- runLoggerT loggingLevel logger
->>>>>>> Add interface files to cache type-checking
-  fromLoggedIO options $ do
-    forM_ messages logMessage
-    return v
-
-flushLogger :: MonadIO m => LoggingLevel -> Handle -> Logger a -> m a
-flushLogger debugLevel logHandle logger = do
-  (v, messages) <- liftIO $ runLogger debugLevel logger
-  flushLogs logHandle messages
-  return v
-
-flushLogs :: MonadIO m => Handle -> [Message] -> m ()
-flushLogs logHandle messages = liftIO $ mapM_ (hPrint logHandle) messages
--}
 
 --------------------------------------------------------------------------------
 -- IO operations

--- a/vehicle/src/Vehicle/Resource.hs
+++ b/vehicle/src/Vehicle/Resource.hs
@@ -54,9 +54,6 @@ data ResourceSummary = ResourceSummary
   , resType  :: Resource
   } deriving (Generic)
 
-instance FromJSON Resource
-instance ToJSON Resource
-
 instance FromJSON ResourceSummary
 instance ToJSON ResourceSummary
 

--- a/vehicle/src/Vehicle/Verify/ProofCache.hs
+++ b/vehicle/src/Vehicle/Verify/ProofCache.hs
@@ -8,6 +8,8 @@ import Data.Version (Version)
 import GHC.Generics (Generic)
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
+import System.FilePath (dropExtension)
+
 import Vehicle.Compile.Prelude
 import Vehicle.Verify.Specification.Status (SpecificationStatus)
 
@@ -26,7 +28,9 @@ instance FromJSON ProofCache
 instance ToJSON ProofCache
 
 writeProofCache :: MonadIO m => FilePath -> ProofCache -> m ()
-writeProofCache file status = liftIO $ ByteString.writeFile file (encodePretty status)
+writeProofCache file status = do
+  let filepath = dropExtension file <> vehicleProofCacheFileExtension
+  liftIO $ ByteString.writeFile filepath (encodePretty status)
 
 readProofCache :: FilePath -> IO ProofCache
 readProofCache file = do

--- a/vehicle/tests/golden/Vehicle/Test/Golden.hs
+++ b/vehicle/tests/golden/Vehicle/Test/Golden.hs
@@ -33,7 +33,7 @@ import Vehicle.Test.Golden.TestSpec (TestOutput (..), TestSpec,
                                      testSpecIsEnabled, testSpecName,
                                      testSpecNeeds, testSpecOptions,
                                      testSpecRun, writeGoldenFiles)
-import Vehicle.Prelude ( vehicleInterfaceFileExtension )
+import Vehicle.Prelude ( vehicleObjectFileExtension )
 
 -- | Create a test tree from all test specifications in a directory, recursively.
 makeTestTreeFromDirectoryRecursive :: TestName -> FilePath -> IO TestTree
@@ -127,4 +127,4 @@ isOutputFile inputFiles file =
   -- Exclude profiling files
   extension /= ".prof" &&
   -- Exclude interface files
-  extension /= vehicleInterfaceFileExtension
+  extension /= vehicleObjectFileExtension

--- a/vehicle/tests/golden/Vehicle/Test/Golden.hs
+++ b/vehicle/tests/golden/Vehicle/Test/Golden.hs
@@ -33,6 +33,7 @@ import Vehicle.Test.Golden.TestSpec (TestOutput (..), TestSpec,
                                      testSpecIsEnabled, testSpecName,
                                      testSpecNeeds, testSpecOptions,
                                      testSpecRun, writeGoldenFiles)
+import Vehicle.Prelude ( vehicleInterfaceFileExtension )
 
 -- | Create a test tree from all test specifications in a directory, recursively.
 makeTestTreeFromDirectoryRecursive :: TestName -> FilePath -> IO TestTree
@@ -121,6 +122,9 @@ getTestOutputFiles ignoredFiles tempDirectory = do
 
 isOutputFile :: Set FilePath -> FilePath -> Bool
 isOutputFile inputFiles file =
+  let extension = takeExtension file in
   file `Set.notMember` inputFiles &&
-  -- Don't include profiling files
-  takeExtension file /= ".prof"
+  -- Exclude profiling files
+  extension /= ".prof" &&
+  -- Exclude interface files
+  extension /= vehicleInterfaceFileExtension

--- a/vehicle/tests/golden/error/argument/missingInputFile/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/argument/missingInputFile/TypeCheck.err.golden
@@ -1,2 +1,2 @@
-Error occured while reading input file: 
+Error occured while reading specification 'missingInputFile.vcl':
   missingInputFile.vcl: openFile: does not exist (No such file or directory)

--- a/vehicle/tests/golden/error/argument/wrongFileExtension/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/argument/wrongFileExtension/TypeCheck.err.golden
@@ -1,0 +1,1 @@
+Specification 'wrongExtension.vclt' has unsupported extension '.vclt'. Only files with a '.vcl' extension are supported.

--- a/vehicle/tests/golden/error/argument/wrongFileExtension/test.json
+++ b/vehicle/tests/golden/error/argument/wrongFileExtension/test.json
@@ -1,0 +1,4 @@
+{
+  "name": "TypeCheck",
+  "run": "vehicle compile -s wrongExtension.vclt -t TypeCheck"
+}

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
@@ -36,11 +36,11 @@ commandLineParserTests = testGroup "CommandLineParser"
         }
 
   , parserTest "checkMode"
-    "vehicle check --proofCache mpc.vpcl" $
+    "vehicle check --proofCache mpc.vclp" $
       Options
       { globalOptions = defaultGlobalOptions
       , modeOptions  = Just $ Check $ CheckOptions
-        { proofCache = "mpc.vpcl"
+        { proofCache = "mpc.vclp"
         }
       }
 

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -131,6 +131,7 @@ library
     Vehicle.Compile.Dependency.Analysis
     Vehicle.Compile.Dependency.Graph
     Vehicle.Compile.ExpandResources.Dataset.IDX
+    Vehicle.Compile.InterfaceFile
     Vehicle.Compile.Monomorphisation
     Vehicle.Compile.Prelude.Contexts
     Vehicle.Compile.Prelude.Utils

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -131,8 +131,8 @@ library
     Vehicle.Compile.Dependency.Analysis
     Vehicle.Compile.Dependency.Graph
     Vehicle.Compile.ExpandResources.Dataset.IDX
-    Vehicle.Compile.InterfaceFile
     Vehicle.Compile.Monomorphisation
+    Vehicle.Compile.ObjectFile
     Vehicle.Compile.Prelude.Contexts
     Vehicle.Compile.Prelude.Utils
     Vehicle.Compile.QuantifierAnalysis


### PR DESCRIPTION
Added interface files (using the `.vcli` extension). Caches the result of type-checking along with a hash, via serialisation to JSON.

@wenkokke any bright ideas about how to test the functionality using the test suite? I guess we can add a double command to the `run` field in the `test.json` to run a Vehicle command twice, but we won't easily be able to detect that it is loading the interfaces... unless we add a `--use-interfaces` option to the command line?