### PR TITLE
Migrate strictness annotations to use of StrictData and add benchmarks

### DIFF
--- a/scripts/benchmark
+++ b/scripts/benchmark
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# build all tests
+cabal build all --enable-tests
+
+# get the current commit hash
+commit_hash=$(git rev-parse HEAD)
+
+# create .benchmark directory
+mkdir -p .benchmark
+
+hyperfine \
+  --warmup 3 \
+  --runs 10 \
+  --export-json ".benchmark/benchmark-$commit_hash.json" \
+  --export-markdown ".benchmark/benchmark-$commit_hash.md" \
+  'cabal test all'

--- a/vehicle-syntax/src/Vehicle/Syntax/AST.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST.hs
@@ -8,9 +8,9 @@ import Vehicle.Syntax.AST.Binder as X
 import Vehicle.Syntax.AST.Builtin as X
 import Vehicle.Syntax.AST.Decl as X
 import Vehicle.Syntax.AST.Expr as X
+import Vehicle.Syntax.AST.Instances.NoThunks ()
 import Vehicle.Syntax.AST.Meta as X
 import Vehicle.Syntax.AST.Name as X
-import Vehicle.Syntax.AST.NoThunks as X
 import Vehicle.Syntax.AST.Prog as X
 import Vehicle.Syntax.AST.Provenance as X hiding
   ( Origin,

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Arg.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Arg.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Arg where
 
@@ -21,13 +21,13 @@ import Vehicle.Syntax.AST.Visibility
 -- stores.
 data GenericArg expr = Arg
   { -- | Has the argument been auto-inserted by the type-checker?
-    argProvenance :: !Provenance,
+    argProvenance :: Provenance,
     -- | The visibility of the argument
-    argVisibility :: !Visibility,
+    argVisibility :: Visibility,
     -- | The relevancy of the argument
-    argRelevance :: !Relevance,
+    argRelevance :: Relevance,
     -- | The argument expression
-    argExpr :: !expr
+    argExpr :: expr
   }
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Binder where
 
@@ -57,15 +57,15 @@ instance Hashable BinderForm
 -- manually provided by the user it never needs to be updated after unification
 -- and type-class resolution.
 data GenericBinder binder expr = Binder
-  { binderProvenance :: !Provenance,
-    binderForm :: !BinderForm,
+  { binderProvenance :: Provenance,
+    binderForm :: BinderForm,
     -- | The visibility of the binder
-    binderVisibility :: !Visibility,
+    binderVisibility :: Visibility,
     -- | The relevancy of the binder
-    binderRelevance :: !Relevance,
+    binderRelevance :: Relevance,
     -- | The representation of the bound variable
-    binderRepresentation :: !binder,
-    binderType :: !expr
+    binderRepresentation :: binder,
+    binderType :: expr
     -- The type of the bound variable
   }
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 -- | This module exports the datatype representations of the builtin symbols.
 module Vehicle.Syntax.AST.Builtin
@@ -34,8 +34,8 @@ import Vehicle.Syntax.AST.Builtin.TypeClass as X
 -- are viewed as constructors for `Type`.
 data BuiltinConstructor
   = -- Annotations - these should not be shown to the user.
-    Polarity !Polarity
-  | Linearity !Linearity
+    Polarity Polarity
+  | Linearity Linearity
   | -- Types
     Unit
   | Bool
@@ -46,7 +46,7 @@ data BuiltinConstructor
   | List
   | Vector
   | -- Type classes
-    TypeClass !TypeClass
+    TypeClass TypeClass
   | -- Container expressions
     Nil
   | Cons
@@ -280,7 +280,7 @@ instance FromJSON MapDomain
 
 -- | Builtins in the Vehicle language
 data Builtin
-  = Constructor !BuiltinConstructor
+  = Constructor BuiltinConstructor
   | -- Boolean expressions
     Not
   | And
@@ -288,24 +288,24 @@ data Builtin
   | Implies
   | If
   | -- Numeric conversion
-    FromNat !Int !FromNatDomain
-  | FromRat !FromRatDomain
-  | FromVec !Int !FromVecDomain
+    FromNat Int FromNatDomain
+  | FromRat FromRatDomain
+  | FromVec Int FromVecDomain
   | -- Numeric operations
-    Neg !NegDomain
-  | Add !AddDomain
-  | Sub !SubDomain
-  | Mul !MulDomain
-  | Div !DivDomain
+    Neg NegDomain
+  | Add AddDomain
+  | Sub SubDomain
+  | Mul MulDomain
+  | Div DivDomain
   | -- Comparison expressions
-    Equals !EqualityDomain !EqualityOp
-  | Order !OrderDomain !OrderOp
+    Equals EqualityDomain EqualityOp
+  | Order OrderDomain OrderOp
   | At
-  | Map !MapDomain
+  | Map MapDomain
   | -- Derived
     Tensor
-  | TypeClassOp !TypeClassOp
-  | Fold !FoldDomain
+  | TypeClassOp TypeClassOp
+  | Fold FoldDomain
   | Foreach
   deriving (Eq, Show, Generic)
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Core.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Core.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 -- | This module exports the datatype representations of the core builtin symbols.
 module Vehicle.Syntax.AST.Builtin.Core
@@ -31,8 +31,8 @@ import Prettyprinter (Doc, Pretty (..))
 
 -- | Represents whether something is an input or an output of a function
 data FunctionPosition
-  = FunctionInput !Text !Int
-  | FunctionOutput !Text
+  = FunctionInput Text Int
+  | FunctionOutput Text
   deriving (Eq, Show, Generic)
 
 instance NFData FunctionPosition

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Linearity.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Linearity.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Builtin.Linearity where
 
@@ -18,9 +18,9 @@ import Vehicle.Syntax.AST.Provenance (Provenance)
 -- 1) rename LinearityProvenance to LinearityProof
 -- 2) mimic AST nodes names
 data LinearityProvenance
-  = QuantifiedVariableProvenance !Provenance !Text
-  | NetworkOutputProvenance !Provenance !Text
-  | LinFunctionProvenance !Provenance !LinearityProvenance !FunctionPosition
+  = QuantifiedVariableProvenance Provenance Text
+  | NetworkOutputProvenance Provenance Text
+  | LinFunctionProvenance Provenance LinearityProvenance FunctionPosition
   deriving (Generic)
 
 instance ToJSON LinearityProvenance
@@ -46,8 +46,8 @@ instance Hashable LinearityProvenance where
 -- constant, linear or non-linear expression.
 data Linearity
   = Constant
-  | Linear !LinearityProvenance
-  | NonLinear !Provenance !LinearityProvenance !LinearityProvenance
+  | Linear LinearityProvenance
+  | NonLinear Provenance LinearityProvenance LinearityProvenance
   deriving (Eq, Show, Generic)
 
 instance Ord Linearity where
@@ -85,7 +85,7 @@ mapLinearityProvenance f = \case
 data LinearityTypeClass
   = MaxLinearity
   | MulLinearity
-  | FunctionLinearity !FunctionPosition
+  | FunctionLinearity FunctionPosition
   | IfCondLinearity
   deriving (Eq, Generic, Show)
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Polarity.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/Polarity.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Builtin.Polarity where
 
@@ -19,11 +19,11 @@ import Vehicle.Syntax.AST.Provenance (Provenance)
 
 -- | Used to track where the polarity information came from.
 data PolarityProvenance
-  = QuantifierProvenance !Provenance
-  | NegateProvenance !Provenance !PolarityProvenance
-  | LHSImpliesProvenance !Provenance !PolarityProvenance
-  | EqProvenance !Provenance !PolarityProvenance !EqualityOp
-  | PolFunctionProvenance !Provenance !PolarityProvenance !FunctionPosition
+  = QuantifierProvenance Provenance
+  | NegateProvenance Provenance PolarityProvenance
+  | LHSImpliesProvenance Provenance PolarityProvenance
+  | EqProvenance Provenance PolarityProvenance EqualityOp
+  | PolFunctionProvenance Provenance PolarityProvenance FunctionPosition
   deriving (Generic)
 
 instance ToJSON PolarityProvenance
@@ -49,11 +49,11 @@ instance Hashable PolarityProvenance where
 -- quantifiers it contains.
 data Polarity
   = Unquantified
-  | Quantified !Quantifier !PolarityProvenance
+  | Quantified Quantifier PolarityProvenance
   | -- | Stores the provenance of the `Forall` first followed by the `Exists`.
-    MixedParallel !PolarityProvenance !PolarityProvenance
+    MixedParallel PolarityProvenance PolarityProvenance
   | -- | Stores the type and provenance of the top-most quantifier first.
-    MixedSequential !Quantifier !Provenance !PolarityProvenance
+    MixedSequential Quantifier Provenance PolarityProvenance
   deriving (Eq, Show, Generic)
 
 instance NFData Polarity
@@ -85,11 +85,11 @@ mapPolarityProvenance f = \case
 
 data PolarityTypeClass
   = NegPolarity
-  | AddPolarity !Quantifier
-  | EqPolarity !EqualityOp
+  | AddPolarity Quantifier
+  | EqPolarity EqualityOp
   | ImpliesPolarity
   | MaxPolarity
-  | FunctionPolarity !FunctionPosition
+  | FunctionPolarity FunctionPosition
   | IfCondPolarity
   deriving (Eq, Generic, Show)
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/TypeClass.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin/TypeClass.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Builtin.TypeClass where
 
@@ -16,13 +16,13 @@ import Vehicle.Syntax.AST.Builtin.Polarity (PolarityTypeClass)
 
 data TypeClass
   = -- Operation type-classes
-    HasEq !EqualityOp
-  | HasOrd !OrderOp
+    HasEq EqualityOp
+  | HasOrd OrderOp
   | HasNot
   | HasAnd
   | HasOr
   | HasImplies
-  | HasQuantifier !Quantifier
+  | HasQuantifier Quantifier
   | HasAdd
   | HasSub
   | HasMul
@@ -31,22 +31,22 @@ data TypeClass
   | HasFold
   | HasMap
   | HasIf
-  | HasQuantifierIn !Quantifier
+  | HasQuantifierIn Quantifier
   | -- Literal type-classes
 
     -- | The parameter is the value (needed for Index).
-    HasNatLits !Int
+    HasNatLits Int
   | HasRatLits
   | -- | The parameter is the size of the vector.
-    HasVecLits !Int
+    HasVecLits Int
   | -- Utility constraints
 
     -- | Types are equal, modulo the auxiliary constraints.
     AlmostEqualConstraint
-  | NatInDomainConstraint !Int
+  | NatInDomainConstraint Int
   | -- Auxiliary typeclasses
-    LinearityTypeClass !LinearityTypeClass
-  | PolarityTypeClass !PolarityTypeClass
+    LinearityTypeClass LinearityTypeClass
+  | PolarityTypeClass PolarityTypeClass
   deriving (Eq, Generic, Show)
 
 instance NFData TypeClass
@@ -89,20 +89,20 @@ data TypeClassOp
   | AndTC
   | OrTC
   | ImpliesTC
-  | FromNatTC !Int
+  | FromNatTC Int
   | FromRatTC
-  | FromVecTC !Int
+  | FromVecTC Int
   | NegTC
   | AddTC
   | SubTC
   | MulTC
   | DivTC
-  | EqualsTC !EqualityOp
-  | OrderTC !OrderOp
+  | EqualsTC EqualityOp
+  | OrderTC OrderOp
   | MapTC
   | FoldTC
-  | QuantifierTC !Quantifier
-  | QuantifierInTC !Quantifier
+  | QuantifierTC Quantifier
+  | QuantifierInTC Quantifier
   deriving (Eq, Generic, Show)
 
 instance NFData TypeClassOp

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Decl where
 
@@ -16,20 +16,20 @@ import Vehicle.Syntax.AST.Provenance (HasProvenance (..), Provenance)
 -- | Type of top-level declarations.
 data GenericDecl expr
   = DefResource
-      !Provenance -- Location in source file.
-      !Identifier -- Name of resource.
-      !Resource -- Type of resource.
-      !expr -- Vehicle type of the resource.
+      Provenance -- Location in source file.
+      Identifier -- Name of resource.
+      Resource -- Type of resource.
+      expr -- Vehicle type of the resource.
   | DefFunction
-      !Provenance -- Location in source file.
-      !Identifier -- Bound function name.
-      !Bool -- Is it a property.
-      !expr -- Bound function type.
-      !expr -- Bound function body.
+      Provenance -- Location in source file.
+      Identifier -- Bound function name.
+      Bool -- Is it a property.
+      expr -- Bound function type.
+      expr -- Bound function body.
   | DefPostulate
-      !Provenance
-      !Identifier
-      !expr
+      Provenance
+      Identifier
+      expr
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 instance NFData expr => NFData (GenericDecl expr)
@@ -86,7 +86,7 @@ pattern InferableOption = "infer"
 
 data Annotation
   = PropertyAnnotation
-  | ResourceAnnotation !Resource
+  | ResourceAnnotation Resource
   deriving (Generic)
 
 instance Pretty Annotation where

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -26,7 +26,7 @@ import Vehicle.Syntax.AST.Provenance (HasProvenance (..), Provenance)
 type UniverseLevel = Int
 
 data Universe
-  = TypeUniv !UniverseLevel
+  = TypeUniv UniverseLevel
   | LinearityUniv
   | PolarityUniv
   deriving (Eq, Ord, Show, Generic)
@@ -53,11 +53,11 @@ instance Pretty Universe where
 -- - There should be a family of `Float` literals, but we haven't got there yet.
 data Literal
   = LUnit
-  | LBool !Bool
-  | LIndex !Int !Int
-  | LNat !Int
-  | LInt !Int
-  | LRat !Rational
+  | LBool Bool
+  | LIndex Int Int
+  | LNat Int
+  | LInt Int
+  | LRat Rational
   deriving (Eq, Ord, Show, Generic)
 
 instance NFData Literal
@@ -93,39 +93,39 @@ instance Pretty Rational where
 data Expr binder var
   = -- | A universe, used to type types.
     Universe
-      !Provenance
-      !Universe
+      Provenance
+      Universe
   | -- | User annotation
     Ann
-      !Provenance
-      !(Expr binder var) -- The term
-      !(Expr binder var) -- The type of the term
+      Provenance
+      (Expr binder var) -- The term
+      (Expr binder var) -- The type of the term
   | -- | Application of one term to another.
     App
-      !Provenance
-      !(Expr binder var) -- Function.
-      !(NonEmpty (Arg binder var)) -- Arguments.
+      Provenance
+      (Expr binder var) -- Function.
+      (NonEmpty (Arg binder var)) -- Arguments.
   | -- | Dependent product (subsumes both functions and universal quantification).
     Pi
-      !Provenance
-      !(Binder binder var) -- The bound name
-      !(Expr binder var) -- (Dependent) result type.
+      Provenance
+      (Binder binder var) -- The bound name
+      (Expr binder var) -- (Dependent) result type.
   | -- | Terms consisting of constants that are built into the language.
     Builtin
-      !Provenance
-      !Builtin -- Builtin name.
+      Provenance
+      Builtin -- Builtin name.
   | -- | Variables that are bound by other expressions
     Var
-      !Provenance
-      !var -- Variable name.
+      Provenance
+      var -- Variable name.
   | -- | A hole in the program.
     Hole
-      !Provenance
-      !Name -- Hole name.
+      Provenance
+      Name -- Hole name.
   | -- | Unsolved meta variables.
     Meta
-      !Provenance
-      !MetaID -- Meta variable number.
+      Provenance
+      MetaID -- Meta variable number.
   | -- | Let expressions. We have these in the core syntax because we want to
     -- cross compile them to various backends.
     --
@@ -133,23 +133,23 @@ data Expr binder var
     -- to better mimic the flow of the context, which makes writing monadic
     -- operations concisely much easier.
     Let
-      !Provenance
-      !(Expr binder var) -- Bound expression body.
-      !(Binder binder var) -- Bound expression name.
-      !(Expr binder var) -- Expression body.
+      Provenance
+      (Expr binder var) -- Bound expression body.
+      (Binder binder var) -- Bound expression name.
+      (Expr binder var) -- Expression body.
   | -- | Lambda expressions (i.e. anonymous functions).
     Lam
-      !Provenance
-      !(Binder binder var) -- Bound expression name.
-      !(Expr binder var) -- Expression body.
+      Provenance
+      (Binder binder var) -- Bound expression name.
+      (Expr binder var) -- Expression body.
   | -- | Built-in literal values e.g. numbers/booleans.
     Literal
-      !Provenance
-      !Literal -- Value.
+      Provenance
+      Literal -- Value.
   | -- | A sequence of terms for e.g. list literals.
     LVec
-      !Provenance
-      ![Expr binder var] -- List of expressions.
+      Provenance
+      [Expr binder var] -- List of expressions.
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 instance (NFData binder, NFData var) => NFData (Expr binder var)

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module Vehicle.Syntax.AST.NoThunks where
+module Vehicle.Syntax.AST.Instances.NoThunks where
 
 #if nothunks
 import Vehicle.Syntax.AST.Arg

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Meta.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Meta.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Meta where
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Name.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Name.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Name where
 
@@ -41,7 +41,7 @@ instance Pretty Module where
 --------------------------------------------------------------------------------
 -- Identifiers
 
-data Identifier = Identifier !Module !Name
+data Identifier = Identifier Module Name
   deriving (Eq, Ord, Show, Generic)
 
 instance Pretty Identifier where

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Prog.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Prog.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Prog where
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Provenance.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Provenance.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Provenance
   ( Provenance,
@@ -44,8 +44,8 @@ import Vehicle.Syntax.Parse.Token (IsToken, Token (Tk), tkLength, tkLocation)
 -- Note we don't use the names `line` and `column` as they clash with the
 -- `Prettyprinter` library.
 data Position = Position
-  { posLine :: !Int,
-    posColumn :: !Int
+  { posLine :: Int,
+    posColumn :: Int
   }
   deriving (Eq, Ord, Generic)
 
@@ -73,8 +73,8 @@ alterColumn f (Position l c) = Position l (f c)
 -- inclusive span ranges in our code.
 
 data Range = Range
-  { start :: !Position,
-    end :: !Position
+  { start :: Position,
+    end :: Position
   }
   deriving (Show, Eq, Generic)
 
@@ -125,10 +125,10 @@ instance FromJSON Owner
 -- | The origin of a piece of code
 data Origin
   = -- | set of locations in the source file
-    FromSource !Range
+    FromSource Range
   | -- | name of the parameter
-    FromParameter !Text
-  | FromDataset !Text
+    FromParameter Text
+  | FromDataset Text
   deriving (Show, Eq, Ord, Generic)
 
 instance Semigroup Origin where
@@ -152,8 +152,8 @@ instance Pretty Origin where
 -- Provenance
 
 data Provenance = Provenance
-  { origin :: !Origin,
-    owner :: !Owner
+  { origin :: Origin,
+    owner :: Owner
   }
   deriving (Generic)
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Relevance.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Relevance.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Relevance where
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Visibility.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Visibility.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE StrictData #-}
 
 module Vehicle.Syntax.AST.Visibility where
 

--- a/vehicle-syntax/vehicle-syntax.cabal
+++ b/vehicle-syntax/vehicle-syntax.cabal
@@ -64,9 +64,9 @@ library
     Vehicle.Syntax.AST.Builtin.TypeClass
     Vehicle.Syntax.AST.Decl
     Vehicle.Syntax.AST.Expr
+    Vehicle.Syntax.AST.Instances.NoThunks
     Vehicle.Syntax.AST.Meta
     Vehicle.Syntax.AST.Name
-    Vehicle.Syntax.AST.NoThunks
     Vehicle.Syntax.AST.Prog
     Vehicle.Syntax.AST.Provenance
     Vehicle.Syntax.AST.Relevance


### PR DESCRIPTION
This PR removes the bang patterns in `dev` and enables `StrictData` in the `Vehicle.Syntax.AST` modules only.

### benchmark: no strictness
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cabal test all` | 20.538 ± 0.241 | 20.286 | 21.163 | 1.00 |

### benchmark: enable StrictData in vehicle-syntax AST modules
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cabal test all` | 19.384 ± 0.105 | 19.238 | 19.575 | 1.00 |

### benchmark: enable StrictData in vehicle & in vehicle-syntax AST modules
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cabal test all` | 19.497 ± 0.063 | 19.409 | 19.622 | 1.00 |
