### PR TITLE
Fix: only pass `-threaded` and `-N` if `--ghc-debug` is set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,21 +40,27 @@ jobs:
         cabal-version: ["3.8"]
         cabal-extra-args: [""]
         include:
-          # Build with -fghc-debug:
-          - os_and_name: [ubuntu-latest, Linux]
-            ghc-version: "9.2.4"
-            cabal-version: "3.8"
-            cabal-extra-args: "-fghc-debug"
           # Build with -fnothunks:
           - os_and_name: [ubuntu-latest, Linux]
             ghc-version: "9.2.4"
             cabal-version: "3.8"
             cabal-extra-args: "-fnothunks"
-          # Build with -fghc-debug and -fnothunks:
-          - os_and_name: [ubuntu-latest, Linux]
-            ghc-version: "9.2.4"
-            cabal-version: "3.8"
-            cabal-extra-args: "-fghc-debug -fnothunks"
+        #
+        # NOTE: These tests are disabled because running with -fghc-debug
+        #       requires at least two threads (one for ghc-debug, and one
+        #       for the main process).
+        #       These tests should be re-enabled after #342 is fixed.
+        #
+        #   # Build with -fghc-debug and -fnothunks:
+        #   - os_and_name: [ubuntu-latest, Linux]
+        #     ghc-version: "9.2.4"
+        #     cabal-version: "3.8"
+        #     cabal-extra-args: "-fghc-debug -fnothunks"
+        #   # Build with -fghc-debug:
+        #   - os_and_name: [ubuntu-latest, Linux]
+        #     ghc-version: "9.2.4"
+        #     cabal-version: "3.8"
+        #     cabal-extra-args: "-fghc-debug"
 
   build-vehicle-python:
     name: ${{ matrix.os_and_name[1] }} / Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,20 +41,20 @@ jobs:
         cabal-extra-args: [""]
         include:
           # Build with -fghc-debug:
-          #- os_and_name: [ubuntu-latest, Linux]
-          #  ghc-version: "9.2.4"
-          #  cabal-version: "3.8"
-          #  cabal-extra-args: "-fghc-debug"
+          - os_and_name: [ubuntu-latest, Linux]
+            ghc-version: "9.2.4"
+            cabal-version: "3.8"
+            cabal-extra-args: "-fghc-debug"
           # Build with -fnothunks:
           - os_and_name: [ubuntu-latest, Linux]
             ghc-version: "9.2.4"
             cabal-version: "3.8"
             cabal-extra-args: "-fnothunks"
           # Build with -fghc-debug and -fnothunks:
-          # - os_and_name: [ubuntu-latest, Linux]
-          #   ghc-version: "9.2.4"
-          #   cabal-version: "3.8"
-          #   cabal-extra-args: "-fghc-debug -fnothunks"
+          - os_and_name: [ubuntu-latest, Linux]
+            ghc-version: "9.2.4"
+            cabal-version: "3.8"
+            cabal-extra-args: "-fghc-debug -fnothunks"
 
   build-vehicle-python:
     name: ${{ matrix.os_and_name[1] }} / Python ${{ matrix.python-version }}

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -68,9 +68,10 @@ common common-language
     UndecidableInstances
     ViewPatterns
 
+  ghc-options:        -Werror -Wall -fprint-potential-instances
+
 common common-library
-  import:      common-language
-  ghc-options: -Werror -Wall -fprint-potential-instances
+  import: common-language
 
   if flag(ghc-debug)
     build-depends: ghc-debug-stub >=0.3 && <0.4
@@ -82,10 +83,14 @@ common common-library
 
 common common-executable
   import:      common-language
-  ghc-options: -Werror -Wall -threaded -with-rtsopts=-N
+  ghc-options: -threaded
 
   if flag(ghc-debug)
-    ghc-options: -threaded -rtsopts
+    ghc-options: -rtsopts -with-rtsopts=-N
+
+common common-test
+  import:      common-language
+  ghc-options: -threaded -with-rtsopts=-N
 
 library
   import:          common-library
@@ -277,7 +282,7 @@ library vehicle-golden-tests-common
     , vehicle
 
 test-suite vehicle-golden-tests
-  import:             common-executable
+  import:             common-test
   type:               exitcode-stdio-1.0
   main-is:            tests/golden/Tests.hs
   build-depends:
@@ -328,7 +333,7 @@ library vehicle-unit-tests-common
     , vehicle-syntax
 
 test-suite vehicle-unit-tests
-  import:        common-executable
+  import:        common-test
   type:          exitcode-stdio-1.0
   main-is:       tests/unit/Tests.hs
   build-depends:


### PR DESCRIPTION
@MatthewDaggitt please benchmark these changes, as the 2nd performance regression isn't detectable on my system.