### PR TITLE
Add `Tensor` as a derived function in the standard library

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@
 
 * Logs now print out in real-time instead of at the end of compilation.
 
+* Added `Type` to the frontend language for the type of types.
+
 ### Bug fixes
 
 * Unbound type arguments are now longer generalised over in the opposite order than they occur.

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Builtin.hs
@@ -295,8 +295,7 @@ data Builtin
   | At
   | Map MapDomain
   | -- Derived
-    Tensor
-  | TypeClassOp TypeClassOp
+    TypeClassOp TypeClassOp
   | Fold FoldDomain
   | Foreach
   deriving (Eq, Show, Generic)
@@ -330,7 +329,6 @@ instance Pretty Builtin where
     FromVec n dom -> "fromVec[" <> pretty n <> "]To" <> pretty dom
     Equals dom op -> equalityOpName op <> pretty dom
     Order dom op -> orderOpName op <> pretty dom
-    Tensor -> "Tensor"
     Foreach -> "foreach"
     Fold dom -> "fold" <> pretty dom
     Map dom -> "map" <> pretty dom

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Name.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Name.hs
@@ -60,6 +60,9 @@ class HasIdentifier a where
 moduleOf :: Identifier -> Module
 moduleOf (Identifier m _) = m
 
+identifierName :: Identifier -> Name
+identifierName (Identifier _ n) = n
+
 --------------------------------------------------------------------------------
 -- Names
 

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -168,9 +168,6 @@ delabUniverse = \case
 delabBuiltin :: MonadDelab m => V.Builtin -> [V.InputExpr] -> m B.Expr
 delabBuiltin fun args = case fun of
   V.Constructor c -> delabConstructor c <$> traverse delabM args
-  V.Tensor -> do
-    args' <- traverse delabM args
-    return $ delabApp (B.Tensor tokTensor) (B.ExplicitArg <$> args')
   V.And -> delabTypeClassOp V.AndTC args
   V.Or -> delabTypeClassOp V.OrTC args
   V.Implies -> delabTypeClassOp V.ImpliesTC args

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Utils.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Utils.hs
@@ -13,7 +13,7 @@ parameterAnn = B.Parameter $ mkToken B.TokParameter "@parameter"
 propertyAnn = B.Property $ mkToken B.TokProperty "@property"
 
 tokType :: Int -> B.Expr
-tokType l = B.Type (mkToken B.TypeToken ("Type" <> pack (show l)))
+tokType l = B.Type (mkToken B.TokType ("Type" <> pack (show l)))
 
 tokArrow = mkToken B.TokArrow "->"
 
@@ -34,8 +34,6 @@ tokElemOf = mkToken B.TokElemOf ":"
 tokLambda = mkToken B.TokLambda "\\"
 
 tokVector = mkToken B.TokVector "Vector"
-
-tokTensor = mkToken B.TokTensor "Tensor"
 
 tokUnit = mkToken B.TokUnit "Unit"
 

--- a/vehicle-syntax/src/Vehicle/Syntax/External.cf
+++ b/vehicle-syntax/src/Vehicle/Syntax/External.cf
@@ -25,13 +25,13 @@ position token TokElemOf    {":"};
 position token TokLambda    {"\\"};
 position token TokLet       {"let"};
 
+position token TokType      {"Type"};
 position token TokUnit      {"Unit"};
 position token TokBool      {"Bool"};
 position token TokNat       {"Nat"};
 position token TokInt       {"Int"};
 position token TokRat       {"Rat"};
 position token TokVector    {"Vector"};
-position token TokTensor    {"Tensor"};
 position token TokList      {"List"};
 position token TokIndex     {"Index"};
 
@@ -68,7 +68,6 @@ position token TokHasMul    {"HasMul"};
 
 position token Name        (letter (letter | digit | '_')*) ;
 position token HoleToken   ({"?"} (letter | digit | '_')*);
-position token TypeToken   ({"Type"} digit+);
 
 position token DeclAnnOptionValue ((letter | digit)+);
 
@@ -128,7 +127,7 @@ BoolLiteral.  Lit ::= Boolean;
 --   aren't used for `let` and `in`.
 
 -- Kinds.
-Type.    Expr15 ::= TypeToken;
+Type.    Expr14 ::= TokType;
 
 -- Core structure.
 Ann.     Expr   ::= Expr2 TokElemOf Expr1;
@@ -185,7 +184,6 @@ Int.     Expr15 ::= TokInt;
 Nat.     Expr15 ::= TokNat;
 List.    Expr14 ::= TokList;
 Vector.  Expr14 ::= TokVector;
-Tensor.  Expr14 ::= TokTensor;
 Index.   Expr14 ::= TokIndex;
 
 -- Type classes.

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -163,10 +163,11 @@ descopeNormExpr f e = case e of
     let var = Var p $ f p v
     let args = descopeSpine f spine
     normAppList p var args
-  VLVec p xs spine -> do
+  VLVec p xs _spine -> do
     let xs' = fmap (descopeNormExpr f) xs
-    let args = descopeSpine f spine
-    normAppList p (LVec p xs') args
+    -- let args = descopeSpine f spine
+    -- normAppList p (LVec p xs') args
+    LVec p xs'
   VPi p binder body -> do
     let binder' = descopeNormBinder f binder
     let body' = descopeNormExpr f body
@@ -175,7 +176,8 @@ descopeNormExpr f e = case e of
     let binder' = descopeNormBinder f binder
     let env' = fmap (descopeNormExpr f) env
     let body' = descopeNaive body
-    normAppList p (Lam p binder' body') [ExplicitArg p $ LVec p env']
+    let envExpr = App p (Var p "ENV") [ExplicitArg p $ LVec p env']
+    Lam p binder' (App p envExpr [ExplicitArg p body'])
 
 descopeSpine ::
   (Provenance -> DBLevel -> Name) ->

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -56,8 +56,8 @@ data CompileError
       (NonEmpty (WithContext UnificationConstraint))
   | FailedEqConstraint ConstraintContext NormType NormType EqualityOp
   | FailedOrdConstraint ConstraintContext NormType NormType OrderOp
-  | FailedBuiltinConstraintArgument ConstraintContext Builtin NormType [Builtin] Int Int
-  | FailedBuiltinConstraintResult ConstraintContext Builtin NormType [Builtin]
+  | FailedBuiltinConstraintArgument ConstraintContext Builtin NormType [UnAnnDoc] Int Int
+  | FailedBuiltinConstraintResult ConstraintContext Builtin NormType [UnAnnDoc]
   | FailedNotConstraint ConstraintContext NormType
   | FailedBoolOp2Constraint ConstraintContext NormType NormType Builtin
   | FailedQuantifierConstraintDomain ConstraintContext NormType Quantifier

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -18,6 +18,7 @@ import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Constraint
 import Vehicle.Expr.AlphaEquivalence (AlphaEquivalence (..))
 import Vehicle.Expr.Normalised
+import Vehicle.Libraries.StandardLibrary (pattern TensorIdent)
 import Vehicle.Syntax.Parse (ParseError (..))
 
 --------------------------------------------------------------------------------
@@ -255,9 +256,9 @@ instance MeaningfulError CompileError where
             "expected"
               <+> squotes (prettyUnificationConstraintOriginExpr ctx expr)
               <+> "to be of type"
-              <+> prettyFriendly (WithContext expectedType boundCtx)
+              <+> squotes (prettyFriendly (WithContext expectedType boundCtx))
               <+> "but was found to be of type"
-              <+> prettyFriendly (WithContext actualType boundCtx)
+              <+> squotes (prettyFriendly (WithContext actualType boundCtx))
           CheckingBinderType varName expectedType actualType ->
             "expected the variable"
               <+> quotePretty varName
@@ -671,7 +672,7 @@ instance MeaningfulError CompileError where
                 <+> pretty io
                 <+> squotes (prettyFriendly (WithContext nonTensorType emptyDBCtx))
                 <+> "is not one of"
-                <+> list [pretty Vector, pretty Tensor] <> ".",
+                <+> list [pretty Vector, pretty (identifierName TensorIdent)] <> ".",
             fix =
               Just $
                 supportedNetworkTypeDescription
@@ -764,7 +765,7 @@ instance MeaningfulError CompileError where
                   <+> "to a supported type."
           }
       where
-        supportedTypes = map pretty [List, Vector] <> [pretty Tensor]
+        supportedTypes = map pretty [List, Vector] <> [pretty (identifierName TensorIdent)]
     DatasetTypeUnsupportedElement (ident, p) datasetType elementType ->
       UError $
         UserError
@@ -1370,11 +1371,11 @@ prettyAuxiliaryFunctionProvenance = \case
   FunctionInput n _ -> "which is used as an input to the function" <+> quotePretty n
   FunctionOutput n -> "which is returned as an output of the function" <+> quotePretty n
 
-prettyAllowedTypes :: [Builtin] -> Doc b
+prettyAllowedTypes :: [UnAnnDoc] -> UnAnnDoc
 prettyAllowedTypes allowedTypes =
   if length allowedTypes == 1
-    then quotePretty (head allowedTypes)
-    else "one of" <+> prettyFlatList (pretty <$> allowedTypes)
+    then squotes (head allowedTypes)
+    else "one of" <+> prettyFlatList allowedTypes
 
 prettyAllowedBuiltins :: [Doc b] -> Doc b
 prettyAllowedBuiltins = commaSep

--- a/vehicle/src/Vehicle/Compile/ExpandResources.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources.hs
@@ -147,8 +147,8 @@ lookupValue ident ctx = case Map.lookup (nameOf ident) ctx of
 
 normDecl :: MonadInsertResources m => TypedDecl -> m TypedDecl
 normDecl decl = do
-  ctx <- gets (fmap glued)
+  ctx <- gets (fmap (normalised . glued))
   for decl $ \(TypedExpr (Glued unnorm norm)) -> do
     -- Ugh, horrible. We really need to be able to renormalise.
-    norm' <- whnf 0 ctx (unnormalise 0 norm)
+    norm' <- whnf 0 ctx mempty (unnormalise 0 norm)
     return $ TypedExpr $ Glued unnorm norm'

--- a/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
@@ -158,7 +158,7 @@ mkTensorType ::
 mkTensorType _ tElem [] = tElem
 mkTensorType ann tElem dims =
   let dimList = mkList ann (NatType ann) dims
-   in App ann (Builtin ann Tensor) (fmap (ExplicitArg ann) [tElem, dimList])
+   in TensorType ann tElem dimList
 
 mkList ::
   Provenance ->

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -177,7 +177,6 @@ scopeVar p symbol = do
         tell [ident]
         return $ Free ident
       Nothing -> do
-        logDebug MaxDetail (pretty boundCtx)
         throwError $ UnboundName p symbol
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -245,20 +245,11 @@ loopOverConstraints loopNumber decl = do
 
 -- | Tries to solve a constraint deterministically.
 solveConstraint :: TCM m => WithContext Constraint -> m ()
-solveConstraint unnormConstraint = do
-  normConstraint@(WithContext constraint ctx) <- substMetas unnormConstraint
-
-  logCompilerSection MaxDetail ("trying:" <+> prettyVerbose normConstraint) $ do
-    logDebug MaxDetail $ prettyFriendly normConstraint
-    result <- case constraint of
-      UnificationConstraint c -> solveUnificationConstraint (WithContext c ctx)
-      TypeClassConstraint c -> solveTypeClassConstraint (WithContext c ctx)
-
-    case result of
-      Progress newConstraints -> addConstraints newConstraints
-      Stuck metas -> do
-        let blockedConstraint = blockConstraintOn (WithContext constraint ctx) metas
-        addConstraints [blockedConstraint]
+solveConstraint constraint@(WithContext c ctx) =
+  logCompilerSection MaxDetail ("trying:" <+> prettyVerbose constraint) $
+    case c of
+      UnificationConstraint uc -> solveUnificationConstraint (WithContext uc ctx)
+      TypeClassConstraint tc -> solveTypeClassConstraint (WithContext tc ctx)
 
 -- | Tries to add new unification constraints using default values.
 addNewConstraintUsingDefaults ::

--- a/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
@@ -32,22 +32,22 @@ import Prelude hiding (pi)
 --------------------------------------------------------------------------------
 -- Debug functions
 
-showCheckEntry :: MonadLogger m => CheckedType -> UncheckedExpr -> m ()
+showCheckEntry :: MonadBidirectional m => CheckedType -> UncheckedExpr -> m ()
 showCheckEntry t e = do
   logDebug MaxDetail ("check-entry" <+> prettyVerbose e <+> ":" <+> prettyVerbose t)
   incrCallDepth
 
-showCheckExit :: MonadLogger m => CheckedExpr -> m ()
+showCheckExit :: MonadBidirectional m => CheckedExpr -> m ()
 showCheckExit e = do
   decrCallDepth
   logDebug MaxDetail ("check-exit " <+> prettyVerbose e)
 
-showInferEntry :: MonadLogger m => UncheckedExpr -> m ()
+showInferEntry :: MonadBidirectional m => UncheckedExpr -> m ()
 showInferEntry e = do
   logDebug MaxDetail ("infer-entry" <+> prettyVerbose e)
   incrCallDepth
 
-showInferExit :: MonadLogger m => (CheckedExpr, CheckedType) -> m ()
+showInferExit :: MonadBidirectional m => (CheckedExpr, CheckedType) -> m ()
 showInferExit (e, t) = do
   decrCallDepth
   logDebug MaxDetail ("infer-exit " <+> prettyVerbose e <+> ":" <+> prettyVerbose t)

--- a/vehicle/src/Vehicle/Compile/Type/Builtin.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Builtin.hs
@@ -12,8 +12,6 @@ typeOfBuiltin p b = fromDSL p $ case b of
   Constructor c -> typeOfConstructor c
   -- Type classes operations
   TypeClassOp tc -> typeOfTypeClassOp tc
-  -- Types
-  Tensor -> type0 ~> tList tNat ~> type0
   -- Boolean operations
   Not ->
     forAllIrrelevant "l" tLin $ \l ->

--- a/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/Core.hs
@@ -1,24 +1,16 @@
 module Vehicle.Compile.Type.ConstraintSolver.Core
   ( blockOn,
     unify,
-    blockOnReductionBlockingMetasOrThrowError,
     malformedConstraintError,
   )
 where
 
-import Control.Monad.Except (MonadError (..))
-import Data.Maybe (maybeToList)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Constraint
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
-import Vehicle.Expr.Normalised
-  ( NormExpr (..),
-    getMeta,
-    isLiteral,
-    pattern VTensorType,
-  )
+import Vehicle.Expr.Normalised (NormExpr (..))
 
 blockOn :: MonadCompile m => [MetaID] -> m ConstraintProgress
 blockOn metas = do
@@ -27,33 +19,6 @@ blockOn metas = do
 
 unify :: ConstraintContext -> NormExpr -> NormExpr -> WithContext Constraint
 unify ctx e1 e2 = WithContext (UnificationConstraint $ Unify e1 e2) (copyContext ctx)
-
--- This is really buggy at the moment. Tensor should not be here as its derived,
--- and all the other computational builtins should be.
-getReductionBlockingMetas :: forall m. MonadLogger m => NormExpr -> m [MetaID]
-getReductionBlockingMetas = \case
-  VTensorType _ _ dims -> do logDebug MaxDetail "Hit"; go dims
-  VBuiltin _ TypeClassOp {} args -> do logDebug MaxDetail (prettyVerbose args); return $ maybeToList (getMeta (fst (findInstanceArg args)))
-  _ -> return []
-  where
-    go :: NormExpr -> m [MetaID]
-    go = \case
-      VMeta _ m _ -> return [m]
-      e
-        | isLiteral e -> return []
-        | otherwise -> getReductionBlockingMetas e
-
-blockOnReductionBlockingMetasOrThrowError ::
-  MonadCompile m =>
-  [NormExpr] ->
-  CompileError ->
-  m ConstraintProgress
-blockOnReductionBlockingMetasOrThrowError args err = do
-  blockingMetas <- concat <$> traverse getReductionBlockingMetas args
-  logDebug MaxDetail (pretty blockingMetas)
-  if null blockingMetas
-    then throwError err
-    else blockOn blockingMetas
 
 malformedConstraintError :: MonadCompile m => WithContext TypeClassConstraint -> m a
 malformedConstraintError c =

--- a/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/Unification.hs
+++ b/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/Unification.hs
@@ -8,24 +8,27 @@ where
 
 import Control.Monad (when)
 import Control.Monad.Except (MonadError (..), throwError)
+import Control.Monad.Reader (ReaderT (..))
+import Control.Monad.Writer (execWriterT)
+import Control.Monad.Writer.Class (MonadWriter (..))
+import Data.Foldable (for_, traverse_)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
 import Data.List (intersect)
 import Data.Maybe (catMaybes)
-import Data.Traversable (for)
 import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.NBE (evalApp)
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Constraint
 import Vehicle.Compile.Type.ConstraintSolver.Core
-  ( blockOnReductionBlockingMetasOrThrowError,
-    unify,
+  ( unify,
   )
 import Vehicle.Compile.Type.Meta
-import Vehicle.Compile.Type.Meta.Map qualified as MetaMap (member, toList)
-import Vehicle.Compile.Type.Meta.Set qualified as MetaSet (singleton)
-import Vehicle.Compile.Type.Meta.Variable (metasInWithDependencies)
+import Vehicle.Compile.Type.Meta.Map (MetaMap)
+import Vehicle.Compile.Type.Meta.Map qualified as MetaMap (lookup, member, singleton, toList)
+import Vehicle.Compile.Type.Meta.Set qualified as MetaSet (fromList, null, singleton, unions)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
@@ -40,21 +43,45 @@ import Vehicle.Expr.Normalised
 pattern (:~:) :: a -> b -> (a, b)
 pattern x :~: y = (x, y)
 
-solveUnificationConstraint ::
-  TCM m =>
-  WithContext UnificationConstraint ->
-  m ConstraintProgress
-solveUnificationConstraint (WithContext (Unify e1 e2) ctx) = do
-  let c = WithContext (Unify e1 e2) ctx
+solveUnificationConstraint :: TCM m => WithContext UnificationConstraint -> m ()
+solveUnificationConstraint uc = do
+  (WithContext cu@(Unify e1 e2) ctx) <- return uc
+  result <- unification ctx e1 e2
+  case result of
+    Stuck metas -> do
+      let blockedConstraint = blockConstraintOn (WithContext (UnificationConstraint cu) ctx) metas
+      addConstraints [blockedConstraint]
+    Progress newConstraints -> do
+      -- In theory this shouldn't be needed, but in practice it is as if
+      -- not all the meta-variables are substituted through then the scope of some
+      -- meta-variables may be larger than the current scope of the constraint.
+      -- These dependencies only disappear on substitution.
+      substNewConstraints <- substMetas newConstraints
+      addConstraints substNewConstraints
+
+unification :: TCM m => ConstraintContext -> NormExpr -> NormExpr -> m ConstraintProgress
+unification ctx e1 e2 = do
+  (ne1, e1BlockingMetas) <- forceHead e1
+  (ne2, e2BlockingMetas) <- forceHead e2
+
+  let c = WithContext (Unify ne1 ne2) ctx
   let constraintLevel = DBLevel $ length (boundContext ctx)
 
-  progress <- case (e1, e2) of
+  progress <- case (ne1, ne2) of
     -----------------------
     -- Rigid-rigid cases --
     -----------------------
 
-    VUniverse _ l1 :~: VUniverse _ l2 ->
-      solveEq c l1 l2
+    VUniverse _ l1 :~: VUniverse _ l2
+      | l1 == l2 -> solveTrivially
+    VLiteral _ l1 :~: VLiteral _ l2
+      | l1 == l2 -> solveTrivially
+    VBuiltin _ b1 spine1 :~: VBuiltin _ b2 spine2
+      | b1 == b2 -> solveSpine c spine1 spine2
+    VBoundVar _ v1 spine1 :~: VBoundVar _ v2 spine2
+      | v1 == v2 -> solveSpine c spine1 spine2
+    VFreeVar _ v1 spine1 :~: VFreeVar _ v2 spine2
+      | v1 == v2 -> solveSpine c spine1 spine2
     -- We ASSUME that all terms here are in normal form, so there
     -- will never be an unreduced redex.
     VLam _ _binder1 _env1 _body1 :~: VLam _ _binder2 _env2 _body2 ->
@@ -63,11 +90,10 @@ solveUnificationConstraint (WithContext (Unify e1 e2) ctx) = do
     -- \| otherwise                         -> throwError $ FailedUnificationConstraints [c]
 
     VLVec _ es1 args1 :~: VLVec _ es2 args2
-      | length es1 /= length es2 -> throwError $ FailedUnificationConstraints [c]
-      | otherwise -> do
+      | length es1 == length es2 -> do
           let elemEqs = zipWith (unify ctx) es1 es2
-          argsEqs <- solveSpine c (args1, args2)
-          return $ Progress $ elemEqs <> argsEqs
+          argsProgress <- solveSpine c args1 args2
+          return $ Progress elemEqs <> argsProgress
     VPi _ binder1 body1 :~: VPi _ binder2 body2
       | visibilityMatches binder1 binder2 -> do
           -- !!TODO!! Block until binders are solved
@@ -76,17 +102,7 @@ solveUnificationConstraint (WithContext (Unify e1 e2) ctx) = do
           let binderConstraint = unify ctx (typeOf binder1) (typeOf binder2)
           let bodyConstraint = unify ctx body1 body2
           return $ Progress [binderConstraint, bodyConstraint]
-      | otherwise -> throwError $ FailedUnificationConstraints [c]
-    VBuiltin _ op1 args1 :~: VBuiltin _ op2 args2
-      | op1 == op2 -> solveSimpleApplication c op1 op2 args1 args2
-      | otherwise ->
-          blockOnReductionBlockingMetasOrThrowError [e1, e2] (FailedUnificationConstraints [c])
-    VBoundVar _ v1 args1 :~: VBoundVar _ v2 args2 ->
-      solveSimpleApplication c v1 v2 args1 args2
-    VFreeVar _ v1 args1 :~: VFreeVar _ v2 args2 ->
-      solveSimpleApplication c v1 v2 args1 args2
-    VLiteral _ l1 :~: VLiteral _ l2 ->
-      solveEq c l1 l2
+
     ---------------------
     -- Flex-flex cases --
     ---------------------
@@ -94,111 +110,93 @@ solveUnificationConstraint (WithContext (Unify e1 e2) ctx) = do
     VMeta _ i args1 :~: VMeta _ j args2
       -- If the meta-variables are equal then simply discard the constraint
       -- as it doesn't tell us anything.
-      | i == j -> Progress <$> solveSpine c (args1, args2)
+      | i == j -> solveSpine c args1 args2
       -- If the meta-variables are different then we have more
       -- flexibility as to how the arguments can relate to each other. In
       -- particular they can be re-arranged, and therefore we calculate the
       -- non-positional intersection of their arguments.
       | otherwise -> do
-          meta1Type <- getMetaType i
-          meta2Type <- getMetaType j
-          typeEq <- unify ctx <$> whnfNBE constraintLevel meta1Type <*> whnfNBE constraintLevel meta2Type
+          let (deps1, remainingSpine1) = getNormMetaDependencies args1
+          let (deps2, remainingSpine2) = getNormMetaDependencies args2
+          if not (null remainingSpine1) || not (null remainingSpine2)
+            then return $ Stuck (MetaSet.fromList [i, j])
+            else do
+              let jointContext = deps1 `intersect` deps2
 
-          meta1Origin <- getMetaProvenance i
-          meta2Origin <- getMetaProvenance j
-          let newOrigin = meta1Origin <> meta2Origin
+              meta1Type <- getMetaType i
+              meta2Type <- getMetaType j
+              typeEq <- unify ctx <$> whnfNBE constraintLevel meta1Type <*> whnfNBE constraintLevel meta2Type
 
-          meta1Level <- DBLevel <$> getMetaCtxSize i
-          meta2Level <- DBLevel <$> getMetaCtxSize j
-          let newLevel = min meta1Level meta2Level
+              meta1Origin <- getMetaProvenance i
+              meta2Origin <- getMetaProvenance j
+              let newOrigin = meta1Origin <> meta2Origin
 
-          let deps1 = getNormMetaDependencies args1
-          let deps2 = getNormMetaDependencies args2
-          let jointContext = deps1 `intersect` deps2
+              meta1Level <- DBLevel <$> getMetaCtxSize i
+              meta2Level <- DBLevel <$> getMetaCtxSize j
+              let newLevel = min meta1Level meta2Level
 
-          newMeta <- createMetaWithRestrictedDependencies newLevel newOrigin meta1Type jointContext
+              newMeta <- createMetaWithRestrictedDependencies newLevel newOrigin meta1Type jointContext
 
-          solveMeta i newMeta constraintLevel
-          solveMeta j newMeta constraintLevel
+              solveMeta i newMeta constraintLevel
+              solveMeta j newMeta constraintLevel
 
-          return $ Progress [typeEq]
+              return $ Progress [typeEq]
 
     ----------------------
     -- Flex-rigid cases --
     ----------------------
 
-    -- ?X e1 e2 e3 =?= ?Y x y z
-
-    -- ==> ?Y := \x. \y. \z. ?X e1 e2 e3
-
-    VMeta _ i args :~: _ -> do
-      let deps = getNormMetaDependencies args
-
-      -- Check that 'args' is a pattern and try to calculate a substitution
-      -- that renames the variables in 'e2' to ones available to meta `i`
-      case getArgPattern constraintLevel deps of
-        -- This constraint is stuck because it is not pattern; shelve
-        -- it for now and hope that another constraint allows us to
-        -- progress.
-        -- TODO need to check with Bob what this is stuck on, presumably i?
-        Nothing -> return $ Stuck $ MetaSet.singleton i
-        Just argPattern -> do
-          metasInE2 <- metasInWithDependencies e2
-
-          -- If `i` is inside the term we're trying to unify it with then error.
-          -- Unsure if this should be a user or a developer error.
-          when (i `MetaMap.member` metasInE2) $
-            compilerDeveloperError $
-              "Meta variable"
-                <+> pretty i
-                <+> "found in own solution"
-                <+> squotes (prettyVerbose e2)
-
-          -- Restrict any arguments to each sub-meta on the RHS to those of i.
-          newMetasSolved <-
-            or
-              <$> for
-                (MetaMap.toList metasInE2)
-                ( \(j, jDeps) -> do
-                    jOrigin <- getMetaProvenance j
-                    jType <- getMetaType j
-
-                    let sharedDependencies = deps `intersect` jDeps
-                    if sharedDependencies == jDeps
-                      then return False
-                      else do
-                        meta <- createMetaWithRestrictedDependencies constraintLevel jOrigin jType sharedDependencies
-                        logDebug MaxDetail (pretty constraintLevel)
-                        logDebug MaxDetail (prettyVerbose meta)
-                        solveMeta j meta constraintLevel
-                        return True
-                )
-
-          finalE2 <- if newMetasSolved then substMetas e2 else return e2
-
-          unnormSolution <- quote constraintLevel finalE2
-          let substSolution = substDBAll 0 (\v -> unIndex v `IntMap.lookup` argPattern) unnormSolution
-          solveMeta i substSolution constraintLevel
-          return $ Progress mempty
-    _t :~: VMeta {} ->
-      -- this is the mirror image of the previous case, so just swap the
-      -- problem over.
-      solveUnificationConstraint (WithContext (Unify e2 e1) ctx)
+    VMeta _ m spine :~: _ -> solveFlexRigid constraintLevel m spine e2
+    _ :~: VMeta _ m spine -> solveFlexRigid constraintLevel m spine e1
     -- Catch-all
-    _ -> blockOnReductionBlockingMetasOrThrowError [e1, e2] (FailedUnificationConstraints [c])
+    _ -> do
+      let blockingMetas = MetaSet.unions [e1BlockingMetas, e2BlockingMetas]
+      if not (MetaSet.null blockingMetas)
+        then return $ Stuck blockingMetas
+        else throwError (FailedUnificationConstraints [c])
 
   return progress
 
-solveEq ::
-  (TCM m, Eq a) =>
-  WithContext UnificationConstraint ->
-  a ->
-  a ->
-  m ConstraintProgress
-solveEq c v1 v2
-  | v1 /= v2 = throwError $ FailedUnificationConstraints [c]
-  | otherwise = do
-      logDebug MaxDetail "solved-trivially"
+solveFlexRigid :: TCM m => DBLevel -> MetaID -> Spine -> NormExpr -> m ConstraintProgress
+solveFlexRigid constraintLevel meta spine e2 = do
+  -- Check that 'args' is a pattern and try to calculate a substitution
+  -- that renames the variables in 'e2' to ones available to meta `i`
+  case getArgPattern constraintLevel spine of
+    -- This constraint is stuck because it is not pattern; shelve
+    -- it for now and hope that another constraint allows us to
+    -- progress.
+    -- TODO need to check with Bob what this is stuck on, presumably i?
+    Nothing -> return $ Stuck $ MetaSet.singleton meta
+    Just argPattern -> do
+      metasInE2 <- metasInWithDependencies e2
+
+      -- If `i` is inside the term we're trying to unify it with then error.
+      -- Unsure if this should be a user or a developer error.
+      when (meta `MetaMap.member` metasInE2) $
+        compilerDeveloperError $
+          "Meta variable"
+            <+> pretty meta
+            <+> "found in own solution"
+            <+> squotes (prettyVerbose e2)
+
+      let (deps, _) = getNormMetaDependencies spine
+
+      -- Restrict any arguments to each sub-meta on the RHS to those of i.
+      for_ (MetaMap.toList metasInE2) $ \(j, jSpine) -> do
+        jOrigin <- getMetaProvenance j
+        jType <- getMetaType j
+        let (jDeps, _) = getNormMetaDependencies jSpine
+        let sharedDependencies = deps `intersect` jDeps
+        if sharedDependencies == jDeps
+          then return False
+          else do
+            newMeta <- createMetaWithRestrictedDependencies constraintLevel jOrigin jType sharedDependencies
+            solveMeta j newMeta constraintLevel
+            return True
+
+      unnormSolution <- quote constraintLevel e2
+      let substSolution = substDBAll 0 (\v -> unIndex v `IntMap.lookup` argPattern) unnormSolution
+      solveMeta meta substSolution constraintLevel
       return $ Progress mempty
 
 solveArg ::
@@ -214,29 +212,20 @@ solveArg c (arg1, arg2)
 solveSpine ::
   TCM m =>
   WithContext UnificationConstraint ->
-  (Spine, Spine) ->
-  m [WithContext Constraint]
-solveSpine c (args1, args2) = catMaybes <$> traverse (solveArg c) (zip args1 args2)
-
-solveSimpleApplication ::
-  (TCM m, Eq a) =>
-  WithContext UnificationConstraint ->
-  a ->
-  a ->
   [NormArg] ->
   [NormArg] ->
   m ConstraintProgress
-solveSimpleApplication constraint fun1 fun2 args1 args2 = do
-  if fun1 /= fun2 || length args1 /= length args2
-    then throwError $ FailedUnificationConstraints [constraint]
-    else
-      if null args1
-        then do
-          logDebug MaxDetail "solved-trivially"
-          return $ Progress mempty
-        else do
-          newConstraints <- solveSpine constraint (args1, args2)
-          return $ Progress newConstraints
+solveSpine constraint args1 args2
+  | length args1 /= length args2 = throwError $ FailedUnificationConstraints [constraint]
+  | null args1 = solveTrivially
+  | otherwise = do
+      newConstraints <- catMaybes <$> traverse (solveArg constraint) (zip args1 args2)
+      return $ Progress newConstraints
+
+solveTrivially :: TCM m => m ConstraintProgress
+solveTrivially = do
+  logDebug MaxDetail "solved-trivially"
+  return $ Progress mempty
 
 createMetaWithRestrictedDependencies ::
   TCM m =>
@@ -247,9 +236,6 @@ createMetaWithRestrictedDependencies ::
   m CheckedExpr
 createMetaWithRestrictedDependencies level p metaType newDependencies = do
   logCompilerPass MaxDetail "restricting dependencies" $ do
-    logDebug MaxDetail $ pretty level
-    logDebug MaxDetail (pretty newDependencies)
-
     meta <- freshExprMeta p metaType (length newDependencies)
     let substitution = IntMap.fromAscList (zip [0 ..] (fmap (dbLevelToIndex level) newDependencies))
     let newMetaExpr = substDBAll 0 (\v -> unIndex v `IntMap.lookup` substitution) (unnormalised meta)
@@ -265,16 +251,46 @@ type ArgPattern = IntMap DBIndex
 
 -- | TODO: explain what this means:
 -- [i2 i4 i1] --> [2 -> 2, 4 -> 1, 1 -> 0]
-getArgPattern :: DBLevel -> [DBLevel] -> Maybe ArgPattern
+getArgPattern :: DBLevel -> Spine -> Maybe ArgPattern
 getArgPattern ctxSize args = go (length args - 1) IntMap.empty args
   where
-    go :: Int -> IntMap DBIndex -> [DBLevel] -> Maybe ArgPattern
-    go _ revMap [] = Just revMap
-    -- TODO: we could eta-reduce arguments too, if possible
-    go i revMap (j : restArgs) = do
-      let jIndex = dbLevelToIndex ctxSize j
-      if IntMap.member (unIndex jIndex) revMap
-        then -- TODO: mark 'j' as ambiguous, and remove ambiguous entries before returning;
-        -- but then we should make sure the solution is well-typed
-          Nothing
-        else go (i - 1) (IntMap.insert (unIndex jIndex) (DBIndex i) revMap) restArgs
+    go :: Int -> IntMap DBIndex -> Spine -> Maybe ArgPattern
+    go i revMap = \case
+      [] -> Just revMap
+      (ExplicitArg _ (VBoundVar _ j []) : restArgs) -> do
+        -- TODO: we could eta-reduce arguments too, if possible
+        let jIndex = dbLevelToIndex ctxSize j
+        if IntMap.member (unIndex jIndex) revMap
+          then -- TODO: mark 'j' as ambiguous, and remove ambiguous entries before returning;
+          -- but then we should make sure the solution is well-typed
+            Nothing
+          else go (i - 1) (IntMap.insert (unIndex jIndex) (DBIndex i) revMap) restArgs
+      -- Not a pattern so return nothing.
+      _ -> Nothing
+
+metasInWithDependencies :: MonadTypeChecker m => NormExpr -> m (MetaMap Spine)
+metasInWithDependencies e = execWriterT (go e)
+  where
+    go :: (MonadTypeChecker m, MonadWriter (MetaMap Spine) m) => NormExpr -> m ()
+    go expr = case expr of
+      VMeta _ m spine -> do
+        metaSubst <- getMetaSubstitution
+        case MetaMap.lookup m metaSubst of
+          Nothing -> tell (MetaMap.singleton m spine)
+          Just solution -> do
+            declSubst <- getDeclSubstitution
+            go =<< runReaderT (evalApp (normalised solution) spine) (declSubst, metaSubst)
+      VUniverse {} -> return ()
+      VLiteral {} -> return ()
+      VBuiltin _ _ spine -> goSpine spine
+      VBoundVar _ _ spine -> goSpine spine
+      VFreeVar _ _ spine -> goSpine spine
+      VLVec _ xs spine -> do traverse_ go xs; goSpine spine
+      VPi _ binder result -> do traverse_ go binder; go result
+      -- Definitely going to have come back and fix this one later.
+      -- Can't inspect the metas in the environment, as not every variable
+      -- in the environment will be used?
+      VLam {} -> return ()
+
+    goSpine :: (MonadTypeChecker m, MonadWriter (MetaMap Spine) m) => Spine -> m ()
+    goSpine = traverse_ (traverse_ go)

--- a/vehicle/src/Vehicle/Compile/Type/VariableContext.hs
+++ b/vehicle/src/Vehicle/Compile/Type/VariableContext.hs
@@ -4,10 +4,15 @@ module Vehicle.Compile.Type.VariableContext where
 
 import Data.Map qualified as Map
 import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Meta.Map (MetaMap)
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
 -- Declaration context
+
+type MetaSubstitution = MetaMap GluedExpr
+
+type DeclSubstitution = DeclCtx NormExpr
 
 type TypingDeclCtxEntry = (CheckedType, Maybe GluedExpr)
 
@@ -15,9 +20,6 @@ type TypingDeclCtx = DeclCtx TypingDeclCtxEntry
 
 toNormalisationDeclContext :: TypingDeclCtx -> DeclCtx CheckedExpr
 toNormalisationDeclContext = Map.mapMaybe (fmap unnormalised . snd)
-
-toNBEDeclContext :: TypingDeclCtx -> DeclCtx NormExpr
-toNBEDeclContext = Map.mapMaybe (fmap normalised . snd)
 
 toDeclCtxEntry :: TypedDecl -> TypingDeclCtxEntry
 toDeclCtxEntry decl = do

--- a/vehicle/src/Vehicle/Expr/DSL.hs
+++ b/vehicle/src/Vehicle/Expr/DSL.hs
@@ -21,7 +21,6 @@ module Vehicle.Expr.DSL
     tAnnRat,
     tList,
     tListRaw,
-    tTensor,
     tIndex,
     tPol,
     tLin,
@@ -244,9 +243,6 @@ tAnnBool linearity polarity =
 
 tVector :: DSLExpr -> DSLExpr -> DSLExpr
 tVector tElem dim = constructor Vector @@ [tElem, dim]
-
-tTensor :: DSLExpr -> DSLExpr -> DSLExpr
-tTensor tElem dims = builtin Tensor @@ [tElem, dims]
 
 tListRaw :: DSLExpr
 tListRaw = constructor List

--- a/vehicle/src/Vehicle/Expr/Patterns.hs
+++ b/vehicle/src/Vehicle/Expr/Patterns.hs
@@ -2,6 +2,7 @@ module Vehicle.Expr.Patterns where
 
 import Data.List.NonEmpty (NonEmpty (..), toList)
 import Vehicle.Expr.DeBruijn
+import Vehicle.Libraries.StandardLibrary (pattern TensorIdent)
 import Vehicle.Libraries.StandardLibrary.Names
 import Vehicle.Syntax.AST
 
@@ -120,24 +121,39 @@ pattern VectorType p tElem tDim <-
 
 pattern TensorType ::
   Provenance ->
-  Expr binder var ->
-  Expr binder var ->
-  Expr binder var
+  Expr binder DBIndexVar ->
+  Expr binder DBIndexVar ->
+  Expr binder DBIndexVar
 pattern TensorType p tElem tDims <-
-  BuiltinExpr
+  App
     p
-    Tensor
+    (FreeVar _ TensorIdent)
     [ ExplicitArg _ tElem,
       ExplicitArg _ tDims
       ]
   where
     TensorType p tElem tDims =
-      BuiltinExpr
+      App
         p
-        Tensor
+        (FreeVar p TensorIdent)
         [ ExplicitArg p tElem,
           ExplicitArg p tDims
         ]
+
+-- | Ugly hack until we work out how to bind builtins in the
+-- user syntax.
+pattern ITensorType ::
+  Provenance ->
+  InputExpr ->
+  InputExpr ->
+  InputExpr
+pattern ITensorType p tElem tDims <-
+  App
+    p
+    (Var _ "Tensor")
+    [ ExplicitArg _ tElem,
+      ExplicitArg _ tDims
+      ]
 
 pattern IndexType :: Provenance -> Expr binder var -> Expr binder var
 pattern IndexType p tSize <- ConstructorExpr p Index [ExplicitArg _ tSize]

--- a/vehicle/src/Vehicle/Libraries/StandardLibrary.hs
+++ b/vehicle/src/Vehicle/Libraries/StandardLibrary.hs
@@ -1,17 +1,19 @@
 module Vehicle.Libraries.StandardLibrary
   ( standardLibrary,
+    pattern TensorIdent,
   )
 where
 
 import Data.Text (Text)
 import Data.Version (Version)
 import Vehicle.Libraries
+import Vehicle.Syntax.AST (Identifier (..), Module (..))
 
 stdlibName :: LibraryName
 stdlibName = "stdlib"
 
 stdlibVersion :: Version
-stdlibVersion = [0, 3]
+stdlibVersion = [0, 4]
 
 standardLibrary :: Library
 standardLibrary =
@@ -35,4 +37,10 @@ content =
   \\n\
   \bigOr : Vector Bool n -> Bool\n\
   \bigOr = fold (\\x y -> x or y) False\n\
+  \\n\
+  \Tensor : Type -> List Nat -> Type\n\
+  \Tensor A ds = fold (\\d t -> Vector t d) A ds\n\
   \"
+
+pattern TensorIdent :: Identifier
+pattern TensorIdent = Identifier StdLib "Tensor"

--- a/vehicle/tests/golden/compile/simple-map/test.json
+++ b/vehicle/tests/golden/compile/simple-map/test.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "TypeCheck",
-    "run": "vehicle compile -s simple-map.vcl -t TypeCheck",
+    "run": "vehicle compile -s simple-map.vcl -t TypeCheck --logging MaxDetail",
     "needs": ["simple-map.vcl"],
     "enabled": false
   }

--- a/vehicle/tests/golden/error/typing/intAsNat/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/typing/intAsNat/TypeCheck.err.golden
@@ -1,1 +1,2 @@
-Error at Line 2, Columns 7-8: the return type of '-' should be one of [ Int, Rat ] but the program is expecting something of type 'Nat'.
+Error at Line 2, Columns 7-8: unable to find a consistent type for the overloaded expression '-'. In particular Int != Nat.
+Fix: check your types

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CoDeBruijn.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CoDeBruijn.hs
@@ -26,7 +26,7 @@ coDeBruijnTests =
       CoDeBruijnTestSpec "typeFun" "Nat -> Nat",
       CoDeBruijnTestSpec "lam" "\\(x : Nat) -> x",
       CoDeBruijnTestSpec "lam2" "\\(f : Nat -> Nat) (x : Nat) -> f x",
-      CoDeBruijnTestSpec "pi" "forallT (n : Nat) . Tensor Nat [n]",
+      CoDeBruijnTestSpec "pi" "forallT (n : Nat) . Vector Nat n",
       CoDeBruijnTestSpec "neg" "\\(x : Int) -> - x"
     ]
 

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -63,7 +63,7 @@ data NBETest = NBETest
 normalisationTest :: NBETest -> TestTree
 normalisationTest NBETest {..} =
   unitTestCase ("normalise" <> name) $ do
-    normInput <- whnf dbLevel mempty input
+    normInput <- whnf dbLevel mempty mempty input
     actual <- quote dbLevel normInput
 
     let errorMessage =


### PR DESCRIPTION
As part of this it was necessary to:
- Force when required instead of substituting all metas in unification constraints
- Add `Type` to frontend language