### PR TITLE
Separate out unification and type-class solving into separate passes

### DIFF
--- a/vehicle/src/Vehicle/Compile/Type/Constraint.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint.hs
@@ -223,8 +223,8 @@ blockConstraintOn (WithContext c ctx) metas = WithContext c (blockCtxOn metas ct
 isBlocked :: MetaSet -> ConstraintContext -> Bool
 isBlocked solvedMetas ctx = isStillBlocked solvedMetas (blockedBy ctx)
 
-constraintIsBlocked :: MetaSet -> WithContext Constraint -> Bool
-constraintIsBlocked solvedMetas ctx = isBlocked solvedMetas (contextOf ctx)
+constraintIsBlocked :: MetaSet -> Contextualised c ConstraintContext -> Bool
+constraintIsBlocked solvedMetas c = isBlocked solvedMetas (contextOf c)
 
 --------------------------------------------------------------------------------
 -- Progress in solving meta-variable constraints

--- a/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/Core.hs
@@ -1,16 +1,62 @@
 module Vehicle.Compile.Type.ConstraintSolver.Core
-  ( blockOn,
+  ( runConstraintSolver,
+    blockOn,
     malformedConstraintError,
     unify,
   )
 where
 
+import Control.Monad (forM_)
+import Data.List (partition)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Print (prettyVerbose)
+import Vehicle.Compile.Print (PrettyVerbose, prettyVerbose)
 import Vehicle.Compile.Type.Constraint
+import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
+import Vehicle.Compile.Type.Monad (TCM)
+import Vehicle.Compile.Type.Monad.Class (getAndClearRecentlySolvedMetas)
 import Vehicle.Expr.Normalised (NormExpr)
+
+-- | Attempts to solve as many constraints as possible. Takes in
+-- the set of meta-variables solved since the solver was last run and outputs
+-- the set of meta-variables solved during this run.
+runConstraintSolver ::
+  forall m constraint.
+  (TCM m, PrettyVerbose (Contextualised constraint ConstraintContext)) =>
+  m [Contextualised constraint ConstraintContext] ->
+  ([Contextualised constraint ConstraintContext] -> m ()) ->
+  (Contextualised constraint ConstraintContext -> m ()) ->
+  MetaSet ->
+  m MetaSet
+runConstraintSolver getConstraints setConstraints attemptToSolveConstraint recentMetas = do
+  solvedMetas <- loop 0 recentMetas
+  logCompilerPassOutput ("metas-solved:" <+> pretty solvedMetas)
+  return solvedMetas
+  where
+    loop :: Int -> MetaSet -> m MetaSet
+    loop loopNumber recentMetasSolved = do
+      unsolvedConstraints <- getConstraints
+
+      if null unsolvedConstraints
+        then return mempty
+        else do
+          let isUnblocked = not . constraintIsBlocked recentMetasSolved
+          let (unblockedConstraints, blockedConstraints) = partition isUnblocked unsolvedConstraints
+
+          if null unblockedConstraints
+            then return mempty
+            else do
+              -- We have made useful progress so start a new pass
+              setConstraints blockedConstraints
+
+              forM_ unblockedConstraints $ \constraint -> do
+                logCompilerSection MaxDetail ("trying:" <+> prettyVerbose constraint) $
+                  attemptToSolveConstraint constraint
+
+              metasSolvedThisLoop <- getAndClearRecentlySolvedMetas
+              metasSolvedInFutureLoops <- loop (loopNumber + 1) metasSolvedThisLoop
+              return $ metasSolvedThisLoop <> metasSolvedInFutureLoops
 
 blockOn :: MonadCompile m => [MetaID] -> m ConstraintProgress
 blockOn metas = do

--- a/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/TypeClass.hs
+++ b/vehicle/src/Vehicle/Compile/Type/ConstraintSolver/TypeClass.hs
@@ -1,5 +1,5 @@
 module Vehicle.Compile.Type.ConstraintSolver.TypeClass
-  ( solveTypeClassConstraint,
+  ( runTypeClassSolver,
   )
 where
 
@@ -27,6 +27,21 @@ import Vehicle.Libraries.StandardLibrary.Names
 --------------------------------------------------------------------------------
 -- Public interface
 
+-- | Attempts to solve as many type-class constraints as possible. Takes in
+-- the set of meta-variables solved since the solver was last run and outputs
+-- the set of meta-variables solved during this run.
+runTypeClassSolver :: TCM m => MetaSet -> m MetaSet
+runTypeClassSolver metasSolved =
+  logCompilerPass MaxDetail ("type class solver run" <> line) $
+    runConstraintSolver
+      getActiveTypeClassConstraints
+      setTypeClassConstraints
+      solveTypeClassConstraint
+      metasSolved
+
+--------------------------------------------------------------------------------
+-- Solver
+
 solveTypeClassConstraint ::
   TCM m => WithContext TypeClassConstraint -> m ()
 solveTypeClassConstraint c = do
@@ -44,9 +59,6 @@ solveTypeClassConstraint c = do
       solution1 <- quote dbLevel solution
       solveMeta m solution1 dbLevel
       addConstraints newConstraints
-
---------------------------------------------------------------------------------
--- Solver
 
 type TypeClassProgress = Either MetaSet ([WithContext Constraint], NormExpr)
 

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -45,11 +45,12 @@ module Vehicle.Compile.Type.Monad.Class
     addUnificationConstraints,
     addTypeClassConstraints,
     setConstraints,
+    setUnificationConstraints,
     setTypeClassConstraints,
   )
 where
 
-import Control.Monad (foldM)
+import Control.Monad (foldM, unless)
 import Control.Monad.Reader (ReaderT (..), mapReaderT)
 import Control.Monad.State (StateT (..), mapStateT)
 import Control.Monad.Trans.Class (lift)
@@ -475,13 +476,17 @@ addConstraints constraints = do
 
 addUnificationConstraints :: MonadTypeChecker m => [WithContext UnificationConstraint] -> m ()
 addUnificationConstraints constraints = do
-  logDebug MaxDetail ("add-constraints " <> align (prettyFriendly constraints))
+  unless (null constraints) $ do
+    logDebug MaxDetail ("add-constraints " <> align (prettyFriendly constraints))
+
   modifyMetaCtx $ \TypeCheckerState {..} ->
     TypeCheckerState {unificationConstraints = unificationConstraints ++ constraints, ..}
 
 addTypeClassConstraints :: MonadTypeChecker m => [WithContext TypeClassConstraint] -> m ()
 addTypeClassConstraints constraints = do
-  logDebug MaxDetail ("add-constraint " <> align (prettyFriendly constraints))
+  unless (null constraints) $ do
+    logDebug MaxDetail ("add-constraints " <> align (prettyFriendly constraints))
+
   modifyMetaCtx $ \TypeCheckerState {..} ->
     TypeCheckerState {typeClassConstraints = typeClassConstraints ++ constraints, ..}
 


### PR DESCRIPTION
We now try to solve as many unification constraints as possible, and only then start trying to solve type-class constraints. We then repeat.