### PR TITLE
Consistently call things of type provenance `p`

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -222,10 +222,10 @@ normApp p fun args = do
 
 normAppList :: Provenance -> Expr binder var -> [Arg binder var] -> Expr binder var
 normAppList _ fun [] = fun
-normAppList ann fun (arg : args) = normApp ann fun (arg :| args)
+normAppList p fun (arg : args) = normApp p fun (arg :| args)
 
 mkHole :: Provenance -> Name -> Expr binder var
-mkHole ann name = Hole ann ("_" <> name)
+mkHole p name = Hole p ("_" <> name)
 
 isTypeSynonym :: Expr binder var -> Bool
 isTypeSynonym = \case

--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -876,7 +876,7 @@ equalityDependencies = \case
   ITensorType _ tElem _tDims -> do
     deps <- equalityDependencies tElem
     return $ [DataTensorInstances] <> deps
-  Var ann n -> throwError $ UnsupportedPolymorphicEquality AgdaBackend (provenanceOf ann) n
+  Var p n -> throwError $ UnsupportedPolymorphicEquality AgdaBackend p n
   t -> unexpectedTypeError t (map pretty [Bool, Nat, Int, List, Vector] <> [pretty (identifierName TensorIdent)])
 
 unexpectedTypeError :: MonadCompile m => OutputExpr -> [Doc ()] -> m a

--- a/vehicle/src/Vehicle/Compile/CapitaliseTypeNames.hs
+++ b/vehicle/src/Vehicle/Compile/CapitaliseTypeNames.hs
@@ -51,19 +51,19 @@ instance CapitaliseTypes CheckedDecl where
 
 instance CapitaliseTypes CheckedExpr where
   cap = cata $ \case
-    UniverseF ann l -> return $ Universe ann l
-    HoleF ann n -> return $ Hole ann n
-    MetaF ann m -> return $ Meta ann m
-    LiteralF ann l -> return $ Literal ann l
-    BuiltinF ann op -> return $ Builtin ann op
-    AnnF ann e t -> Ann ann <$> e <*> t
-    AppF ann fun args -> App ann <$> fun <*> traverse sequenceA args -- traverse cap args
-    PiF ann binder result -> Pi ann <$> sequenceA binder <*> result
-    LetF ann bound binder body -> Let ann <$> bound <*> sequenceA binder <*> body
-    LamF ann binder body -> Lam ann <$> sequenceA binder <*> body
-    LVecF ann xs -> LVec ann <$> sequence xs
-    VarF ann v@(Bound _) -> return $ Var ann v
-    VarF ann (Free ident) -> Var ann . Free <$> cap ident
+    UniverseF p l -> return $ Universe p l
+    HoleF p n -> return $ Hole p n
+    MetaF p m -> return $ Meta p m
+    LiteralF p l -> return $ Literal p l
+    BuiltinF p op -> return $ Builtin p op
+    AnnF p e t -> Ann p <$> e <*> t
+    AppF p fun args -> App p <$> fun <*> traverse sequenceA args -- traverse cap args
+    PiF p binder result -> Pi p <$> sequenceA binder <*> result
+    LetF p bound binder body -> Let p <$> bound <*> sequenceA binder <*> body
+    LamF p binder body -> Lam p <$> sequenceA binder <*> body
+    LVecF p xs -> LVec p <$> sequence xs
+    VarF p v@(Bound _) -> return $ Var p v
+    VarF p (Free ident) -> Var p . Free <$> cap ident
 
 instance CapitaliseTypes Identifier where
   cap ident@(Identifier m s) = do

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -113,28 +113,28 @@ descopeExpr ::
   Expr DBBinding var ->
   m InputExpr
 descopeExpr f e = showScopeExit $ case showScopeEntry e of
-  Universe ann l -> return $ Universe ann l
-  Hole ann name -> return $ Hole ann name
-  Builtin ann op -> return $ Builtin ann op
-  Literal ann l -> return $ Literal ann l
-  Meta ann i -> return $ Meta ann i
-  Var ann v -> Var ann <$> f ann v
-  Ann ann e1 t -> Ann ann <$> descopeExpr f e1 <*> descopeExpr f t
-  App ann fun args -> App ann <$> descopeExpr f fun <*> traverse (descopeArg f) args
-  LVec ann es -> LVec ann <$> traverse (descopeExpr f) es
-  Let ann bound binder body -> do
+  Universe p l -> return $ Universe p l
+  Hole p name -> return $ Hole p name
+  Builtin p op -> return $ Builtin p op
+  Literal p l -> return $ Literal p l
+  Meta p i -> return $ Meta p i
+  Var p v -> Var p <$> f p v
+  Ann p e1 t -> Ann p <$> descopeExpr f e1 <*> descopeExpr f t
+  App p fun args -> App p <$> descopeExpr f fun <*> traverse (descopeArg f) args
+  LVec p es -> LVec p <$> traverse (descopeExpr f) es
+  Let p bound binder body -> do
     bound' <- descopeExpr f bound
     binder' <- descopeBinder f binder
     body' <- local (addBinderToCtx binder') (descopeExpr f body)
-    return $ Let ann bound' binder' body'
-  Lam ann binder body -> do
+    return $ Let p bound' binder' body'
+  Lam p binder body -> do
     binder' <- descopeBinder f binder
     body' <- local (addBinderToCtx binder') (descopeExpr f body)
-    return $ Lam ann binder' body'
-  Pi ann binder body -> do
+    return $ Lam p binder' body'
+  Pi p binder body -> do
     binder' <- descopeBinder f binder
     body' <- local (addBinderToCtx binder') (descopeExpr f body)
-    return $ Pi ann binder' body'
+    return $ Pi p binder' body'
 
 descopeBinder ::
   (MonadReader Ctx f, Show var) =>

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -1219,10 +1219,10 @@ instance MeaningfulError CompileError where
             problem = "No properties found in file.",
             fix = Just $ "an expression is labelled as a property by giving it type" <+> squotes (pretty Bool) <+> "."
           }
-    NoNetworkUsedInProperty target ann ident ->
+    NoNetworkUsedInProperty target p ident ->
       UError $
         UserError
-          { provenance = provenanceOf ann,
+          { provenance = p,
             problem =
               "After normalisation, the property"
                 <+> prettyIdentName ident

--- a/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
@@ -134,7 +134,7 @@ mkNameWithIndices n index = n <> pack (show index)
 -- mconcat (n : [pack (show index) | index <- indices])
 
 mkDoubleExpr :: Provenance -> Double -> DBExpr
-mkDoubleExpr ann v = RatLiteral ann (toRational v)
+mkDoubleExpr p v = RatLiteral p (toRational v)
 
 mkIndexType :: Provenance -> Int -> DBExpr
 mkIndexType p n =
@@ -145,15 +145,15 @@ mkIndexType p n =
     ]
 
 mkIntExpr :: Provenance -> Int -> DBExpr
-mkIntExpr ann v
-  | v >= 0 = NatLiteral ann v
-  | otherwise = IntLiteral ann v
+mkIntExpr p v
+  | v >= 0 = NatLiteral p v
+  | otherwise = IntLiteral p v
 
 mkTensorDims ::
   Provenance ->
   [Int] ->
   [DBExpr]
-mkTensorDims ann = fmap (NatLiteral ann)
+mkTensorDims p = fmap (NatLiteral p)
 
 mkTensorType ::
   Provenance ->

--- a/vehicle/src/Vehicle/Compile/Queries/DNF.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/DNF.hs
@@ -70,7 +70,7 @@ dnf expr = do
   return result
 
 liftOr :: (CheckedExpr -> CheckedExpr) -> CheckedExpr -> CheckedExpr
-liftOr f (OrExpr ann [e1, e2]) = OrExpr ann (fmap (liftOr f) <$> [e1, e2])
+liftOr f (OrExpr p [e1, e2]) = OrExpr p (fmap (liftOr f) <$> [e1, e2])
 liftOr f e = f e
 
 lowerNot :: CheckedExpr -> CheckedExpr

--- a/vehicle/src/Vehicle/Compile/Queries/IfElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/IfElimination.hs
@@ -30,11 +30,11 @@ currentPass = "if elimination"
 -- If operations
 
 liftIf :: (CheckedExpr -> CheckedExpr) -> CheckedExpr -> CheckedExpr
-liftIf f (IfExpr ann _t [cond, e1, e2]) =
+liftIf f (IfExpr p _t [cond, e1, e2]) =
   IfExpr
-    ann
+    p
     -- Can't reconstruct the result type of `f` here, so have to insert a hole.
-    (BoolType ann)
+    (BoolType p)
     [ cond,
       fmap (liftIf f) e1,
       fmap (liftIf f) e2
@@ -44,12 +44,12 @@ liftIf f e = f e
 -- | Recursively removes all top-level `if` statements in the current
 -- provided expression.
 elimIf :: CheckedExpr -> CheckedExpr
-elimIf (IfExpr ann _ [cond, e1, e2]) =
-  OrExpr ann $
+elimIf (IfExpr p _ [cond, e1, e2]) =
+  OrExpr p $
     fmap
-      (ExplicitArg ann)
-      [ AndExpr ann [cond, fmap elimIf e1],
-        AndExpr ann [normaliseNotArg cond, fmap elimIf e2]
+      (ExplicitArg p)
+      [ AndExpr p [cond, fmap elimIf e1],
+        AndExpr p [normaliseNotArg cond, fmap elimIf e2]
       ]
 elimIf e = e
 
@@ -87,7 +87,7 @@ liftAndElimIf expr = case expr of
   Lam {} -> normalisationError currentPass "Non-quantified Lam"
 
 liftArg :: (CheckedArg -> CheckedExpr) -> CheckedArg -> CheckedExpr
-liftArg f (Arg ann v r e) = liftIf (f . Arg ann v r) e
+liftArg f (Arg p v r e) = liftIf (f . Arg p v r) e
 
 liftSeq :: ([CheckedExpr] -> CheckedExpr) -> [CheckedExpr] -> CheckedExpr
 liftSeq f [] = f []

--- a/vehicle/src/Vehicle/Compile/Resource.hs
+++ b/vehicle/src/Vehicle/Compile/Resource.hs
@@ -40,8 +40,8 @@ instance Pretty NetworkBaseType where
   pretty = \case
     NetworkRatType -> pretty Rat
 
-reconstructNetworkBaseType :: Provenance -> NetworkBaseType -> CheckedType
-reconstructNetworkBaseType ann NetworkRatType = RatType ann
+reconstructNetworkBaseType :: NetworkBaseType -> Provenance -> CheckedType
+reconstructNetworkBaseType NetworkRatType = RatType
 
 type NetworkContext = Map Name NetworkType
 

--- a/vehicle/src/Vehicle/Compile/Simplify.hs
+++ b/vehicle/src/Vehicle/Compile/Simplify.hs
@@ -27,12 +27,12 @@ instance Simplify (Expr binder var) where
     Builtin {} -> expr
     Literal {} -> expr
     Var {} -> expr
-    App ann fun args -> normAppList ann (simplify fun) (simplifyArgs args)
-    LVec ann xs -> LVec ann (fmap simplify xs)
-    Ann ann e t -> Ann ann (simplify e) (simplify t)
-    Pi ann binder result -> Pi ann (simplify binder) (simplify result)
-    Let ann bound binder body -> Let ann (simplify bound) (simplify binder) (simplify body)
-    Lam ann binder body -> Lam ann (simplify binder) (simplify body)
+    App p fun args -> normAppList p (simplify fun) (simplifyArgs args)
+    LVec p xs -> LVec p (fmap simplify xs)
+    Ann p e t -> Ann p (simplify e) (simplify t)
+    Pi p binder result -> Pi p (simplify binder) (simplify result)
+    Let p bound binder body -> Let p (simplify bound) (simplify binder) (simplify body)
+    Lam p binder body -> Lam p (simplify binder) (simplify body)
 
 instance Simplify (Binder binder var) where
   simplify = fmap simplify

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -80,12 +80,12 @@ makeMetaType ::
   Provenance ->
   CheckedType ->
   CheckedType
-makeMetaType boundCtx ann resultType = foldr entryToPi resultType (reverse boundCtx)
+makeMetaType boundCtx p resultType = foldr entryToPi resultType (reverse boundCtx)
   where
     entryToPi :: (Maybe Name, CheckedType, Maybe CheckedExpr) -> CheckedType -> CheckedType
     entryToPi (name, t, _) = do
       let n = fromMaybe "_" name
-      Pi ann (Binder ann (BinderDisplayForm (OnlyName n) True) Explicit Relevant () t)
+      Pi p (Binder p (BinderDisplayForm (OnlyName n) True) Explicit Relevant () t)
 
 getMetaDependencies :: [CheckedArg] -> [DBIndex]
 getMetaDependencies = \case

--- a/vehicle/src/Vehicle/Expr/CoDeBruijn/Conversion.hs
+++ b/vehicle/src/Vehicle/Expr/CoDeBruijn/Conversion.hs
@@ -21,33 +21,33 @@ import Vehicle.Expr.DeBruijn as DB
 
 toCoDBExpr :: DBExpr -> CoDBExpr
 toCoDBExpr = cata $ \case
-  UniverseF ann l -> (Universe ann l, mempty)
-  HoleF ann n -> (Hole ann n, mempty)
-  MetaF ann m -> (Meta ann m, mempty)
-  BuiltinF ann op -> (Builtin ann op, mempty)
-  LiteralF ann l -> (Literal ann l, mempty)
-  LVecF ann xs ->
-    let (xs', bvms) = unzip xs in (LVec ann xs', nodeBVM bvms)
-  VarF ann v -> case v of
-    DB.Free ident -> (Var ann (CoDBFree ident), mempty)
-    DB.Bound i -> (Var ann CoDBBound, leafBVM i)
-  AnnF ann (e', bvm1) (t', bvm2) ->
-    (Ann ann e' t', nodeBVM [bvm1, bvm2])
-  AppF ann (fun', bvm) args ->
+  UniverseF p l -> (Universe p l, mempty)
+  HoleF p n -> (Hole p n, mempty)
+  MetaF p m -> (Meta p m, mempty)
+  BuiltinF p op -> (Builtin p op, mempty)
+  LiteralF p l -> (Literal p l, mempty)
+  LVecF p xs ->
+    let (xs', bvms) = unzip xs in (LVec p xs', nodeBVM bvms)
+  VarF p v -> case v of
+    DB.Free ident -> (Var p (CoDBFree ident), mempty)
+    DB.Bound i -> (Var p CoDBBound, leafBVM i)
+  AnnF p (e', bvm1) (t', bvm2) ->
+    (Ann p e' t', nodeBVM [bvm1, bvm2])
+  AppF p (fun', bvm) args ->
     let (args', bvms) = NonEmpty.unzip $ fmap unpairArg args
-     in (App ann fun' args', nodeBVM (bvm : NonEmpty.toList bvms))
-  PiF ann binder (result', bvm2) ->
+     in (App p fun' args', nodeBVM (bvm : NonEmpty.toList bvms))
+  PiF p binder (result', bvm2) ->
     let (positionTree, bvm2') = liftBVM bvm2
      in let (binder', bvm1) = toCoDBBinder binder positionTree
-         in (Pi ann binder' result', nodeBVM [bvm1, bvm2'])
-  LetF ann (bound', bvm1) binder (body', bvm3) ->
+         in (Pi p binder' result', nodeBVM [bvm1, bvm2'])
+  LetF p (bound', bvm1) binder (body', bvm3) ->
     let (positionTree, bvm3') = liftBVM bvm3
      in let (binder', bvm2) = toCoDBBinder binder positionTree
-         in (Let ann bound' binder' body', nodeBVM [bvm1, bvm2, bvm3'])
-  LamF ann binder (body', bvm2) ->
+         in (Let p bound' binder' body', nodeBVM [bvm1, bvm2, bvm3'])
+  LamF p binder (body', bvm2) ->
     let (positionTree, bvm2') = liftBVM bvm2
      in let (binder', bvm1) = toCoDBBinder binder positionTree
-         in (Lam ann binder' body', nodeBVM [bvm1, bvm2'])
+         in (Lam p binder' body', nodeBVM [bvm1, bvm2'])
 
 toCoDBBinder ::
   GenericBinder DBBinding CoDBExpr ->

--- a/vehicle/src/Vehicle/Expr/DSL.hs
+++ b/vehicle/src/Vehicle/Expr/DSL.hs
@@ -144,7 +144,7 @@ tMax :: DBExpr -> DBExpr -> DBExpr
 tMax t1 t2 = if universeLevel t1 > universeLevel t2 then t1 else t2
 
 builtin :: Builtin -> DSLExpr
-builtin b = DSL $ \ann _ -> Builtin ann b
+builtin b = DSL $ \p _ -> Builtin p b
 
 constructor :: BuiltinConstructor -> DSLExpr
 constructor = builtin . Constructor
@@ -206,7 +206,7 @@ forAllPolarityTriples f =
       forAllIrrelevant "p3" tPol $ \l3 -> f l1 l2 l3
 
 universe :: Universe -> DSLExpr
-universe u = DSL $ \ann _ -> Universe ann u
+universe u = DSL $ \p _ -> Universe p u
 
 type0 :: DSLExpr
 type0 = universe $ TypeUniv 0
@@ -254,7 +254,7 @@ tIndex :: DSLExpr -> DSLExpr
 tIndex n = constructor Index @@ [n]
 
 tHole :: Name -> DSLExpr
-tHole name = DSL $ \ann _ -> Hole ann name
+tHole name = DSL $ \p _ -> Hole p name
 
 --------------------------------------------------------------------------------
 -- TypeClass

--- a/vehicle/src/Vehicle/Expr/Patterns.hs
+++ b/vehicle/src/Vehicle/Expr/Patterns.hs
@@ -195,9 +195,9 @@ pattern HasQuantifierInExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasQuantifierInExpr ann q tElem tCont <-
+pattern HasQuantifierInExpr p q tElem tCont <-
   BuiltinTypeClass
-    ann
+    p
     (HasQuantifierIn q)
     [ ExplicitArg _ tElem,
       ExplicitArg _ tCont
@@ -208,9 +208,9 @@ pattern HasNatLitsExpr ::
   Int ->
   Expr binder var ->
   Expr binder var
-pattern HasNatLitsExpr ann n t <-
+pattern HasNatLitsExpr p n t <-
   BuiltinTypeClass
-    ann
+    p
     (HasNatLits n)
     [ ExplicitArg _ t
       ]
@@ -219,9 +219,9 @@ pattern HasRatLitsExpr ::
   Provenance ->
   Expr binder var ->
   Expr binder var
-pattern HasRatLitsExpr ann t <-
+pattern HasRatLitsExpr p t <-
   BuiltinTypeClass
-    ann
+    p
     HasRatLits
     [ ExplicitArg _ t
       ]
@@ -233,9 +233,9 @@ pattern HasArithOp2Expr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasArithOp2Expr ann tc t1 t2 t3 <-
+pattern HasArithOp2Expr p tc t1 t2 t3 <-
   BuiltinTypeClass
-    ann
+    p
     tc
     [ ExplicitArg _ t1,
       ExplicitArg _ t2,
@@ -248,7 +248,7 @@ pattern HasAddExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasAddExpr ann t1 t2 t3 <- HasArithOp2Expr ann HasAdd t1 t2 t3
+pattern HasAddExpr p t1 t2 t3 <- HasArithOp2Expr p HasAdd t1 t2 t3
 
 pattern HasSubExpr ::
   Provenance ->
@@ -256,7 +256,7 @@ pattern HasSubExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasSubExpr ann t1 t2 t3 <- HasArithOp2Expr ann HasSub t1 t2 t3
+pattern HasSubExpr p t1 t2 t3 <- HasArithOp2Expr p HasSub t1 t2 t3
 
 pattern HasMulExpr ::
   Provenance ->
@@ -264,7 +264,7 @@ pattern HasMulExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasMulExpr ann t1 t2 t3 <- HasArithOp2Expr ann HasMul t1 t2 t3
+pattern HasMulExpr p t1 t2 t3 <- HasArithOp2Expr p HasMul t1 t2 t3
 
 pattern HasDivExpr ::
   Provenance ->
@@ -272,16 +272,16 @@ pattern HasDivExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasDivExpr ann t1 t2 t3 <- HasArithOp2Expr ann HasDiv t1 t2 t3
+pattern HasDivExpr p t1 t2 t3 <- HasArithOp2Expr p HasDiv t1 t2 t3
 
 pattern HasNegExpr ::
   Provenance ->
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern HasNegExpr ann argType resType <-
+pattern HasNegExpr p argType resType <-
   BuiltinTypeClass
-    ann
+    p
     HasNeg
     [ ExplicitArg _ argType,
       ExplicitArg _ resType
@@ -324,22 +324,22 @@ pattern HasEqExpr p eq arg1Type arg2Type resType <-
 --------------------------------------------------------------------------------
 
 pattern UnitLiteral :: Provenance -> Expr binder var
-pattern UnitLiteral ann = Literal ann LUnit
+pattern UnitLiteral p = Literal p LUnit
 
 pattern BoolLiteral :: Provenance -> Bool -> Expr binder var
-pattern BoolLiteral ann n = Literal ann (LBool n)
+pattern BoolLiteral p n = Literal p (LBool n)
 
 pattern IndexLiteral :: Provenance -> Int -> Int -> Expr binder var
-pattern IndexLiteral ann n x = Literal ann (LIndex n x)
+pattern IndexLiteral p n x = Literal p (LIndex n x)
 
 pattern NatLiteral :: Provenance -> Int -> Expr binder var
-pattern NatLiteral ann n = Literal ann (LNat n)
+pattern NatLiteral p n = Literal p (LNat n)
 
 pattern IntLiteral :: Provenance -> Int -> Expr binder var
-pattern IntLiteral ann n = Literal ann (LInt n)
+pattern IntLiteral p n = Literal p (LInt n)
 
 pattern RatLiteral :: Provenance -> Rational -> Expr binder var
-pattern RatLiteral ann n = Literal ann (LRat n)
+pattern RatLiteral p n = Literal p (LRat n)
 
 pattern VecLiteral ::
   Provenance ->
@@ -358,10 +358,10 @@ pattern AnnVecLiteral ::
 pattern AnnVecLiteral p tElem xs <- App p (LVec _ xs) (ImplicitArg _ tElem :| _)
 
 pattern TrueExpr :: Provenance -> Expr binder var
-pattern TrueExpr ann = BoolLiteral ann True
+pattern TrueExpr p = BoolLiteral p True
 
 pattern FalseExpr :: Provenance -> Expr binder var
-pattern FalseExpr ann = BoolLiteral ann False
+pattern FalseExpr p = BoolLiteral p False
 
 --------------------------------------------------------------------------------
 -- Expressions
@@ -473,8 +473,8 @@ pattern ForallInTCExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern ForallInTCExpr ann tCont binder body container <-
-  QuantifierInTCExpr Forall ann tCont binder body container
+pattern ForallInTCExpr p tCont binder body container <-
+  QuantifierInTCExpr Forall p tCont binder body container
 
 pattern ExistsInTCExpr ::
   Provenance ->
@@ -483,8 +483,8 @@ pattern ExistsInTCExpr ::
   Expr binder var ->
   Expr binder var ->
   Expr binder var
-pattern ExistsInTCExpr ann tCont binder body container <-
-  QuantifierInTCExpr Exists ann tCont binder body container
+pattern ExistsInTCExpr p tCont binder body container <-
+  QuantifierInTCExpr Exists p tCont binder body container
 
 --------------------------------------------------------------------------------
 -- IfExpr
@@ -628,7 +628,7 @@ pattern DivExpr p dom args = BuiltinExpr p (Div dom) args
 -- EqualityOp
 
 -- pattern BuiltinEquality :: Provenance -> EqualityOp -> Expr binder var
--- pattern BuiltinEquality ann eq = Builtin ann (EqualityOp eq)
+-- pattern BuiltinEquality p eq = Builtin p (EqualityOp eq)
 
 pattern EqualityTCExpr ::
   Provenance ->
@@ -664,7 +664,7 @@ pattern EqualityExpr p dom op args <- App p (Builtin _ (Equals dom op)) args
 -- OrderOp
 {-
 pattern BuiltinOrder :: Provenance -> OrderOp -> Expr binder var
-pattern BuiltinOrder ann order = Builtin ann (OrderOp order)
+pattern BuiltinOrder p order = Builtin p (OrderOp order)
 -}
 pattern OrderTCExpr ::
   Provenance ->
@@ -707,9 +707,9 @@ pattern ConsExpr ::
   Expr binder var ->
   [Arg binder var] ->
   Expr binder var
-pattern ConsExpr ann tElem explicitArgs <-
+pattern ConsExpr p tElem explicitArgs <-
   ConstructorExpr
-    ann
+    p
     Cons
     ( ImplicitArg _ tElem
         :| explicitArgs
@@ -756,9 +756,9 @@ pattern AtExpr ::
   Expr binder var ->
   [Arg binder var] ->
   Expr binder var
-pattern AtExpr ann tElem tDim explicitArgs <-
+pattern AtExpr p tElem tDim explicitArgs <-
   App
-    ann
+    p
     (Builtin _ At)
     ( ImplicitArg _ tElem
         :| ImplicitArg _ tDim

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Common.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Common.hs
@@ -72,24 +72,24 @@ unitTestCase testName errorOrAssertionWithLogs =
 
 normTypeClasses :: MonadCompile m => CheckedExpr -> m CheckedExpr
 normTypeClasses = cata $ \case
-  AppF ann fun args -> do
+  AppF p fun args -> do
     fun' <- fun
     args' <- traverse sequenceA args
     case fun' of
-      Builtin p (TypeClassOp op) -> case nfTypeClassOp p op (NonEmpty.toList args') of
+      Builtin p' (TypeClassOp op) -> case nfTypeClassOp p' op (NonEmpty.toList args') of
         Nothing -> error "No metas should be present"
         Just res -> do
           (fn, newArgs) <- res
           return $ normApp p fn newArgs
-      _ -> return $ App ann fun' args'
-  UniverseF ann l -> return $ Universe ann l
-  HoleF ann n -> return $ Hole ann n
-  MetaF ann m -> return $ Meta ann m
-  LiteralF ann l -> return $ Literal ann l
-  BuiltinF ann op -> return $ Builtin ann op
-  AnnF ann e t -> Ann ann <$> e <*> t
-  PiF ann binder result -> Pi ann <$> sequenceA binder <*> result
-  LetF ann bound binder body -> Let ann <$> bound <*> sequenceA binder <*> body
-  LamF ann binder body -> Lam ann <$> sequenceA binder <*> body
-  LVecF ann xs -> LVec ann <$> sequence xs
-  VarF ann v -> return $ Var ann v
+      _ -> return $ App p fun' args'
+  UniverseF p l -> return $ Universe p l
+  HoleF p n -> return $ Hole p n
+  MetaF p m -> return $ Meta p m
+  LiteralF p l -> return $ Literal p l
+  BuiltinF p op -> return $ Builtin p op
+  AnnF p e t -> Ann p <$> e <*> t
+  PiF p binder result -> Pi p <$> sequenceA binder <*> result
+  LetF p bound binder body -> Let p <$> bound <*> sequenceA binder <*> body
+  LamF p binder body -> Lam p <$> sequenceA binder <*> body
+  LVecF p xs -> LVec p <$> sequence xs
+  VarF p v -> return $ Var p v


### PR DESCRIPTION
Make use of `p` consistently everywhere