### PR TITLE
Use a continuation passing to cut out the use of CSE

### DIFF
--- a/vehicle/src/Vehicle/Compile/Queries.hs
+++ b/vehicle/src/Vehicle/Compile/Queries.hs
@@ -18,8 +18,10 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.QuantifierAnalysis (checkQuantifiersAndNegateIfNecessary)
 import Vehicle.Compile.Queries.DNF (convertToDNF)
 import Vehicle.Compile.Queries.IfElimination (eliminateIfs)
+import Vehicle.Compile.Queries.LinearSatisfactionProblem (generateCLSTProblem)
 import Vehicle.Compile.Queries.NetworkElimination
 import Vehicle.Compile.Queries.QuantifierLifting (liftAndRemoveQuantifiers)
+import Vehicle.Compile.Queries.Variable (UserVariable (..))
 import Vehicle.Compile.Queries.VariableReconstruction
 import Vehicle.Compile.Resource
 import Vehicle.Compile.Type (getPropertyInfo, getUnnormalised)
@@ -177,9 +179,24 @@ compileSingleQuery expr = do
     -- First lift all the quantifiers to the top-level and remove them.
     (quantLiftedExpr, userVariables) <- liftAndRemoveQuantifiers expr
 
-    -- Convert all user variables and applications of networks into magic I/O variables
-    clstQuery <- normUserVariables ident verifier networkCtx userVariables quantLiftedExpr
+    -- Substitute through the let-bound applications.
+    let boundCtx = fmap (Just . userVarName) userVariables
 
+    -- Convert all user variables and applications of networks into magic I/O variables
+    (metaNetwork, networkVariables, inputEqualities, queryExpr) <-
+      replaceNetworkApplications networkCtx boundCtx quantLiftedExpr
+
+    -- Convert it into a linear satisfaction problem in the user variables
+    let state =
+          ( networkCtx,
+            ident,
+            metaNetwork,
+            userVariables,
+            networkVariables
+          )
+    clstQuery <- generateCLSTProblem state inputEqualities queryExpr
+
+    -- Compile the query to the specific verifiers.
     flip traverseQuery clstQuery $ \(clstProblem, u, v) -> do
       queryDoc <- compileQuery verifier clstProblem
       logCompilerPassOutput queryDoc

--- a/vehicle/src/Vehicle/Compile/Queries/LinearSatisfactionProblem.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearSatisfactionProblem.hs
@@ -1,0 +1,280 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use section" #-}
+module Vehicle.Compile.Queries.LinearSatisfactionProblem
+  ( generateCLSTProblem,
+  )
+where
+
+import Control.Monad (forM)
+import Control.Monad.Except (MonadError (..))
+import Control.Monad.Reader (MonadReader (..), runReaderT)
+import Data.Bifunctor (Bifunctor (..))
+import Data.List (partition)
+import Data.Map (Map)
+import Data.Map qualified as Map
+  ( lookup,
+    singleton,
+    unionWith,
+  )
+import Data.Maybe (mapMaybe)
+import Data.Set qualified as Set
+import Vehicle.Backend.Prelude
+import Vehicle.Compile.Error
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Print (prettyVerbose)
+import Vehicle.Compile.Queries.FourierMotzkinElimination (fourierMotzkinElimination)
+import Vehicle.Compile.Queries.GaussianElimination
+  ( gaussianElimination,
+    solutionEquality,
+  )
+import Vehicle.Compile.Queries.LNF (convertToLNF)
+import Vehicle.Compile.Queries.LinearExpr
+import Vehicle.Compile.Queries.NetworkElimination (InputEqualities)
+import Vehicle.Compile.Queries.Variable
+import Vehicle.Compile.Queries.VariableReconstruction
+import Vehicle.Compile.Resource
+import Vehicle.Expr.DeBruijn
+import Vehicle.Verify.Specification
+
+-- | Generates a constraint satisfication problem in the magic network variables only.
+generateCLSTProblem ::
+  MonadCompile m =>
+  LCSState ->
+  InputEqualities ->
+  CheckedExpr ->
+  m (Query (CLSTProblem NetworkVariable, MetaNetwork, UserVarReconstructionInfo))
+generateCLSTProblem state inputEqualities queryExpr = flip runReaderT state $ do
+  (_, _, metaNetwork, userVariables, _) <- ask
+  variables <- getVariables
+
+  inputEqualityAssertions <- forM inputEqualities $ \(i, expr) -> do
+    -- Create linear expression equating the magic variable `x_i`
+    -- with the expression `e` in the relevant point = xs_i`
+    exprSize <- getExprSize
+    let lhs = linearExprFromMap exprSize (Map.singleton i 1)
+    rhs <- compileLinearExpr expr
+    return $ constructAssertion (lhs, Equal, rhs)
+
+  result <- compileAssertions queryExpr
+
+  flip traverseQuery result $ \userAssertions -> do
+    let assertions = inputEqualityAssertions <> userAssertions
+    let clst = CLSTProblem variables assertions
+
+    (solvedCLST, userVarReconstruction) <-
+      solveForUserVariables (length userVariables) clst
+
+    logCompilerPassOutput $ pretty solvedCLST
+    return (solvedCLST, metaNetwork, userVarReconstruction)
+
+solveForUserVariables ::
+  MonadCompile m =>
+  Int ->
+  CLSTProblem Variable ->
+  m (CLSTProblem NetworkVariable, UserVarReconstructionInfo)
+solveForUserVariables numberOfUserVars (CLSTProblem variables assertions) =
+  logCompilerPass MinDetail "elimination of user variables" $ do
+    let allUserVars = Set.fromList [0 .. numberOfUserVars - 1]
+
+    -- First remove those assertions that don't have any user variables in them.
+    let (withUserVars, withoutUserVars) =
+          partition (hasUserVariables numberOfUserVars) assertions
+
+    -- Then split out the equalities from the inequalities.
+    let (equalitiesWithUserVars, inequalitiesWithUserVars) =
+          partition isEquality withUserVars
+
+    -- Try to solve for user variables using Gaussian elimination.
+    (gaussianSolutions, unusedEqualityExprs) <-
+      gaussianElimination variables (map assertionExpr equalitiesWithUserVars) numberOfUserVars
+    let unusedEqualities = fmap (Assertion Equal) unusedEqualityExprs
+
+    -- Eliminate the solved user variables in the inequalities
+    let gaussianSolutionEqualities = fmap (second solutionEquality) gaussianSolutions
+    let reducedInequalities =
+          flip fmap inequalitiesWithUserVars $ \assertion ->
+            foldl (uncurry . substitute) assertion gaussianSolutionEqualities
+
+    -- Calculate the set of unsolved user variables
+    let varsSolvedByGaussianElim = Set.fromList (fmap fst gaussianSolutions)
+    let varsUnsolvedByGaussianElim = Set.difference allUserVars varsSolvedByGaussianElim
+
+    -- Eliminate the remaining unsolved user vars using Fourier-Motzkin elimination
+    (fourierMotzkinSolutions, fmElimOutputInequalities) <-
+      fourierMotzkinElimination variables varsUnsolvedByGaussianElim reducedInequalities
+
+    -- Calculate the way to reconstruct the user variables
+    let varSolutions =
+          fmap (second FourierMotzkinSolution) fourierMotzkinSolutions
+            <> fmap (second GaussianSolution) gaussianSolutions
+
+    -- Calculate the final set of (user-variable free) assertions
+    let resultingAssertions = withoutUserVars <> unusedEqualities <> fmElimOutputInequalities
+
+    -- Remove all user variables
+    let networkVariables = mapMaybe getNetworkVariable variables
+    let finalAssertions = fmap (removeUserVariables numberOfUserVars) resultingAssertions
+
+    -- Return the problem
+    return (CLSTProblem networkVariables finalAssertions, varSolutions)
+
+--------------------------------------------------------------------------------
+-- Monad
+
+type LCSState =
+  ( NetworkContext,
+    Identifier,
+    MetaNetwork,
+    [UserVariable],
+    [NetworkVariable]
+  )
+
+type MonadSMT m =
+  ( MonadCompile m,
+    MonadReader LCSState m
+  )
+
+getNetworkDetailsFromCtx :: MonadCompile m => NetworkContext -> Name -> m NetworkType
+getNetworkDetailsFromCtx networkCtx name = do
+  case Map.lookup name networkCtx of
+    Just details -> return details
+    Nothing ->
+      compilerDeveloperError $
+        "Either" <+> squotes (pretty name) <+> "is not a network or it is not in scope"
+
+getBoundContext :: MonadSMT m => m BoundDBCtx
+getBoundContext = do
+  (_, _, _, userVariables, networkVariables) <- ask
+  let userNames = reverse $ fmap (layoutAsText . pretty) userVariables
+  let networkNames = reverse $ fmap (layoutAsText . pretty) networkVariables
+  return $ fmap Just (userNames <> networkNames)
+
+getNumberOfUserVariables :: MonadSMT m => m Int
+getNumberOfUserVariables = do
+  (_, _, _, userVariables, _) <- ask
+  return $ length userVariables
+
+getMetaNetworkType :: MonadSMT m => m [NetworkType]
+getMetaNetworkType = do
+  (networkCtx, _, metaNetwork, _, _) <- ask
+  traverse (getNetworkDetailsFromCtx networkCtx) metaNetwork
+
+getNumberOfMagicVariables :: MonadSMT m => m Int
+getNumberOfMagicVariables = sum . fmap networkSize <$> getMetaNetworkType
+
+getTotalNumberOfVariables :: MonadSMT m => m Int
+getTotalNumberOfVariables = do
+  numberOfUserVariables <- getNumberOfUserVariables
+  numberOfMagicVariables <- getNumberOfMagicVariables
+  return $ numberOfUserVariables + numberOfMagicVariables
+
+getExprSize :: MonadSMT m => m Int
+getExprSize =
+  -- Add one more for the constant term.
+  (1 +) <$> getTotalNumberOfVariables
+
+getVariables :: MonadSMT m => m [Variable]
+getVariables = do
+  (_, _, _, userVariables, networkVariables) <- ask
+  return $ fmap UserVar userVariables <> fmap NetworkVar networkVariables
+
+getExprConstantIndex :: MonadSMT m => m Int
+getExprConstantIndex =
+  -- The contant in the linear expression is stored in the last index.
+  getTotalNumberOfVariables
+
+--------------------------------------------------------------------------------
+-- Steps 3 & 4: replace network applications
+
+compileAssertions :: MonadSMT m => CheckedExpr -> m (Query [Assertion])
+compileAssertions = \case
+  BoolLiteral _ b -> return $ Trivial b
+  e -> NonTrivial <$> go e
+  where
+    go :: MonadSMT m => CheckedExpr -> m [Assertion]
+    go expr = case expr of
+      Universe {} -> unexpectedTypeInExprError currentPass "Universe"
+      Pi {} -> unexpectedTypeInExprError currentPass "Pi"
+      Hole {} -> resolutionError currentPass "Hole"
+      Meta {} -> resolutionError currentPass "Meta"
+      Ann {} -> normalisationError currentPass "Ann"
+      Lam {} -> normalisationError currentPass "Lam"
+      Let {} -> normalisationError currentPass "Let"
+      LVec {} -> normalisationError currentPass "LVec"
+      Builtin {} -> normalisationError currentPass "LVec"
+      Var {} -> caseError currentPass "Var" ["OrderOp", "Eq"]
+      Literal _ l -> case l of
+        LBool _ -> normalisationError currentPass "LBool"
+        _ -> caseError currentPass "Literal" ["AndExpr"]
+      AndExpr _ [ExplicitArg _ e1, ExplicitArg _ e2] -> do
+        as1 <- go e1
+        as2 <- go e2
+        return (as1 <> as2)
+      OrderExpr _ OrderRat ord [ExplicitArg _ e1, ExplicitArg _ e2] -> do
+        let (rel, lhs, rhs) = case ord of
+              Lt -> (LessThan, e1, e2)
+              Le -> (LessThanOrEqualTo, e1, e2)
+              Gt -> (LessThan, e2, e1)
+              Ge -> (LessThanOrEqualTo, e2, e1)
+        assertion <- compileAssertion rel lhs rhs
+        return [assertion]
+      EqualityExpr p EqRat eq [ExplicitArg _ e1, ExplicitArg _ e2] -> case eq of
+        Neq -> do
+          (_, ident, _, _, _) <- ask
+          throwError $ UnsupportedInequality MarabouBackend ident p
+        Eq -> do
+          assertion <- compileAssertion Equal e1 e2
+          return [assertion]
+      App {} -> unexpectedExprError currentPass (prettyVerbose expr)
+
+compileAssertion ::
+  MonadSMT m =>
+  Relation ->
+  CheckedExpr ->
+  CheckedExpr ->
+  m Assertion
+compileAssertion rel lhs rhs = do
+  lhsLinExpr <- compileLinearExpr lhs
+  rhsLinExpr <- compileLinearExpr rhs
+  return $ constructAssertion (lhsLinExpr, rel, rhsLinExpr)
+
+compileLinearExpr :: MonadSMT m => CheckedExpr -> m LinearExpr
+compileLinearExpr expr = do
+  lnfExpr <- convertToLNF expr
+  linearExpr <- go lnfExpr
+  exprSize <- getExprSize
+  return $ linearExprFromMap exprSize linearExpr
+  where
+    singletonVar :: MonadSMT m => DBIndexVar -> Coefficient -> m (Map Int Coefficient)
+    singletonVar Free {} _ = normalisationError currentPass "FreeVar"
+    singletonVar (Bound (DBIndex v)) c = do
+      numberOfUserVariables <- getNumberOfUserVariables
+      let i = if v < numberOfUserVariables then numberOfUserVariables - v - 1 else v
+      return $ Map.singleton i c
+
+    go :: MonadSMT m => CheckedExpr -> m (Map Int Coefficient)
+    go e = case e of
+      Var _ v ->
+        singletonVar v 1
+      NegExpr _ NegRat [ExplicitArg _ (Var _ v)] ->
+        singletonVar v (-1)
+      RatLiteral _ l -> do
+        constIndex <- getExprConstantIndex
+        singletonVar (Bound (DBIndex constIndex)) (fromRational l)
+      AddExpr _ AddRat [ExplicitArg _ e1, ExplicitArg _ e2] -> do
+        Map.unionWith (+) <$> go e1 <*> go e2
+      MulExpr _ MulRat [ExplicitArg _ e1, ExplicitArg _ e2] ->
+        case (e1, e2) of
+          (RatLiteral _ l, Var _ v) -> singletonVar v (fromRational l)
+          (Var _ v, RatLiteral _ l) -> singletonVar v (fromRational l)
+          _ -> do
+            (_, _ident, _, _, _) <- ask
+            _ctx <- getBoundContext
+            compilerDeveloperError $
+              "Unexpected non-linear constraint that should have been caught by the"
+                <+> "linearity analysis during type-checking."
+      ex -> unexpectedExprError currentPass $ prettyVerbose ex
+
+currentPass :: Doc a
+currentPass = "linear satisfaction problem compilation"

--- a/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
@@ -1,394 +1,163 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use section" #-}
 module Vehicle.Compile.Queries.NetworkElimination
-  ( MetaNetwork,
-    normUserVariables,
+  ( InputEqualities,
+    replaceNetworkApplications,
   )
 where
 
 import Control.Monad (zipWithM)
-import Control.Monad.Except (MonadError (..))
-import Control.Monad.Reader (MonadReader (..), runReaderT)
-import Data.Bifunctor (Bifunctor (..))
-import Data.List (partition)
+import Control.Monad.State (MonadState (..), StateT (..))
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as HashMap
 import Data.List.Split (chunksOf)
 import Data.Map (Map)
 import Data.Map qualified as Map
   ( insertWith,
     lookup,
-    member,
-    singleton,
-    unionWith,
   )
-import Data.Maybe (mapMaybe)
-import Data.Set qualified as Set
-import Vehicle.Backend.Prelude
 import Vehicle.Compile.Error
-import Vehicle.Compile.LetInsertion (insertLets)
 import Vehicle.Compile.Normalise
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
-import Vehicle.Compile.Queries.FourierMotzkinElimination (fourierMotzkinElimination)
-import Vehicle.Compile.Queries.GaussianElimination
-  ( gaussianElimination,
-    solutionEquality,
-  )
-import Vehicle.Compile.Queries.LNF (convertToLNF)
-import Vehicle.Compile.Queries.LinearExpr
 import Vehicle.Compile.Queries.Variable
-import Vehicle.Compile.Queries.VariableReconstruction
 import Vehicle.Compile.Resource
-import Vehicle.Expr.CoDeBruijn (CoDBExpr, CoDBVar (..))
 import Vehicle.Expr.DeBruijn
-import Vehicle.Verify.Specification
-import Vehicle.Verify.Verifier.Interface
 
---------------------------------------------------------------------------------
--- Removing network applications
---
--- Okay so this is a wild ride. The Marabou query format has special variable
+-- Pairs of (input variable == expression)
+type InputEqualities = [(Int, CheckedExpr)]
+
+-- | Okay so this is a wild ride. The Marabou query format has special variable
 -- names for input and output variables, namely x1 ... xN and y1 ... yM but
 -- otherwise has the standard SMTLib syntax. We refer to these variables as
--- "magic variables".
+-- "network IO variables".
 --
 -- This means that in theory you can only reason about a single network applied
 -- to a single input per property. We get around this restriction by combining
 -- multiple networks, or multiple applications of the same network into a
--- single "meta" network. Concretely this process goes as follows for each
--- property we identify in the program.
+-- single "meta" network.
 --
---
--- Consider the example property
---
---   exists a1 a2 . a1 <= a2 => f (a1 + 1) <= f a2
---
--- Compilation therefore proceeds as follows:
---
--- 1. We perform let-lifting of network applications so that forall application
--- of a network to a unique input sits in its own let binding underneath a
--- universal quantifier.
---
---  exists a1 a2 . let z1 = f (a1 + 1) in let z2 = f a2 in a1 <= a2 => z1 <= z2
---
--- 2. We traverse the expression compiling a list of all network applications,
--- which we refer to as the "meta-network". From this we can generate a list
--- of the network variables we need.
---
---  meta-network: [f,f]
---  network-variables: x0 y0 x1 y1
---
--- 3. We traverse the resulting expression finding all let-bound
--- applications of the network and equate the inputs with the vector
--- of network input variables and subsitute the vector of network output
--- variables into the body of the let expression. For example after
--- processing both let expressions we get:
---
---  exists a1 . exists a2 . a1 <= a2 => y0 <= y1
---
--- with equations:
---
---  1) x0 == a1 + 1
---  2) x1 == a2
---
--- 4. We then use Gaussian/Fourier-Motzkin elimination to solve for the user
--- variables, e.g.
---
---  1) a1 == x0 - 1
---  2) a2 == x1
---
--- 5. We then substitute these solutions through the remaining equations to get:
---
---  x0 - 1 <= x1 => y0 <= y1
-
--- | Converts all user quantified variables to magic I/O variables.
-normUserVariables ::
+-- This function converts all user quantified variables to network I/O
+-- variables, and returns:
+--   - the ordered list of network applications
+--   - the network variables
+--   - equalities relating network input variables to the corresponding expressions
+--   - the final expression.
+replaceNetworkApplications ::
   MonadCompile m =>
-  Identifier ->
-  Verifier ->
   NetworkContext ->
-  [UserVariable] ->
+  BoundDBCtx ->
   CheckedExpr ->
-  m (Query (CLSTProblem NetworkVariable, MetaNetwork, UserVarReconstructionInfo))
-normUserVariables ident verifier networkCtx userVariables expr =
+  m (MetaNetwork, [NetworkVariable], InputEqualities, CheckedExpr)
+replaceNetworkApplications networkCtx boundCtx query = do
   logCompilerPass MinDetail "input/output variable insertion" $ do
-    -- Let-lift all the network applications to avoid duplicates.
-    let dbLevel = DBLevel $ length userVariables
-    liftedNetworkAppExpr <- liftNetworkApplications networkCtx dbLevel expr
+    let initialState = IOVarState mempty mempty mempty 0 0
+    let processApplicationFn = processNetworkApplication networkCtx boundCtx
+
+    (queryExpr, IOVarState {..}) <- runStateT (go query processApplicationFn) initialState
+    let finalMetaNetwork = reverse metaNetwork
+    let finalInputEqualities = concat (reverse inputEqualities)
 
     -- We can now calculate the meta-network and the network variables.
-    let metaNetwork = generateMetaNetwork networkCtx liftedNetworkAppExpr
-    typedMetaNetwork <- getTypedMetaNetwork networkCtx metaNetwork
-    let networkVariables = getNetworkVariables typedMetaNetwork
-    logDebug MinDetail $ "Generated meta-network" <+> pretty metaNetwork <> line
-
-    -- Generate the SMT problem
-    let problemState =
-          ( networkCtx,
-            ident,
-            metaNetwork,
-            verifier,
-            userVariables,
-            networkVariables
-          )
-
-    runReaderT (generateCLSTProblem liftedNetworkAppExpr) problemState
-
-generateCLSTProblem ::
-  MonadSMT m =>
-  CheckedExpr ->
-  m (Query (CLSTProblem NetworkVariable, MetaNetwork, UserVarReconstructionInfo))
-generateCLSTProblem assertionsExpr = do
-  (_, _, metaNetwork, _, userVariables, _) <- ask
-  variables <- getVariables
-
-  -- Substitute through the let-bound applications.
-  (userExprBody, inputEqualityAssertions) <-
-    replaceNetworkApplications (IOVarState 0 0) assertionsExpr
-
-  -- Normalise to remove newly introduced lookups into tensors of
-  -- output variables
-  boundCtx <- getBoundContext
-  normExprBody <-
-    normaliseExpr userExprBody $
-      fullNormalisationOptions
-        { boundContext = boundCtx
-        }
-
-  result <- compileAssertions normExprBody
-
-  flip traverseQuery result $ \userAssertions -> do
-    let assertions = inputEqualityAssertions <> userAssertions
-    let clst = CLSTProblem variables assertions
-
-    (solvedCLST, userVarReconstruction) <-
-      solveForUserVariables (length userVariables) clst
-
-    logCompilerPassOutput $ pretty solvedCLST
-    return (solvedCLST, metaNetwork, userVarReconstruction)
-
-solveForUserVariables ::
-  MonadCompile m =>
-  Int ->
-  CLSTProblem Variable ->
-  m (CLSTProblem NetworkVariable, UserVarReconstructionInfo)
-solveForUserVariables numberOfUserVars (CLSTProblem variables assertions) =
-  logCompilerPass MinDetail "elimination of user variables" $ do
-    let allUserVars = Set.fromList [0 .. numberOfUserVars - 1]
-
-    -- First remove those assertions that don't have any user variables in them.
-    let (withUserVars, withoutUserVars) =
-          partition (hasUserVariables numberOfUserVars) assertions
-
-    -- Then split out the equalities from the inequalities.
-    let (equalitiesWithUserVars, inequalitiesWithUserVars) =
-          partition isEquality withUserVars
-
-    -- Try to solve for user variables using Gaussian elimination.
-    (gaussianSolutions, unusedEqualityExprs) <-
-      gaussianElimination variables (map assertionExpr equalitiesWithUserVars) numberOfUserVars
-    let unusedEqualities = fmap (Assertion Equal) unusedEqualityExprs
-
-    -- Eliminate the solved user variables in the inequalities
-    let gaussianSolutionEqualities = fmap (second solutionEquality) gaussianSolutions
-    let reducedInequalities =
-          flip fmap inequalitiesWithUserVars $ \assertion ->
-            foldl (uncurry . substitute) assertion gaussianSolutionEqualities
-
-    -- Calculate the set of unsolved user variables
-    let varsSolvedByGaussianElim = Set.fromList (fmap fst gaussianSolutions)
-    let varsUnsolvedByGaussianElim = Set.difference allUserVars varsSolvedByGaussianElim
-
-    -- Eliminate the remaining unsolved user vars using Fourier-Motzkin elimination
-    (fourierMotzkinSolutions, fmElimOutputInequalities) <-
-      fourierMotzkinElimination variables varsUnsolvedByGaussianElim reducedInequalities
-
-    -- Calculate the way to reconstruct the user variables
-    let varSolutions =
-          fmap (second FourierMotzkinSolution) fourierMotzkinSolutions
-            <> fmap (second GaussianSolution) gaussianSolutions
-
-    -- Calculate the final set of (user-variable free) assertions
-    let resultingAssertions = withoutUserVars <> unusedEqualities <> fmElimOutputInequalities
-
-    -- Remove all user variables
-    let networkVariables = mapMaybe getNetworkVariable variables
-    let finalAssertions = fmap (removeUserVariables numberOfUserVars) resultingAssertions
-
-    -- Return the problem
-    return (CLSTProblem networkVariables finalAssertions, varSolutions)
-
---------------------------------------------------------------------------------
--- Monad
-
-type MonadSMT m =
-  ( MonadCompile m,
-    MonadReader
-      ( NetworkContext,
-        Identifier,
-        MetaNetwork,
-        Verifier,
-        [UserVariable],
-        [NetworkVariable]
-      )
-      m
-  )
-
-getNetworkDetailsFromCtx :: MonadCompile m => NetworkContext -> Name -> m NetworkType
-getNetworkDetailsFromCtx networkCtx name = do
-  case Map.lookup name networkCtx of
-    Just details -> return details
-    Nothing ->
-      compilerDeveloperError $
-        "Either" <+> squotes (pretty name) <+> "is not a network or it is not in scope"
-
-getTypedMetaNetwork :: MonadCompile m => NetworkContext -> MetaNetwork -> m [(Name, NetworkType)]
-getTypedMetaNetwork ctx = traverse $ \name -> do
-  networkType <- getNetworkDetailsFromCtx ctx name
-  return (name, networkType)
-
-getBoundContext :: MonadSMT m => m BoundDBCtx
-getBoundContext = do
-  (_, _, _, _, userVariables, networkVariables) <- ask
-  let userNames = reverse $ fmap (layoutAsText . pretty) userVariables
-  let networkNames = reverse $ fmap (layoutAsText . pretty) networkVariables
-  return $ fmap Just (userNames <> networkNames)
-
-getNumberOfUserVariables :: MonadSMT m => m Int
-getNumberOfUserVariables = do
-  (_, _, _, _, userVariables, _) <- ask
-  return $ length userVariables
-
-getMetaNetworkType :: MonadSMT m => m [NetworkType]
-getMetaNetworkType = do
-  (networkCtx, _, metaNetwork, _, _, _) <- ask
-  traverse (getNetworkDetailsFromCtx networkCtx) metaNetwork
-
-getNumberOfMagicVariables :: MonadSMT m => m Int
-getNumberOfMagicVariables = sum . fmap networkSize <$> getMetaNetworkType
-
-getTotalNumberOfVariables :: MonadSMT m => m Int
-getTotalNumberOfVariables = do
-  numberOfUserVariables <- getNumberOfUserVariables
-  numberOfMagicVariables <- getNumberOfMagicVariables
-  return $ numberOfUserVariables + numberOfMagicVariables
-
-getExprSize :: MonadSMT m => m Int
-getExprSize =
-  -- Add one more for the constant term.
-  (1 +) <$> getTotalNumberOfVariables
-
-getVariables :: MonadSMT m => m [Variable]
-getVariables = do
-  (_, _, _, _, userVariables, networkVariables) <- ask
-  return $ fmap UserVar userVariables <> fmap NetworkVar networkVariables
-
-getExprConstantIndex :: MonadSMT m => m Int
-getExprConstantIndex =
-  -- The contant in the linear expression is stored in the last index.
-  getTotalNumberOfVariables
-
---------------------------------------------------------------------------------
--- Algorithm
---------------------------------------------------------------------------------
--- Remove user quantifiers
-
--- | We lift all network applications regardless if they are duplicated or not to
--- ensure that they are at the top-level underneath a quantifier and hence have
--- a body with the type `Bool`.
-liftNetworkApplications :: MonadCompile m => NetworkContext -> DBLevel -> CheckedExpr -> m CheckedExpr
-liftNetworkApplications networks = insertLets isNetworkApplication False
+    networkVariables <- getNetworkVariables networkCtx finalMetaNetwork
+    logDebug MinDetail $ "Generated meta-network" <+> pretty finalMetaNetwork <> line
+    return (finalMetaNetwork, networkVariables, finalInputEqualities, queryExpr)
   where
-    isNetworkApplication :: CoDBExpr -> Int -> Bool
-    isNetworkApplication (App _ (Var _ (CoDBFree ident)) _, _) _ =
-      Map.member (nameOf ident) networks
-    isNetworkApplication _ _ = False
+    go ::
+      MonadCompile m =>
+      CheckedExpr ->
+      (Identifier -> CheckedExpr -> m CheckedExpr) ->
+      m CheckedExpr
+    go expr k = case expr of
+      Universe {} -> unexpectedTypeInExprError currentPass "Universe"
+      Pi {} -> unexpectedTypeInExprError currentPass "Pi"
+      Hole {} -> resolutionError currentPass "Hole"
+      Meta {} -> resolutionError currentPass "Meta"
+      Ann {} -> normalisationError currentPass "Ann"
+      Lam {} -> normalisationError currentPass "Lam"
+      Let {} -> normalisationError currentPass "Let"
+      Var {} -> return expr
+      Literal {} -> return expr
+      Builtin {} -> return expr
+      LVec p xs -> LVec p <$> traverse (flip go k) xs
+      App p fun args -> do
+        fun' <- go fun k
+        args' <- traverse (traverse (flip go k)) args
+        case (fun', args') of
+          (FreeVar _ network, [ExplicitArg _ arg]) -> k network arg
+          (FreeVar _ network, _) ->
+            compilerDeveloperError $
+              "Network" <+> quotePretty network <+> "seems to have multiple arguments"
+          _ -> do
+            runSilentLoggerT $
+              normaliseExpr (normApp p fun' args') $
+                fullNormalisationOptions
+                  { boundContext = boundCtx
+                  }
 
---------------------------------------------------------------------------------
--- Generate the meta-network
-
--- | As we've normalised out all function applications and dataset declarations,
---  the only free names left should be network applications.
-generateMetaNetwork :: NetworkContext -> CheckedExpr -> MetaNetwork
-generateMetaNetwork ctx e =
-  let freeNames = fmap nameOf (freeNamesIn e)
-   in filter (`Map.member` ctx) freeNames
-
---------------------------------------------------------------------------------
--- Steps 3 & 4: replace network applications
-
--- | The state propagated downwards during the pass replacing neural network
---  applications with magic variables.
+-- | The current state of the input/output network variables.
 data IOVarState = IOVarState
-  { magicInputVarCount :: Int,
+  { applicationCache :: HashMap (Identifier, CheckedExpr) CheckedExpr,
+    metaNetwork :: MetaNetwork,
+    inputEqualities :: [InputEqualities],
+    magicInputVarCount :: Int,
     magicOutputVarCount :: Int
   }
 
-pattern NetworkApp :: Provenance -> Identifier -> CheckedExpr -> CheckedExpr
-pattern NetworkApp p ident inputs <- App p (Var _ (Free ident)) [ExplicitArg _ inputs]
-
--- Takes in the expression to process and returns a function
--- from the current binding depth to the altered expression.
-replaceNetworkApplications ::
-  MonadSMT m =>
-  IOVarState ->
+processNetworkApplication ::
+  (MonadCompile m, MonadState IOVarState m) =>
+  NetworkContext ->
+  BoundDBCtx ->
+  Identifier ->
   CheckedExpr ->
-  m (CheckedExpr, [Assertion])
-replaceNetworkApplications IOVarState {..} (Let _ (NetworkApp p ident inputExprs) _binder body) = do
-  logDebug MaxDetail $ "Replacing application:" <+> pretty ident <+> prettyVerbose inputExprs
-  incrCallDepth
-  (networkCtx, _, _, _, _, _) <- ask
+  m CheckedExpr
+processNetworkApplication networkCtx boundCtx ident inputVector = do
+  let sectionLog = "Replacing application:" <+> pretty ident <+> prettyVerbose inputVector
+  logCompilerSection MaxDetail sectionLog $ do
+    IOVarState {..} <- get
+    let p = mempty
+    case HashMap.lookup (ident, inputVector) applicationCache of
+      Just result -> return result
+      Nothing -> do
+        NetworkType inputs outputs <- getNetworkDetailsFromCtx networkCtx (nameOf ident)
+        let inputSize = tensorSize inputs
+        let outputSize = tensorSize outputs
+        let outputType = baseType outputs
 
-  NetworkType inputs outputs <- getNetworkDetailsFromCtx networkCtx (nameOf ident)
-  let inputSize = tensorSize inputs
-  let outputSize = tensorSize outputs
-  let outputType = baseType outputs
+        let numberOfUserVariables = length boundCtx
+        let inputStartingDBIndex = numberOfUserVariables + magicInputVarCount + magicOutputVarCount
+        let outputStartingDBIndex = inputStartingDBIndex + inputSize
+        let outputEndingDBIndex = outputStartingDBIndex + outputSize
+        let inputVarIndices = [inputStartingDBIndex .. outputStartingDBIndex - 1]
+        let outputVarIndices = [outputStartingDBIndex .. outputEndingDBIndex - 1]
 
-  numberOfUserVariables <- getNumberOfUserVariables
-  let inputStartingDBIndex = numberOfUserVariables + magicInputVarCount + magicOutputVarCount
-  let outputStartingDBIndex = inputStartingDBIndex + inputSize
-  let outputEndingDBIndex = outputStartingDBIndex + outputSize
-  let inputVarIndices = [inputStartingDBIndex .. outputStartingDBIndex - 1]
-  let outputVarIndices = [outputStartingDBIndex .. outputEndingDBIndex - 1]
+        logDebug MaxDetail $ "starting index:            " <+> pretty inputStartingDBIndex
+        logDebug MaxDetail $ "number of input variables: " <+> pretty inputSize
+        logDebug MaxDetail $ "number of output variables:" <+> pretty outputSize
+        logDebug MaxDetail $ "input indices:             " <+> pretty inputVarIndices
+        logDebug MaxDetail $ "output indices:            " <+> pretty outputVarIndices
 
-  logDebug MaxDetail $ "starting index:            " <+> pretty inputStartingDBIndex
-  logDebug MaxDetail $ "number of input variables: " <+> pretty inputSize
-  logDebug MaxDetail $ "number of output variables:" <+> pretty outputSize
-  logDebug MaxDetail $ "input indices:             " <+> pretty inputVarIndices
-  logDebug MaxDetail $ "output indices:            " <+> pretty outputVarIndices
+        inputVarEqualities <- createInputVarEqualities (dimensions inputs) inputVarIndices inputVector
 
-  inputVarEqualities <- createInputVarEqualities (dimensions inputs) inputVarIndices inputExprs
+        outputVarsExpr <- mkMagicVariableSeq p outputType (dimensions outputs) outputVarIndices
 
-  whenM (loggingLevelAtLeast MidDetail) $ do
-    variableNames <- getVariables
-    logDebug MidDetail $
-      "input variable equalities:"
-        <> line
-        <> pretty (CLSTProblem variableNames inputVarEqualities)
-        <> line
+        put $
+          IOVarState
+            { applicationCache = HashMap.insert (ident, inputVector) outputVarsExpr applicationCache,
+              inputEqualities = inputVarEqualities : inputEqualities,
+              metaNetwork = identifierName ident : metaNetwork,
+              magicInputVarCount = magicInputVarCount + inputSize,
+              magicOutputVarCount = magicInputVarCount + outputSize
+            }
 
-  outputVarsExpr <- mkMagicVariableSeq p outputType (dimensions outputs) outputVarIndices
-  let newBody = outputVarsExpr `substDBInto` body
+        return outputVarsExpr
 
-  (result, equalities) <-
-    flip replaceNetworkApplications newBody $
-      IOVarState
-        { magicInputVarCount = magicInputVarCount + inputSize,
-          magicOutputVarCount = magicInputVarCount + outputSize
-        }
-
-  decrCallDepth
-  return (result, inputVarEqualities <> equalities)
-replaceNetworkApplications _ e = return (e, [])
-
-createInputVarEqualities :: MonadSMT m => [Int] -> [Int] -> CheckedExpr -> m [Assertion]
+createInputVarEqualities :: MonadCompile m => [Int] -> [Int] -> CheckedExpr -> m InputEqualities
 createInputVarEqualities (_dim : dims) inputVarIndices (VecLiteral _ _ xs) = do
   let inputVarIndicesChunks = chunksOf (product dims) inputVarIndices
   concat <$> zipWithM (createInputVarEqualities dims) inputVarIndicesChunks xs
-createInputVarEqualities [] [i] e = do
-  -- Create linear expression equating the magic variable `x_i`
-  -- with the expression `e` in the relevant point = xs_i`
-  exprSize <- getExprSize
-  let lhs = linearExprFromMap exprSize (Map.singleton i 1)
-  rhs <- compileLinearExpr e
-  return [constructAssertion (lhs, Equal, rhs)]
+createInputVarEqualities [] [i] e = return [(i, e)]
 createInputVarEqualities dims d xs =
   compilerDeveloperError $
     "apparently miscalculated number of magic input variables:"
@@ -422,105 +191,14 @@ mkMagicVariableSeq p tElem = go
           <+> pretty dims
           <+> pretty outputVarIndices
 
-compileAssertions :: MonadSMT m => CheckedExpr -> m (Query [Assertion])
-compileAssertions = \case
-  BoolLiteral _ b -> return $ Trivial b
-  e -> NonTrivial <$> go e
-  where
-    go :: MonadSMT m => CheckedExpr -> m [Assertion]
-    go expr = case expr of
-      Universe {} -> unexpectedTypeInExprError currentPass "Universe"
-      Pi {} -> unexpectedTypeInExprError currentPass "Pi"
-      Hole {} -> resolutionError currentPass "Hole"
-      Meta {} -> resolutionError currentPass "Meta"
-      Ann {} -> normalisationError currentPass "Ann"
-      Lam {} -> normalisationError currentPass "Lam"
-      Let {} -> normalisationError currentPass "Let"
-      LVec {} -> normalisationError currentPass "LVec"
-      Builtin {} -> normalisationError currentPass "LVec"
-      Var {} -> caseError currentPass "Var" ["OrderOp", "Eq"]
-      Literal _ l -> case l of
-        LBool _ -> normalisationError currentPass "LBool"
-        _ -> caseError currentPass "Literal" ["AndExpr"]
-      AndExpr _ [ExplicitArg _ e1, ExplicitArg _ e2] -> do
-        as1 <- go e1
-        as2 <- go e2
-        return (as1 <> as2)
-      OrderExpr _ OrderRat ord [ExplicitArg _ e1, ExplicitArg _ e2] -> do
-        let (rel, lhs, rhs) = case ord of
-              Lt -> (LessThan, e1, e2)
-              Le -> (LessThanOrEqualTo, e1, e2)
-              Gt -> (LessThan, e2, e1)
-              Ge -> (LessThanOrEqualTo, e2, e1)
-        assertion <- compileAssertion rel lhs rhs
-        return [assertion]
-      EqualityExpr p EqRat eq [ExplicitArg _ e1, ExplicitArg _ e2] -> case eq of
-        Neq -> do
-          (_, ident, _, _, _, _) <- ask
-          throwError $ UnsupportedInequality MarabouBackend ident p
-        Eq -> do
-          assertion <- compileAssertion Equal e1 e2
-          return [assertion]
-      App {} -> unexpectedExprError currentPass (prettyVerbose expr)
-
-compileAssertion ::
-  MonadSMT m =>
-  Relation ->
-  CheckedExpr ->
-  CheckedExpr ->
-  m Assertion
-compileAssertion rel lhs rhs = do
-  lhsLinExpr <- compileLinearExpr lhs
-  rhsLinExpr <- compileLinearExpr rhs
-  return $ constructAssertion (lhsLinExpr, rel, rhsLinExpr)
-
-compileLinearExpr :: MonadSMT m => CheckedExpr -> m LinearExpr
-compileLinearExpr expr = do
-  lnfExpr <- convertToLNF expr
-  linearExpr <- go lnfExpr
-  exprSize <- getExprSize
-  return $ linearExprFromMap exprSize linearExpr
-  where
-    singletonVar :: MonadSMT m => DBIndexVar -> Coefficient -> m (Map Int Coefficient)
-    singletonVar Free {} _ = normalisationError currentPass "FreeVar"
-    singletonVar (Bound (DBIndex v)) c = do
-      numberOfUserVariables <- getNumberOfUserVariables
-      let i = if v < numberOfUserVariables then numberOfUserVariables - v - 1 else v
-      return $ Map.singleton i c
-
-    go :: MonadSMT m => CheckedExpr -> m (Map Int Coefficient)
-    go e = case e of
-      Var _ v ->
-        singletonVar v 1
-      NegExpr _ NegRat [ExplicitArg _ (Var _ v)] ->
-        singletonVar v (-1)
-      RatLiteral _ l -> do
-        constIndex <- getExprConstantIndex
-        singletonVar (Bound (DBIndex constIndex)) (fromRational l)
-      AddExpr _ AddRat [ExplicitArg _ e1, ExplicitArg _ e2] -> do
-        Map.unionWith (+) <$> go e1 <*> go e2
-      MulExpr _ MulRat [ExplicitArg _ e1, ExplicitArg _ e2] ->
-        case (e1, e2) of
-          (RatLiteral _ l, Var _ v) -> singletonVar v (fromRational l)
-          (Var _ v, RatLiteral _ l) -> singletonVar v (fromRational l)
-          _ -> do
-            (_, _ident, _, _, _, _) <- ask
-            _ctx <- getBoundContext
-            compilerDeveloperError $
-              "Unexpected non-linear constraint that should have been caught by the"
-                <+> "linearity analysis during type-checking."
-      ex -> unexpectedExprError currentPass $ prettyVerbose ex
-
---------------------------------------------------------------------------------
--- Step 6: quantification over magic variables
-
 type Applications = Map Name Int
 
-getNetworkVariables :: [(Name, NetworkType)] -> [NetworkVariable]
-getNetworkVariables metaNetworkDetails = do
+getNetworkVariables :: MonadCompile m => NetworkContext -> MetaNetwork -> m [NetworkVariable]
+getNetworkVariables networkCtx metaNetwork = do
+  metaNetworkDetails <- getTypedMetaNetwork networkCtx metaNetwork
   let applicationCounts = countNetworkApplications (fmap fst metaNetworkDetails)
   let (_, result) = foldr (forNetwork applicationCounts) (mempty, mempty) metaNetworkDetails
-  result
+  return result
   where
     forNetwork ::
       Applications ->
@@ -540,6 +218,19 @@ getNetworkVariables metaNetworkDetails = do
       let outputNames = [NetworkVariable networkName application Output i | i <- outputIndices]
 
       (newApplicationsSoFar, result <> inputNames <> outputNames)
+
+getNetworkDetailsFromCtx :: MonadCompile m => NetworkContext -> Name -> m NetworkType
+getNetworkDetailsFromCtx networkCtx name = do
+  case Map.lookup name networkCtx of
+    Just details -> return details
+    Nothing ->
+      compilerDeveloperError $
+        "Either" <+> squotes (pretty name) <+> "is not a network or it is not in scope"
+
+getTypedMetaNetwork :: MonadCompile m => NetworkContext -> MetaNetwork -> m [(Name, NetworkType)]
+getTypedMetaNetwork ctx = traverse $ \name -> do
+  networkType <- getNetworkDetailsFromCtx ctx name
+  return (name, networkType)
 
 countNetworkApplications :: MetaNetwork -> Applications
 countNetworkApplications = foldr (\n m -> Map.insertWith (+) n 1 m) mempty

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -123,6 +123,7 @@ library
     Vehicle.Compile.Queries.GaussianElimination
     Vehicle.Compile.Queries.IfElimination
     Vehicle.Compile.Queries.LinearExpr
+    Vehicle.Compile.Queries.LinearSatisfactionProblem
     Vehicle.Compile.Queries.LNF
     Vehicle.Compile.Queries.NetworkElimination
     Vehicle.Compile.Queries.QuantifierLifting


### PR DESCRIPTION
This should open the door to entirely eliminating all CoDeBruijn code but will leave that for a subsequent PR.