### PR TITLE
Make the type-checker generic with respect to a typing subsystem

### DIFF
--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -28,6 +28,7 @@ import Vehicle.Compile.Normalise (nfTypeClassOp)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type (getUnnormalised)
+import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Libraries.StandardLibrary (pattern TensorIdent)
 import Vehicle.Syntax.Sugar
 
@@ -40,7 +41,7 @@ data AgdaOptions = AgdaOptions
     moduleName :: Maybe String
   }
 
-compileProgToAgda :: MonadCompile m => TypedProg -> AgdaOptions -> m (Doc a)
+compileProgToAgda :: MonadCompile m => StandardTypedProg -> AgdaOptions -> m (Doc a)
 compileProgToAgda prog options = logCompilerPass MinDetail currentPhase $
   flip runReaderT (options, BoolLevel) $ do
     unnormalisedProg <- traverse getUnnormalised prog
@@ -76,7 +77,7 @@ compileProgToAgda prog options = logCompilerPass MinDetail currentPhase $
 logEntry :: MonadAgdaCompile m => OutputExpr -> m ()
 logEntry e = do
   incrCallDepth
-  logDebug MaxDetail $ "compile-entry" <+> prettyVerbose e
+  logDebug MaxDetail $ "compile-entry" <+> prettyExternal e
 
 logExit :: MonadAgdaCompile m => Code -> m ()
 logExit e = do
@@ -559,7 +560,7 @@ compileBuiltin op allArgs = case normAppList mempty (Builtin mempty op) allArgs 
     let e = normAppList mempty (Builtin mempty op) allArgs
     compilerDeveloperError $
       "unexpected application of builtin found during compilation to Agda:"
-        <+> squotes (prettyVerbose e)
+        <+> squotes (prettyExternal e)
         <+> parens (pretty $ provenanceOf e)
 
 compileTypeClass :: MonadAgdaCompile m => Code -> OutputExpr -> m Code
@@ -861,7 +862,7 @@ unexpectedTypeError actualType expectedTypes =
       <+> "Was expecting one of"
       <+> list expectedTypes
       <+> "but found"
-      <+> prettyVerbose actualType
+      <+> prettyExternal actualType
       <+> "at"
       <+> pretty (provenanceOf actualType) <> "."
 

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -8,7 +8,8 @@ import Prettyprinter (list)
 import Vehicle.Backend.Prelude
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Constraint
-import Vehicle.Expr.Normalised
+import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Syntax.Parse (ParseError)
 import Vehicle.Verify.Core (VerifierIdentifier)
 
@@ -44,65 +45,65 @@ data CompileError
   | FunTypeMismatch
       Provenance -- The location of the mismatch.
       BoundDBCtx -- The context at the time of the failure
-      CheckedExpr -- The function being typed
-      CheckedType -- The possible inferred types.
-      CheckedType -- The expected type.
-  | UnsolvedConstraints (NonEmpty (WithContext Constraint))
-  | UnsolvedMetas (NonEmpty (MetaID, Provenance))
+      TypeCheckedExpr -- The function being typed
+      TypeCheckedType -- The possible inferred types.
+      TypeCheckedType -- The expected type.
   | MissingExplicitArg
       BoundDBCtx -- The context at the time of the failure
-      UncheckedArg -- The non-explicit argument
-      CheckedType -- Expected type of the argument
-  | FailedUnificationConstraints (NonEmpty (WithContext UnificationConstraint))
-  | FailedEqConstraint ConstraintContext BasicNormType BasicNormType EqualityOp
-  | FailedOrdConstraint ConstraintContext BasicNormType BasicNormType OrderOp
-  | FailedBuiltinConstraintArgument ConstraintContext Builtin BasicNormType [UnAnnDoc] Int Int
-  | FailedBuiltinConstraintResult ConstraintContext Builtin BasicNormType [UnAnnDoc]
-  | FailedNotConstraint ConstraintContext BasicNormType
-  | FailedBoolOp2Constraint ConstraintContext BasicNormType BasicNormType Builtin
-  | FailedQuantifierConstraintDomain ConstraintContext BasicNormType Quantifier
-  | FailedQuantifierConstraintBody ConstraintContext BasicNormType Quantifier
-  | FailedArithOp2Constraint ConstraintContext BasicNormType BasicNormType Builtin
-  | FailedFoldConstraintContainer ConstraintContext BasicNormType
-  | FailedQuantInConstraintContainer ConstraintContext BasicNormType Quantifier
-  | FailedNatLitConstraint ConstraintContext Int BasicNormType
-  | FailedNatLitConstraintTooBig ConstraintContext Int Int
-  | FailedNatLitConstraintUnknown ConstraintContext Int BasicNormType
-  | FailedIntLitConstraint ConstraintContext BasicNormType
-  | FailedRatLitConstraint ConstraintContext BasicNormType
-  | FailedConLitConstraint ConstraintContext BasicNormType
-  | FailedInstanceConstraint ConstraintContext InstanceGoal
-  | QuantifiedIfCondition ConstraintContext
-  | NonLinearIfCondition ConstraintContext
+      (UncheckedArg Builtin) -- The non-explicit argument
+      TypeCheckedType -- Expected type of the argument
+  | UnsolvedConstraints (NonEmpty (WithContext (Constraint Builtin)))
+  | UnsolvedMetas (NonEmpty (MetaID, Provenance))
+  | FailedUnificationConstraints (NonEmpty (WithContext (UnificationConstraint Builtin)))
+  | FailedEqConstraint StandardConstraintContext StandardNormType StandardNormType EqualityOp
+  | FailedOrdConstraint StandardConstraintContext StandardNormType StandardNormType OrderOp
+  | FailedBuiltinConstraintArgument StandardConstraintContext Builtin StandardNormType [UnAnnDoc] Int Int
+  | FailedBuiltinConstraintResult StandardConstraintContext Builtin StandardNormType [UnAnnDoc]
+  | FailedNotConstraint StandardConstraintContext StandardNormType
+  | FailedBoolOp2Constraint StandardConstraintContext StandardNormType StandardNormType Builtin
+  | FailedQuantifierConstraintDomain StandardConstraintContext StandardNormType Quantifier
+  | FailedQuantifierConstraintBody StandardConstraintContext StandardNormType Quantifier
+  | FailedArithOp2Constraint StandardConstraintContext StandardNormType StandardNormType Builtin
+  | FailedFoldConstraintContainer StandardConstraintContext StandardNormType
+  | FailedQuantInConstraintContainer StandardConstraintContext StandardNormType Quantifier
+  | FailedNatLitConstraint StandardConstraintContext Int StandardNormType
+  | FailedNatLitConstraintTooBig StandardConstraintContext Int Int
+  | FailedNatLitConstraintUnknown StandardConstraintContext Int StandardNormType
+  | FailedIntLitConstraint StandardConstraintContext StandardNormType
+  | FailedRatLitConstraint StandardConstraintContext StandardNormType
+  | FailedConLitConstraint StandardConstraintContext StandardNormType
+  | FailedInstanceConstraint StandardConstraintContext InstanceGoal
+  | QuantifiedIfCondition StandardConstraintContext
+  | NonLinearIfCondition StandardConstraintContext
   | -- Resource typing errors
     ResourceNotProvided DeclProvenance Resource
   | ResourceIOError DeclProvenance Resource IOException
   | UnsupportedResourceFormat DeclProvenance Resource String
   | UnableToParseResource DeclProvenance Resource String
-  | NetworkTypeIsNotAFunction DeclProvenance GluedType
-  | NetworkTypeIsNotOverTensors DeclProvenance GluedType BasicNormType InputOrOutput
-  | NetworkTypeHasNonExplicitArguments DeclProvenance GluedType BasicNormBinder
-  | NetworkTypeHasVariableSizeTensor DeclProvenance GluedType BasicNormType InputOrOutput
-  | NetworkTypeHasImplicitSizeTensor DeclProvenance GluedType Identifier InputOrOutput
-  | NetworkTypeHasUnsupportedElementType DeclProvenance GluedType BasicNormType InputOrOutput
-  | DatasetTypeUnsupportedContainer DeclProvenance GluedType
-  | DatasetTypeUnsupportedElement DeclProvenance GluedType BasicNormType
-  | DatasetVariableSizeTensor DeclProvenance GluedType BasicNormType
+  | NetworkTypeIsNotAFunction DeclProvenance StandardGluedType
+  | NetworkTypeIsNotOverTensors DeclProvenance StandardGluedType StandardNormType InputOrOutput
+  | NetworkTypeHasNonExplicitArguments DeclProvenance StandardGluedType StandardNormBinder
+  | NetworkTypeHasVariableSizeTensor DeclProvenance StandardGluedType StandardNormType InputOrOutput
+  | NetworkTypeHasImplicitSizeTensor DeclProvenance StandardGluedType Identifier InputOrOutput
+  | NetworkTypeHasUnsupportedElementType DeclProvenance StandardGluedType StandardNormType InputOrOutput
+  | DatasetTypeUnsupportedContainer DeclProvenance StandardGluedType
+  | DatasetTypeUnsupportedElement DeclProvenance StandardGluedType StandardNormType
+  | DatasetVariableSizeTensor DeclProvenance StandardGluedType StandardNormType
   | DatasetDimensionSizeMismatch DeclProvenance FilePath Int Int [Int] [Int]
-  | DatasetDimensionsMismatch DeclProvenance FilePath GluedExpr [Int]
-  | DatasetTypeMismatch DeclProvenance FilePath GluedType BasicNormType BasicNormType
+  | DatasetDimensionsMismatch DeclProvenance FilePath StandardGluedExpr [Int]
+  | DatasetTypeMismatch DeclProvenance FilePath StandardGluedType StandardNormType StandardNormType
   | DatasetInvalidIndex DeclProvenance FilePath Int Int
   | DatasetInvalidNat DeclProvenance FilePath Int
-  | ParameterTypeUnsupported DeclProvenance GluedType
-  | ParameterTypeVariableSizeIndex DeclProvenance GluedType
+  | ParameterTypeUnsupported DeclProvenance StandardGluedType
+  | ParameterTypeVariableSizeIndex DeclProvenance StandardGluedType
   | ParameterTypeInferableParameterIndex DeclProvenance Identifier
   | ParameterValueUnparsable DeclProvenance String BuiltinConstructor
   | ParameterValueInvalidIndex DeclProvenance Int Int
   | ParameterValueInvalidNat DeclProvenance Int
-  | InferableParameterTypeUnsupported DeclProvenance GluedType
+  | InferableParameterTypeUnsupported DeclProvenance StandardGluedType
   | InferableParameterContradictory Identifier (DeclProvenance, Resource, Int) (DeclProvenance, Resource, Int)
   | InferableParameterUninferrable DeclProvenance
-  | PropertyTypeUnsupported DeclProvenance GluedType
+  | PropertyTypeUnsupported DeclProvenance StandardGluedType
   | -- Backend errors
     NoPropertiesFound
   | UnsupportedResource Backend Identifier Provenance Resource
@@ -110,10 +111,10 @@ data CompileError
   | UnsupportedPolymorphicEquality Backend Provenance Name
   | UnsupportedNonMagicVariable Backend Provenance Name
   | NoNetworkUsedInProperty Backend Provenance Identifier
-  | UnsupportedVariableType VerifierIdentifier Identifier Provenance Name BasicNormType BasicNormType [Builtin]
+  | UnsupportedVariableType VerifierIdentifier Identifier Provenance Name StandardNormType StandardNormType [Builtin]
   | UnsupportedAlternatingQuantifiers Backend DeclProvenance Quantifier Provenance PolarityProvenance
   | UnsupportedNonLinearConstraint Backend DeclProvenance Provenance LinearityProvenance LinearityProvenance
-  | UnsupportedNegatedOperation DifferentiableLogic DeclProvenance Provenance CheckedExpr
+  | UnsupportedNegatedOperation DifferentiableLogic DeclProvenance Provenance TypeCheckedExpr
   deriving (Show)
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -16,6 +16,8 @@ import Vehicle.Compile.Normalise.Quote (unnormalise)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Constraint
+import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.AlphaEquivalence (AlphaEquivalence (..))
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (pattern TensorIdent)
@@ -354,7 +356,7 @@ instance MeaningfulError CompileError where
             fix = Nothing
           }
       where
-        getMessage :: BasicNormExpr -> Doc a
+        getMessage :: StandardNormExpr -> Doc a
         getMessage = \case
           VConstructor (TypeClass tc) args -> case (tc, args) of
             (HasMap, _) ->
@@ -373,7 +375,7 @@ instance MeaningfulError CompileError where
             _ -> developerError $ "Instance search error messages not complete for" <+> quotePretty tc
           e -> developerError $ "Invalid instance in error message" <+> quotePretty (show e)
 
-        failedOp2Message :: BoundDBCtx -> TypeClassOp -> BasicNormExpr -> BasicNormExpr -> BasicNormExpr -> Doc a
+        failedOp2Message :: BoundDBCtx -> TypeClassOp -> StandardNormExpr -> StandardNormExpr -> StandardNormExpr -> Doc a
         failedOp2Message boundCtx op t1 t2 t3 =
           "cannot apply"
             <+> squotes (pretty op)
@@ -859,7 +861,7 @@ instance MeaningfulError CompileError where
             fix = Just $ datasetDimensionsFix "dimensions" ident file
           }
       where
-        dimensionsOf :: BasicNormType -> Int
+        dimensionsOf :: StandardNormType -> Int
         dimensionsOf = \case
           VListType t -> 1 + dimensionsOf t
           VVectorType t _ -> 1 + dimensionsOf t
@@ -1301,7 +1303,7 @@ datasetDimensionsFix feature ident file =
     <+> quotePretty (takeFileName file)
     <+> "is in the format you were expecting."
 
-unsupportedAnnotationTypeDescription :: Annotation -> Identifier -> GluedType -> Doc a
+unsupportedAnnotationTypeDescription :: Annotation -> Identifier -> StandardGluedType -> Doc a
 unsupportedAnnotationTypeDescription annotation ident resourceType =
   "The type of"
     <+> pretty annotation
@@ -1323,7 +1325,7 @@ unsupportedAnnotationTypeDescription annotation ident resourceType =
     unreducedResourceType = unnormalised resourceType
     reducedResourceType = unnormalise 0 (normalised resourceType)
 
-unsupportedResourceTypeDescription :: Resource -> Identifier -> GluedType -> Doc a
+unsupportedResourceTypeDescription :: Resource -> Identifier -> StandardGluedType -> Doc a
 unsupportedResourceTypeDescription resource =
   unsupportedAnnotationTypeDescription (ResourceAnnotation resource)
 
@@ -1446,7 +1448,7 @@ prettyOrdinal object argNo argTotal
       9 -> "ninth"
       _ -> developerError "Cannot convert ordinal"
 
-prettyTypeClassConstraintOriginExpr :: ConstraintContext -> CheckedExpr -> [UncheckedArg] -> Doc a
+prettyTypeClassConstraintOriginExpr :: StandardConstraintContext -> TypeCheckedExpr -> [UncheckedArg Builtin] -> Doc a
 prettyTypeClassConstraintOriginExpr ctx fun args = case fun of
   Builtin _ b
     -- Need to check whether the function was introduced as part of desugaring
@@ -1460,7 +1462,7 @@ prettyTypeClassConstraintOriginExpr ctx fun args = case fun of
       isDesugared _ = False
   _ -> prettyFriendly $ WithContext fun (boundContextOf ctx)
 
-prettyUnificationConstraintOriginExpr :: ConstraintContext -> CheckedExpr -> Doc a
+prettyUnificationConstraintOriginExpr :: StandardConstraintContext -> TypeCheckedExpr -> Doc a
 prettyUnificationConstraintOriginExpr ctx = \case
   Builtin _ b -> pretty b
   expr -> prettyFriendly $ WithContext expr (boundContextOf ctx)

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Core.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Core.hs
@@ -7,6 +7,7 @@ import Data.Map qualified as Map
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Resource
+import Vehicle.Compile.Type.Subsystem.Standard.Core
 
 --------------------------------------------------------------------------------
 -- The resource monad
@@ -29,9 +30,9 @@ type InferableParameterEntry = (DeclProvenance, Resource, Int)
 
 type InferableParameterContext = Map Name (Maybe InferableParameterEntry)
 
-type ParameterContext = Map Name TypedExpr
+type ParameterContext = Map Name StandardTypedExpr
 
-type DatasetContext = Map Name TypedExpr
+type DatasetContext = Map Name StandardTypedExpr
 
 data ResourceContext = ResourceContext
   { inferableParameterContext :: InferableParameterContext,
@@ -57,14 +58,14 @@ addPossibleInferableParameterSolution ident entry ResourceContext {..} =
       ..
     }
 
-addParameter :: Identifier -> TypedExpr -> ResourceContext -> ResourceContext
+addParameter :: Identifier -> StandardTypedExpr -> ResourceContext -> ResourceContext
 addParameter ident value ResourceContext {..} =
   ResourceContext
     { parameterContext = Map.insert (nameOf ident) value parameterContext,
       ..
     }
 
-addDataset :: Identifier -> TypedExpr -> ResourceContext -> ResourceContext
+addDataset :: Identifier -> StandardTypedExpr -> ResourceContext -> ResourceContext
 addDataset ident value ResourceContext {..} =
   ResourceContext
     { datasetContext = Map.insert (nameOf ident) value datasetContext,

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Dataset.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Dataset.hs
@@ -10,7 +10,7 @@ import Vehicle.Compile.Error
 import Vehicle.Compile.ExpandResources.Core
 import Vehicle.Compile.ExpandResources.Dataset.IDX (readIDX)
 import Vehicle.Compile.Prelude
-import Vehicle.Expr.Normalised
+import Vehicle.Compile.Type.Subsystem.Standard
 
 --------------------------------------------------------------------------------
 -- Dataset parsing
@@ -19,8 +19,8 @@ parseDataset ::
   (MonadIO m, MonadExpandResources m) =>
   DatasetLocations ->
   DeclProvenance ->
-  GluedType ->
-  m BasicNormExpr
+  StandardGluedType ->
+  m StandardNormExpr
 parseDataset datasetLocations decl@(ident, _) expectedType =
   case Map.lookup (nameOf ident) datasetLocations of
     Just file -> do

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Dataset/IDX.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Dataset/IDX.hs
@@ -22,6 +22,7 @@ import Vehicle.Compile.Error
 import Vehicle.Compile.ExpandResources.Core
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
+import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.Normalised
 
 -- | Reads the IDX dataset from the provided file, checking that the user type
@@ -30,8 +31,8 @@ readIDX ::
   (MonadExpandResources m, MonadIO m) =>
   FilePath ->
   DeclProvenance ->
-  GluedType ->
-  m BasicNormExpr
+  StandardGluedType ->
+  m StandardNormExpr
 readIDX file decl expectedType = do
   contents <- readIDXFile decl file
   case contents of
@@ -70,7 +71,7 @@ parseIDX ::
   (MonadExpandResources m, Vector.Unbox a) =>
   ParseContext m a ->
   Vector a ->
-  m BasicNormExpr
+  m StandardNormExpr
 parseIDX ctx@(_, _, expectedDatasetType, actualDatasetDims, _) elems = do
   parseContainer ctx True actualDatasetDims elems (normalised expectedDatasetType)
 
@@ -80,8 +81,8 @@ parseContainer ::
   Bool ->
   [Int] ->
   Vector a ->
-  BasicNormType ->
-  m BasicNormExpr
+  StandardNormType ->
+  m StandardNormExpr
 parseContainer ctx topLevel actualDims elems expectedType = case expectedType of
   VListType expectedElemType -> parseList ctx expectedElemType actualDims elems
   VVectorType expectedElemType expectedDim -> parseVector ctx actualDims elems expectedElemType expectedDim
@@ -95,9 +96,9 @@ parseVector ::
   ParseContext m a ->
   [Int] ->
   Vector a ->
-  BasicNormType ->
-  BasicNormExpr ->
-  m BasicNormExpr
+  StandardNormType ->
+  StandardNormExpr ->
+  m StandardNormExpr
 parseVector ctx [] _ _ _ = dimensionMismatchError ctx
 parseVector ctx@(decl, file, _, allDims, _) (actualDim : actualDims) elems expectedElemType expectedDim = do
   currentDim <- case expectedDim of
@@ -126,10 +127,10 @@ parseVector ctx@(decl, file, _, allDims, _) (actualDim : actualDims) elems expec
 parseList ::
   (MonadExpandResources m, Vector.Unbox a) =>
   ParseContext m a ->
-  BasicNormType ->
+  StandardNormType ->
   [Int] ->
   Vector a ->
-  m BasicNormExpr
+  m StandardNormExpr
 parseList ctx expectedElemType actualDims actualElems =
   case actualDims of
     [] -> dimensionMismatchError ctx
@@ -143,8 +144,8 @@ parseElement ::
   ParseContext m a ->
   [Int] ->
   Vector a ->
-  BasicNormType ->
-  m BasicNormExpr
+  StandardNormType ->
+  m StandardNormExpr
 parseElement ctx@(_, _, _, _, elemParser) dims elems expectedType
   | not (null dims) = dimensionMismatchError ctx
   | Vector.length elems /= 1 = compilerDeveloperError "Malformed IDX file: mismatch between dimensions and acutal data"
@@ -153,17 +154,17 @@ parseElement ctx@(_, _, _, _, elemParser) dims elems expectedType
 type ParseContext m a =
   ( DeclProvenance, -- The provenance of the dataset declaration
     FilePath, -- The path of the dataset
-    GluedType, -- The overall dataset type
+    StandardGluedType, -- The overall dataset type
     [Int], -- Actual dimensions of dataset
     ElemParser m a
   )
 
-type ElemParser m a = a -> BasicNormType -> m BasicNormExpr
+type ElemParser m a = a -> StandardNormType -> m StandardNormExpr
 
 doubleElemParser ::
   MonadExpandResources m =>
   DeclProvenance ->
-  GluedType ->
+  StandardGluedType ->
   FilePath ->
   ElemParser m Double
 doubleElemParser decl datasetType file value expectedElementType = case expectedElementType of
@@ -175,7 +176,7 @@ doubleElemParser decl datasetType file value expectedElementType = case expected
 intElemParser ::
   MonadExpandResources m =>
   DeclProvenance ->
-  GluedType ->
+  StandardGluedType ->
   FilePath ->
   ElemParser m Int
 intElemParser decl datasetType file value expectedElementType = case expectedElementType of
@@ -199,7 +200,7 @@ partitionData dim dims content = do
   i <- [0 .. dim - 1]
   return $ Vector.slice (i * entrySize) entrySize content
 
-variableSizeError :: MonadCompile m => ParseContext m a -> BasicNormExpr -> m b
+variableSizeError :: MonadCompile m => ParseContext m a -> StandardNormExpr -> m b
 variableSizeError (decl, _, expectedDatasetType, _, _) dim =
   throwError $ DatasetVariableSizeTensor decl expectedDatasetType dim
 

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
@@ -13,6 +13,7 @@ import Vehicle.Compile.Error
 import Vehicle.Compile.ExpandResources.Core
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
+import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
@@ -22,8 +23,8 @@ parseParameterValue ::
   MonadExpandResources m =>
   ParameterValues ->
   DeclProvenance ->
-  GluedType ->
-  m BasicNormExpr
+  StandardGluedType ->
+  m StandardNormExpr
 parseParameterValue parameterValues decl@(ident, _) parameterType = do
   implicitParams <- gets inferableParameterContext
 
@@ -53,29 +54,29 @@ parseParameterValue parameterValues decl@(ident, _) parameterType = do
     Nothing -> throwError $ ResourceNotProvided decl Parameter
     Just value -> parser decl value
 
-parseBool :: MonadCompile m => DeclProvenance -> String -> m BasicNormExpr
+parseBool :: MonadCompile m => DeclProvenance -> String -> m StandardNormExpr
 parseBool decl value = case readMaybe value of
   Just v -> return $ VBoolLiteral v
   Nothing -> throwError $ ParameterValueUnparsable decl value Bool
 
-parseNat :: MonadCompile m => DeclProvenance -> String -> m BasicNormExpr
+parseNat :: MonadCompile m => DeclProvenance -> String -> m StandardNormExpr
 parseNat decl value = case readMaybe value of
   Just v
     | v >= 0 -> return $ VNatLiteral v
     | otherwise -> throwError $ ParameterValueInvalidNat decl v
   Nothing -> throwError $ ParameterValueUnparsable decl value Nat
 
-parseInt :: MonadCompile m => DeclProvenance -> String -> m BasicNormExpr
+parseInt :: MonadCompile m => DeclProvenance -> String -> m StandardNormExpr
 parseInt decl value = case readMaybe value of
   Just v -> return $ VIntLiteral v
   Nothing -> throwError $ ParameterValueUnparsable decl value Int
 
-parseRat :: MonadCompile m => DeclProvenance -> String -> m BasicNormExpr
+parseRat :: MonadCompile m => DeclProvenance -> String -> m StandardNormExpr
 parseRat decl value = case rational (pack value) of
   Left _err -> throwError $ ParameterValueUnparsable decl value Rat
   Right (v, _) -> return $ VRatLiteral v
 
-parseIndex :: MonadCompile m => Int -> DeclProvenance -> String -> m BasicNormExpr
+parseIndex :: MonadCompile m => Int -> DeclProvenance -> String -> m StandardNormExpr
 parseIndex n decl value = case readMaybe value of
   Nothing -> throwError $ ParameterValueUnparsable decl value Index
   Just v ->

--- a/vehicle/src/Vehicle/Compile/ObjectFile.hs
+++ b/vehicle/src/Vehicle/Compile/ObjectFile.hs
@@ -12,10 +12,11 @@ import Data.Serialize (Serialize, decode, encode)
 import GHC.Generics (Generic)
 import System.FilePath (dropExtension)
 import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Subsystem.Standard
 
 data ObjectFileContents = ObjectFileContents
   { _fileHash :: Int,
-    _typeResult :: TypedProg
+    _typeResult :: StandardTypedProg
   }
   deriving (Generic)
 
@@ -29,7 +30,7 @@ readObjectFile ::
   (MonadLogger m, MonadIO m) =>
   FilePath ->
   SpecificationText ->
-  m (Maybe TypedProg)
+  m (Maybe StandardTypedProg)
 readObjectFile specificationFile spec = do
   let interfaceFile = getObjectFileFromSpecificationFile specificationFile
   errorOrContents <- liftIO $ do
@@ -55,7 +56,7 @@ writeObjectFile ::
   MonadIO m =>
   FilePath ->
   SpecificationText ->
-  TypedProg ->
+  StandardTypedProg ->
   m ()
 writeObjectFile specificationFile spec result = do
   let interfaceFile = getObjectFileFromSpecificationFile specificationFile

--- a/vehicle/src/Vehicle/Compile/Prelude.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude.hs
@@ -6,7 +6,6 @@ where
 
 import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON)
-import Data.Serialize (Serialize)
 import GHC.Generics (Generic)
 import Vehicle.Compile.Dependency.Graph as X
 import Vehicle.Compile.Prelude.Contexts as X
@@ -23,43 +22,33 @@ import Vehicle.Syntax.AST as X
 --------------------------------------------------------------------------------
 -- Type synonyms
 
--- * Types pre type-checking
+type NamedBinding = ()
 
-type UncheckedBinding = DBBinding
+type NamedVar = Name
 
-type UncheckedVar = DBIndexVar
+type NamedArg builtin = Arg NamedBinding NamedVar builtin
 
-type UncheckedBinder = DBBinder Builtin
+type NamedBinder builtin = Binder NamedBinding NamedVar builtin
 
-type UncheckedArg = DBArg Builtin
+type NamedExpr builtin = Expr NamedBinding NamedVar builtin
 
-type UncheckedExpr = DBExpr Builtin
+type NamedDecl builtin = Decl NamedBinding NamedVar builtin
 
-type UncheckedType = DBExpr Builtin
-
-type UncheckedDecl = DBDecl Builtin
-
-type UncheckedProg = DBProg Builtin
+type NamedProg builtin = Prog NamedBinding NamedVar builtin
 
 -- * Types post type-checking
 
-type CheckedBinding = DBBinding
+type TypeCheckedBinder = DBBinder Builtin
 
-type CheckedVar = DBIndexVar
+type TypeCheckedArg = DBArg Builtin
 
-type CheckedBinder = DBBinder Builtin
+type TypeCheckedExpr = DBExpr Builtin
 
-type CheckedArg = DBArg Builtin
+type TypeCheckedType = DBExpr Builtin
 
-type CheckedExpr = DBExpr Builtin
+type TypeCheckedDecl = DBDecl Builtin
 
-type CheckedType = CheckedExpr
-
-type CheckedDecl = DBDecl Builtin
-
-type CheckedProg = DBProg Builtin
-
-type CheckedTelescope = [CheckedBinder]
+type TypeCheckedProg = DBProg Builtin
 
 -- * Type of annotations attached to the AST that are output by the compiler
 
@@ -87,22 +76,18 @@ type DeclProvenance = (Identifier, Provenance)
 --------------------------------------------------------------------------------
 -- Typed expressions
 
-type ImportedModules = [TypedProg]
-
 -- | A typed-expression. Outside of the type-checker, the contents of this
 -- should not be inspected directly but instead use
-newtype TypedExpr = TypedExpr
-  { glued :: GluedExpr
+newtype TypedExpr builtin = StandardTypedExpr
+  { glued :: GluedExpr builtin
   }
   -- \|^ Stores the both the unnormalised and normalised expression, WITH
   -- auxiliary annotations.
   deriving (Generic)
 
-instance Serialize TypedExpr
+type TypedProg builtin = GenericProg (TypedExpr builtin)
 
-type TypedDecl = GenericDecl TypedExpr
-
-type TypedProg = GenericProg TypedExpr
+type TypedDecl builtin = GenericDecl (TypedExpr builtin)
 
 --------------------------------------------------------------------------------
 -- Property annotations

--- a/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
@@ -14,19 +14,19 @@ import Vehicle.Syntax.AST
 --------------------------------------------------------------------------------
 -- Utility functions
 
-isTypeUniverse :: Expr binder var Builtin -> Bool
+isTypeUniverse :: Expr binder var builtin -> Bool
 isTypeUniverse TypeUniverse {} = True
 isTypeUniverse _ = False
 
-isPolarityUniverse :: Expr binder var Builtin -> Bool
+isPolarityUniverse :: Expr binder var builtin -> Bool
 isPolarityUniverse PolarityUniverse {} = True
 isPolarityUniverse _ = False
 
-isLinearityUniverse :: Expr binder var Builtin -> Bool
+isLinearityUniverse :: Expr binder var builtin -> Bool
 isLinearityUniverse LinearityUniverse {} = True
 isLinearityUniverse _ = False
 
-isAuxiliaryUniverse :: Expr binder var Builtin -> Bool
+isAuxiliaryUniverse :: Expr binder var builtin -> Bool
 isAuxiliaryUniverse e = isPolarityUniverse e || isLinearityUniverse e
 
 isBoundVar :: DBExpr Builtin -> Bool

--- a/vehicle/src/Vehicle/Compile/Queries/LNF.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LNF.hs
@@ -6,10 +6,11 @@ where
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
+import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.Normalised
 
 -- | Converts an arithmetic expression to linear normal form.
-convertToLNF :: MonadCompile m => BasicNormExpr -> m BasicNormExpr
+convertToLNF :: MonadCompile m => StandardNormExpr -> m StandardNormExpr
 convertToLNF expr =
   logCompilerPass MinDetail "conversion to linear normal form" $ do
     result <- lnf expr
@@ -19,7 +20,7 @@ convertToLNF expr =
 --------------------------------------------------------------------------------
 -- PNF
 
-lnf :: MonadCompile m => BasicNormExpr -> m BasicNormExpr
+lnf :: MonadCompile m => StandardNormExpr -> m StandardNormExpr
 lnf expr = case expr of
   VLVec {} -> normalisationError currentPass "LVec"
   VUniverse {} -> unexpectedTypeInExprError currentPass "Universe"
@@ -57,7 +58,7 @@ lnf expr = case expr of
   where
     p = mempty
 
-lowerNeg :: NegDomain -> BasicNormExpr -> BasicNormExpr
+lowerNeg :: NegDomain -> StandardNormExpr -> StandardNormExpr
 lowerNeg dom = \case
   -- Base cases
   VBuiltinFunction (Neg _) [e] -> argExpr e

--- a/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
@@ -8,7 +8,6 @@ module Vehicle.Compile.Queries.NetworkElimination
 where
 
 import Control.Monad (zipWithM)
-import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.State (MonadState (..), StateT (..))
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HashMap
@@ -20,11 +19,12 @@ import Data.Map qualified as Map
     lookup,
   )
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (reeval)
+import Vehicle.Compile.Normalise.NBE (reeval, runEmptyNormT)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Queries.Variable
 import Vehicle.Compile.Resource
+import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.AlphaEquivalence ()
 import Vehicle.Expr.Boolean (ConjunctAll (unConjunctAll))
 import Vehicle.Expr.DeBruijn
@@ -33,7 +33,7 @@ import Vehicle.Verify.Specification (MetaNetwork)
 
 -- Pairs of (input variable == expression)
 -- TODO push back through this file once changing CheckedExpr to NormExpr
-type InputEqualities = [(DBLevel, BasicNormExpr)]
+type InputEqualities = [(DBLevel, StandardNormExpr)]
 
 -- | Okay so this is a wild ride. The Marabou query format has special variable
 -- names for input and output variables, namely x1 ... xN and y1 ... yM but
@@ -55,8 +55,8 @@ replaceNetworkApplications ::
   MonadCompile m =>
   NetworkContext ->
   BoundDBCtx ->
-  ConjunctAll BasicNormExpr ->
-  m (MetaNetwork, [NetworkVariable], InputEqualities, ConjunctAll BasicNormExpr)
+  ConjunctAll StandardNormExpr ->
+  m (MetaNetwork, [NetworkVariable], InputEqualities, ConjunctAll StandardNormExpr)
 replaceNetworkApplications networkCtx boundCtx conjunctions = do
   logCompilerPass MinDetail "input/output variable insertion" $ do
     let initialState = IOVarState mempty mempty mempty 0 0
@@ -71,16 +71,16 @@ replaceNetworkApplications networkCtx boundCtx conjunctions = do
     networkVariables <- getNetworkVariables networkCtx finalMetaNetwork
     logDebug MinDetail $ "Generated meta-network" <+> pretty finalMetaNetwork <> line
 
-    normQueryExpr <- runReaderT (traverse reeval networkFreeConjunctions) mempty
+    normQueryExpr <- traverse reevalute networkFreeConjunctions
 
     logCompilerPassOutput $ prettyVerbose (NonEmpty.toList $ unConjunctAll normQueryExpr)
     return (finalMetaNetwork, networkVariables, finalInputEqualities, normQueryExpr)
   where
     go ::
       MonadCompile m =>
-      (Identifier -> BasicNormExpr -> m BasicNormExpr) ->
-      BasicNormExpr ->
-      m BasicNormExpr
+      (Identifier -> StandardNormExpr -> m StandardNormExpr) ->
+      StandardNormExpr ->
+      m StandardNormExpr
     go k expr = case expr of
       VUniverse {} -> unexpectedTypeInExprError currentPass "Universe"
       VPi {} -> unexpectedTypeInExprError currentPass "Pi"
@@ -100,16 +100,19 @@ replaceNetworkApplications networkCtx boundCtx conjunctions = do
 
     goSpine ::
       MonadCompile m =>
-      (Identifier -> BasicNormExpr -> m BasicNormExpr) ->
-      BasicSpine ->
-      m BasicSpine
+      (Identifier -> StandardNormExpr -> m StandardNormExpr) ->
+      StandardSpine ->
+      m StandardSpine
     goSpine k = traverse (traverse (go k))
+
+reevalute :: MonadCompile m => StandardNormExpr -> m StandardNormExpr
+reevalute expr = runEmptyNormT @Builtin (reeval expr)
 
 -- | The current state of the input/output network variables.
 data IOVarState = IOVarState
-  { applicationCache :: HashMap (Identifier, BasicNormExpr) BasicNormExpr,
+  { applicationCache :: HashMap (Identifier, StandardNormExpr) StandardNormExpr,
     metaNetwork :: MetaNetwork,
-    inputEqualities :: [[(DBLevel, BasicNormExpr)]],
+    inputEqualities :: [[(DBLevel, StandardNormExpr)]],
     magicInputVarCount :: Int,
     magicOutputVarCount :: Int
   }
@@ -119,8 +122,8 @@ processNetworkApplication ::
   NetworkContext ->
   BoundDBCtx ->
   Identifier ->
-  BasicNormExpr ->
-  m BasicNormExpr
+  StandardNormExpr ->
+  m StandardNormExpr
 processNetworkApplication networkCtx boundCtx ident inputVector = do
   let sectionLog = "Replacing application:" <+> pretty ident <+> prettyVerbose inputVector
   logCompilerSection MaxDetail sectionLog $ do
@@ -161,7 +164,7 @@ processNetworkApplication networkCtx boundCtx ident inputVector = do
 
         return outputVarsExpr
 
-createInputVarEqualities :: MonadCompile m => [Int] -> [DBLevel] -> BasicNormExpr -> m [(DBLevel, BasicNormExpr)]
+createInputVarEqualities :: MonadCompile m => [Int] -> [DBLevel] -> StandardNormExpr -> m [(DBLevel, StandardNormExpr)]
 createInputVarEqualities (_dim : dims) inputVarIndices (VLVec xs _) = do
   let inputVarIndicesChunks = chunksOf (product dims) inputVarIndices
   concat <$> zipWithM (createInputVarEqualities dims) inputVarIndicesChunks xs
@@ -178,10 +181,10 @@ mkMagicVariableSeq ::
   NetworkBaseType ->
   [Int] ->
   [DBLevel] ->
-  m BasicNormExpr
+  m StandardNormExpr
 mkMagicVariableSeq tElem = go
   where
-    go :: MonadCompile m => [Int] -> [DBLevel] -> m BasicNormExpr
+    go :: MonadCompile m => [Int] -> [DBLevel] -> m StandardNormExpr
     go (_dim : dims) outputVarIndices = do
       let outputVarIndicesChunks = chunksOf (product dims) outputVarIndices
       elems <- traverse (go dims) outputVarIndicesChunks

--- a/vehicle/src/Vehicle/Compile/Resource.hs
+++ b/vehicle/src/Vehicle/Compile/Resource.hs
@@ -2,6 +2,7 @@ module Vehicle.Compile.Resource where
 
 import Data.Map (Map)
 import Vehicle.Compile.Prelude
+import Vehicle.Expr.DeBruijn (DBType)
 
 --------------------------------------------------------------------------------
 -- Networks
@@ -40,7 +41,7 @@ instance Pretty NetworkBaseType where
   pretty = \case
     NetworkRatType -> pretty Rat
 
-reconstructNetworkBaseType :: NetworkBaseType -> Provenance -> CheckedType
+reconstructNetworkBaseType :: NetworkBaseType -> Provenance -> DBType Builtin
 reconstructNetworkBaseType NetworkRatType = RatType
 
 type NetworkContext = Map Name (FilePath, NetworkType)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -4,19 +4,11 @@ module Vehicle.Compile.Type.Constraint.Core
     malformedConstraintError,
     unify,
     solveTypeClassMeta,
-    TypeClassProgress,
-    InstanceSolver,
-    TypeClassSolver,
-    AuxiliaryTypeClassSolver,
-    mkVAnnBoolType,
-    mkVAnnRatType,
-    mkVIndexType,
-    mkVListType,
-    mkVVecType,
   )
 where
 
 import Control.Monad (forM_)
+import Data.Data (Proxy (..))
 import Data.List (partition)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Quote (Quote (..))
@@ -25,48 +17,18 @@ import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Constraint
 import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
-import Vehicle.Compile.Type.Monad (TCM, solveMeta)
-import Vehicle.Compile.Type.Monad.Class (trackSolvedMetas)
+import Vehicle.Compile.Type.Monad (TCM, solveMeta, trackSolvedMetas)
 import Vehicle.Expr.Normalised
-
--- | Function signature for constraints solved by instance search.
-type InstanceSolver =
-  forall m.
-  TCM m =>
-  ConstraintContext ->
-  MetaID ->
-  BasicSpine ->
-  m ()
-
-type TypeClassProgress = Either MetaSet ([WithContext Constraint], BasicNormExpr)
-
--- | Function signature for constraints solved by type class resolution.
--- This should eventually be refactored out so all are solved by instance
--- search.
-type TypeClassSolver =
-  forall m.
-  TCM m =>
-  WithContext TypeClassConstraint ->
-  [BasicNormType] ->
-  m TypeClassProgress
-
--- | Function signature for auxiliary constraints solved by type class resolution.
-type AuxiliaryTypeClassSolver =
-  forall m.
-  TCM m =>
-  WithContext TypeClassConstraint ->
-  [BasicNormType] ->
-  m ConstraintProgress
 
 -- | Attempts to solve as many constraints as possible. Takes in
 -- the set of meta-variables solved since the solver was last run and outputs
 -- the set of meta-variables solved during this run.
 runConstraintSolver ::
-  forall m constraint.
-  (TCM m, PrettyExternal (Contextualised constraint ConstraintContext)) =>
-  m [Contextualised constraint ConstraintContext] ->
-  ([Contextualised constraint ConstraintContext] -> m ()) ->
-  (Contextualised constraint ConstraintContext -> m ()) ->
+  forall builtin m constraint.
+  (TCM builtin m, PrettyExternal (Contextualised constraint (ConstraintContext builtin))) =>
+  m [Contextualised constraint (ConstraintContext builtin)] ->
+  ([Contextualised constraint (ConstraintContext builtin)] -> m ()) ->
+  (Contextualised constraint (ConstraintContext builtin) -> m ()) ->
   MetaSet ->
   m ()
 runConstraintSolver getConstraints setConstraints attemptToSolveConstraint = loop 0
@@ -87,41 +49,26 @@ runConstraintSolver getConstraints setConstraints attemptToSolveConstraint = loo
               -- We have made useful progress so start a new pass
               setConstraints blockedConstraints
 
-              solvedMetas <- trackSolvedMetas $ do
+              solvedMetas <- trackSolvedMetas (Proxy @builtin) $ do
                 forM_ unblockedConstraints $ \constraint -> do
                   logCompilerSection MaxDetail ("trying:" <+> prettyExternal constraint) $ do
                     attemptToSolveConstraint constraint
 
               loop (loopNumber + 1) solvedMetas
 
-blockOn :: MonadCompile m => [MetaID] -> m ConstraintProgress
+blockOn :: MonadCompile m => [MetaID] -> m (ConstraintProgress builtin)
 blockOn metas = do
   logDebug MaxDetail $ "stuck-on metas" <+> pretty metas
   return $ Stuck $ MetaSet.fromList metas
 
-malformedConstraintError :: MonadCompile m => WithContext TypeClassConstraint -> m a
+malformedConstraintError :: (PrintableBuiltin builtin, MonadCompile m) => WithContext (TypeClassConstraint builtin) -> m a
 malformedConstraintError c =
   compilerDeveloperError $ "Malformed type-class constraint:" <+> prettyVerbose c
 
-unify :: ConstraintContext -> BasicNormExpr -> BasicNormExpr -> WithContext Constraint
+unify :: ConstraintContext builtin -> NormExpr builtin -> NormExpr builtin -> WithContext (Constraint builtin)
 unify ctx e1 e2 = WithContext (UnificationConstraint $ Unify e1 e2) (copyContext ctx)
 
-solveTypeClassMeta :: TCM m => ConstraintContext -> MetaID -> BasicNormExpr -> m ()
+solveTypeClassMeta :: TCM builtin m => ConstraintContext builtin -> MetaID -> NormExpr builtin -> m ()
 solveTypeClassMeta ctx meta solution = do
   quotedSolution <- quote mempty (contextDBLevel ctx) solution
   solveMeta meta quotedSolution (boundContext ctx)
-
-mkVAnnBoolType :: BasicNormExpr -> BasicNormExpr -> BasicNormExpr
-mkVAnnBoolType lin pol = VConstructor Bool [IrrelevantImplicitArg mempty lin, IrrelevantImplicitArg mempty pol]
-
-mkVAnnRatType :: BasicNormExpr -> BasicNormExpr
-mkVAnnRatType lin = VConstructor Rat [IrrelevantImplicitArg mempty lin]
-
-mkVIndexType :: BasicNormExpr -> BasicNormExpr
-mkVIndexType size = VConstructor Index [ExplicitArg mempty size]
-
-mkVListType :: BasicNormType -> BasicNormExpr
-mkVListType tElem = VConstructor List [ExplicitArg mempty tElem]
-
-mkVVecType :: BasicNormType -> BasicNormExpr -> BasicNormExpr
-mkVVecType tElem dim = VConstructor Vector [ExplicitArg mempty tElem, ExplicitArg mempty dim]

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -1,13 +1,11 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Vehicle.Compile.Type.Constraint.UnificationSolver
-  ( runUnificationSolver,
+  ( solveUnificationConstraint,
   )
 where
 
 import Control.Monad (when)
-import Control.Monad.Except (MonadError (..), throwError)
-import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.Writer (execWriterT)
 import Control.Monad.Writer.Class (MonadWriter (..))
 import Data.Foldable (for_, traverse_)
@@ -16,18 +14,21 @@ import Data.IntMap qualified as IntMap
 import Data.IntSet qualified as IntSet
 import Data.List (intersect)
 import Data.Maybe (mapMaybe)
+import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Constraint
-import Vehicle.Compile.Type.Constraint.Core (runConstraintSolver)
+import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta
 import Vehicle.Compile.Type.Meta.Map (MetaMap)
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap (lookup, member, singleton, toList)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet (null, unions)
+import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
+import Vehicle.Compile.Type.Subsystem (TypableBuiltin (..))
 import Vehicle.Compile.Type.VariableContext (TypingBoundCtx)
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
@@ -38,22 +39,12 @@ import Vehicle.Expr.Normalised
 -- See https://github.com/AndrasKovacs/elaboration-zoo/
 -- for an excellent tutorial on the algorithm.
 
--- | Attempts to solve as many unification constraints as possible. Takes in
--- the set of meta-variables solved since unification was last run and outputs
--- the set of meta-variables solved during this run.
-runUnificationSolver :: TCM m => MetaSet -> m ()
-runUnificationSolver metasSolved =
-  logCompilerPass MaxDetail "unification solver run" $
-    runConstraintSolver
-      getActiveUnificationConstraints
-      setUnificationConstraints
-      solveUnificationConstraint
-      metasSolved
-
 --------------------------------------------------------------------------------
 -- Unification algorithm
 
-solveUnificationConstraint :: TCM m => WithContext UnificationConstraint -> m ()
+type MonadUnify builtin m = TCM builtin m
+
+solveUnificationConstraint :: MonadUnify builtin m => WithContext (UnificationConstraint builtin) -> m ()
 solveUnificationConstraint (WithContext (Unify e1 e2) ctx) = do
   (ne1', e1BlockingMetas) <- forceHead e1
   (ne2', e2BlockingMetas) <- forceHead e2
@@ -72,35 +63,39 @@ solveUnificationConstraint (WithContext (Unify e1 e2) ctx) = do
     SoftFailure -> do
       let blockingMetas = MetaSet.unions [e1BlockingMetas, e2BlockingMetas]
       if MetaSet.null blockingMetas
-        then throwError (FailedUnificationConstraints [WithContext nu ctx])
+        then handleTypingError (FailedUnification [WithContext nu ctx])
         else do
           let normConstraint = WithContext nu ctx
           let blockedConstraint = blockConstraintOn normConstraint blockingMetas
           addUnificationConstraints [blockedConstraint]
-    HardFailure -> do
-      throwError (FailedUnificationConstraints [WithContext nu ctx])
+    HardFailure ->
+      handleTypingError (FailedUnification [WithContext nu ctx])
 
-data UnificationResult
-  = Success [WithContext UnificationConstraint]
+data UnificationResult builtin
+  = Success [WithContext (UnificationConstraint builtin)]
   | -- | Always an error
     HardFailure
   | -- | Only an error when further reduction will never occur.
     SoftFailure
 
-instance Semigroup UnificationResult where
+instance Semigroup (UnificationResult builtin) where
   HardFailure <> _ = HardFailure
   _ <> HardFailure = HardFailure
   SoftFailure <> _ = SoftFailure
   _ <> SoftFailure = SoftFailure
   Success cs1 <> Success cs2 = Success (cs1 <> cs2)
 
-instance Monoid UnificationResult where
+instance Monoid (UnificationResult builtin) where
   mempty = Success mempty
 
 pattern (:~:) :: a -> b -> (a, b)
 pattern x :~: y = (x, y)
 
-unification :: TCM m => ConstraintContext -> (BasicNormExpr, BasicNormExpr) -> m UnificationResult
+unification ::
+  MonadUnify builtin m =>
+  ConstraintContext builtin ->
+  (NormExpr builtin, NormExpr builtin) ->
+  m (UnificationResult builtin)
 unification ctx = \case
   -----------------------
   -- Rigid-rigid cases --
@@ -141,51 +136,51 @@ unification ctx = \case
   -- Catch-all
   _ -> return SoftFailure
 
-solveTrivially :: TCM m => m UnificationResult
+solveTrivially :: MonadUnify builtin m => m (UnificationResult builtin)
 solveTrivially = do
   logDebug MaxDetail "solved-trivially"
   return $ Success mempty
 
-solveArg :: ConstraintContext -> (BasicNormArg, BasicNormArg) -> Maybe UnificationResult
+solveArg :: ConstraintContext builtin -> (NormArg builtin, NormArg builtin) -> Maybe (UnificationResult builtin)
 solveArg ctx (arg1, arg2)
   | not (visibilityMatches arg1 arg2) = Just HardFailure
   | isInstance arg1 = Nothing
   | otherwise = Just $ Success [unify ctx (argExpr arg1) (argExpr arg2)]
 
 solveSpine ::
-  TCM m =>
-  ConstraintContext ->
-  [BasicNormArg] ->
-  [BasicNormArg] ->
-  m UnificationResult
+  MonadUnify builtin m =>
+  ConstraintContext builtin ->
+  [NormArg builtin] ->
+  [NormArg builtin] ->
+  m (UnificationResult builtin)
 solveSpine ctx args1 args2
   | length args1 /= length args2 = return HardFailure
   | otherwise = return $ mconcat $ mapMaybe (solveArg ctx) (zip args1 args2)
 
 solveLam ::
-  TCM m =>
-  (BasicNormBinder, BasicEnv, CheckedExpr) ->
-  (BasicNormBinder, BasicEnv, CheckedExpr) ->
-  m UnificationResult
+  MonadUnify builtin m =>
+  (NormBinder builtin, Env builtin, DBExpr builtin) ->
+  (NormBinder builtin, Env builtin, DBExpr builtin) ->
+  m (UnificationResult builtin)
 solveLam _l1 _l2 = compilerDeveloperError "unification of type-level lambdas not yet supported"
 
 solveVec ::
-  TCM m =>
-  ConstraintContext ->
-  ([BasicNormExpr], BasicSpine) ->
-  ([BasicNormExpr], BasicSpine) ->
-  m UnificationResult
+  MonadUnify builtin m =>
+  ConstraintContext builtin ->
+  ([NormExpr builtin], Spine builtin) ->
+  ([NormExpr builtin], Spine builtin) ->
+  m (UnificationResult builtin)
 solveVec ctx (xs1, spine1) (xs2, spine2) = do
   let elemProgress = Success $ zipWith (unify ctx) xs1 xs2
   argsProgress <- solveSpine ctx spine1 spine2
   return $ elemProgress <> argsProgress
 
 solvePi ::
-  TCM m =>
-  ConstraintContext ->
-  (BasicNormBinder, BasicNormExpr) ->
-  (BasicNormBinder, BasicNormExpr) ->
-  m UnificationResult
+  MonadUnify builtin m =>
+  ConstraintContext builtin ->
+  (NormBinder builtin, NormExpr builtin) ->
+  (NormBinder builtin, NormExpr builtin) ->
+  m (UnificationResult builtin)
 solvePi ctx (binder1, body1) (binder2, body2) = do
   -- !!TODO!! Block until binders are solved
   -- One possible implementation, blocked metas = set of sets where outer is conjunction and inner is disjunction
@@ -194,7 +189,7 @@ solvePi ctx (binder1, body1) (binder2, body2) = do
   let bodyConstraint = unify ctx body1 body2
   return $ Success [binderConstraint, bodyConstraint]
 
-solveFlexFlex :: TCM m => ConstraintContext -> (MetaID, BasicSpine) -> (MetaID, BasicSpine) -> m UnificationResult
+solveFlexFlex :: MonadUnify builtin m => ConstraintContext builtin -> (MetaID, Spine builtin) -> (MetaID, Spine builtin) -> m (UnificationResult builtin)
 solveFlexFlex ctx (meta1, spine1) (meta2, spine2) = do
   -- It may be that only one of the two spines is invertible
   let maybeRenaming = invert (contextDBLevel ctx) spine1
@@ -202,7 +197,7 @@ solveFlexFlex ctx (meta1, spine1) (meta2, spine2) = do
     Nothing -> solveFlexRigid ctx (meta2, spine2) (VMeta meta1 spine1)
     Just renaming -> solveFlexRigidWithRenaming ctx (meta1, spine1) renaming (VMeta meta2 spine2)
 
-solveFlexRigid :: TCM m => ConstraintContext -> (MetaID, BasicSpine) -> BasicNormExpr -> m UnificationResult
+solveFlexRigid :: MonadUnify builtin m => ConstraintContext builtin -> (MetaID, Spine builtin) -> NormExpr builtin -> m (UnificationResult builtin)
 solveFlexRigid ctx (meta, spine) = do
   let constraintLevel = DBLevel $ length (boundContext ctx)
   -- Check that 'args' is a pattern and try to calculate a substitution
@@ -214,7 +209,7 @@ solveFlexRigid ctx (meta, spine) = do
     Nothing -> \_ -> return SoftFailure
     Just renaming -> solveFlexRigidWithRenaming ctx (meta, spine) renaming
 
-solveFlexRigidWithRenaming :: TCM m => ConstraintContext -> (MetaID, BasicSpine) -> Renaming -> BasicNormExpr -> m UnificationResult
+solveFlexRigidWithRenaming :: forall builtin m. MonadUnify builtin m => ConstraintContext builtin -> (MetaID, Spine builtin) -> Renaming -> NormExpr builtin -> m (UnificationResult builtin)
 solveFlexRigidWithRenaming ctx (meta, spine) renaming e2 = do
   metasInE2 <- metasInWithDependencies e2
 
@@ -231,7 +226,7 @@ solveFlexRigidWithRenaming ctx (meta, spine) renaming e2 = do
 
   -- Restrict any arguments to each sub-meta on the RHS to those of i.
   for_ (MetaMap.toList metasInE2) $ \(j, jSpine) -> do
-    jOrigin <- getMetaProvenance j
+    jOrigin <- getMetaProvenance (Proxy @builtin) j
     jType <- getMetaType j
     let (jDeps, _) = getNormMetaDependencies jSpine
     let sharedDependencies = deps `intersect` jDeps
@@ -248,12 +243,12 @@ solveFlexRigidWithRenaming ctx (meta, spine) renaming e2 = do
   return $ Success mempty
 
 createMetaWithRestrictedDependencies ::
-  TCM m =>
-  ConstraintContext ->
+  MonadUnify builtin m =>
+  ConstraintContext builtin ->
   Provenance ->
-  CheckedType ->
+  CheckedType builtin ->
   [DBLevel] ->
-  m CheckedExpr
+  m (CheckedExpr builtin)
 createMetaWithRestrictedDependencies ctx p metaType newDependencies = do
   logCompilerPass MaxDetail "restricting dependencies" $ do
     let restrictedContext = restrictBoundContext newDependencies (boundContext ctx)
@@ -266,10 +261,10 @@ createMetaWithRestrictedDependencies ctx p metaType newDependencies = do
 
     return newMetaExpr
 
-unify :: ConstraintContext -> BasicNormExpr -> BasicNormExpr -> WithContext UnificationConstraint
+unify :: ConstraintContext builtin -> NormExpr builtin -> NormExpr builtin -> WithContext (UnificationConstraint builtin)
 unify ctx e1 e2 = WithContext (Unify e1 e2) (copyContext ctx)
 
-restrictBoundContext :: [DBLevel] -> TypingBoundCtx -> TypingBoundCtx
+restrictBoundContext :: [DBLevel] -> TypingBoundCtx builtin -> TypingBoundCtx builtin
 restrictBoundContext levels ctx = do
   let levelSet = IntSet.fromList $ fmap unLevel levels
   let makeElem (i, v) = if i `IntSet.member` levelSet then Just v else Nothing
@@ -282,10 +277,10 @@ type Renaming = IntMap DBIndex
 
 -- | TODO: explain what this means:
 -- [i2 i4 i1] --> [2 -> 2, 4 -> 1, 1 -> 0]
-invert :: DBLevel -> BasicSpine -> Maybe Renaming
+invert :: DBLevel -> Spine builtin -> Maybe Renaming
 invert ctxSize args = go (length args - 1) IntMap.empty args
   where
-    go :: Int -> IntMap DBIndex -> BasicSpine -> Maybe Renaming
+    go :: Int -> IntMap DBIndex -> Spine builtin -> Maybe Renaming
     go i revMap = \case
       [] -> Just revMap
       (ExplicitArg _ (VBoundVar j []) : restArgs) -> do
@@ -299,18 +294,16 @@ invert ctxSize args = go (length args - 1) IntMap.empty args
       -- Not a pattern so return nothing.
       _ -> Nothing
 
-metasInWithDependencies :: MonadTypeChecker m => BasicNormExpr -> m (MetaMap BasicSpine)
+metasInWithDependencies :: MonadUnify builtin m => NormExpr builtin -> m (MetaMap (Spine builtin))
 metasInWithDependencies e = execWriterT (go e)
   where
-    go :: (MonadTypeChecker m, MonadWriter (MetaMap BasicSpine) m) => BasicNormExpr -> m ()
+    go :: (MonadUnify builtin m, MonadWriter (MetaMap (Spine builtin)) m) => NormExpr builtin -> m ()
     go expr = case expr of
       VMeta m spine -> do
         metaSubst <- getMetaSubstitution
         case MetaMap.lookup m metaSubst of
           Nothing -> tell (MetaMap.singleton m spine)
-          Just solution -> do
-            declSubst <- getDeclSubstitution
-            go =<< runReaderT (evalApp (normalised solution) spine) (declSubst, metaSubst)
+          Just solution -> go =<< evalApp (normalised solution) spine
       VUniverse {} -> return ()
       VLiteral {} -> return ()
       VBuiltin _ spine -> goSpine spine
@@ -323,5 +316,5 @@ metasInWithDependencies e = execWriterT (go e)
       -- in the environment will be used?
       VLam {} -> return ()
 
-    goSpine :: (MonadTypeChecker m, MonadWriter (MetaMap BasicSpine) m) => BasicSpine -> m ()
+    goSpine :: (MonadUnify builtin m, MonadWriter (MetaMap (Spine builtin)) m) => Spine builtin -> m ()
     goSpine = traverse_ (traverse_ go)

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -1,0 +1,52 @@
+module Vehicle.Compile.Type.Core where
+
+import Data.List.NonEmpty (NonEmpty)
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Constraint (Constraint, UnificationConstraint)
+import Vehicle.Compile.Type.VariableContext (TypingBoundCtx)
+import Vehicle.Expr.DeBruijn
+
+-- * Types pre type-checking
+
+type UncheckedBinding = DBBinding
+
+type UncheckedVar = DBIndexVar
+
+type UncheckedBinder builtin = DBBinder builtin
+
+type UncheckedArg builtin = DBArg builtin
+
+type UncheckedExpr builtin = DBExpr builtin
+
+type UncheckedType builtin = DBExpr builtin
+
+type UncheckedDecl builtin = DBDecl builtin
+
+type UncheckedProg builtin = DBProg builtin
+
+-- * Types post type-checking
+
+type CheckedBinding = DBBinding
+
+type CheckedVar = DBIndexVar
+
+type CheckedBinder builtin = DBBinder builtin
+
+type CheckedArg builtin = DBArg builtin
+
+type CheckedExpr builtin = DBExpr builtin
+
+type CheckedType builtin = CheckedExpr builtin
+
+type CheckedDecl builtin = DBDecl builtin
+
+type CheckedProg builtin = DBProg builtin
+
+type Imports builtin = [TypedProg builtin]
+
+-- | Errors in bidirectional type-checking
+data TypingError builtin
+  = MissingExplicitArgument (TypingBoundCtx builtin) (CheckedBinder builtin) (UncheckedArg builtin)
+  | FunctionTypeMismatch (TypingBoundCtx builtin) (CheckedExpr builtin) [UncheckedArg builtin] (CheckedExpr builtin) [UncheckedArg builtin]
+  | FailedUnification (NonEmpty (WithContext (UnificationConstraint builtin)))
+  | UnsolvableConstraints (NonEmpty (WithContext (Constraint builtin)))

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -1,65 +1,51 @@
 module Vehicle.Compile.Type.Meta.Substitution
-  ( MetaSubstitution,
-    MetaSubstitutable,
-    substituteMetas,
+  ( MetaSubstitutable,
+    substMetas,
   )
 where
 
-import Control.Monad.Reader (MonadReader (..), ReaderT (..))
 import Data.List.NonEmpty (NonEmpty)
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (evalApp, evalBuiltin)
+import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Constraint
 import Vehicle.Compile.Type.Meta.Map (MetaMap (..))
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Meta.Variable (MetaInfo (..))
-import Vehicle.Compile.Type.VariableContext (MetaSubstitution)
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalised (BasicNormExpr, GluedExpr (..), NormExpr (..))
+import Vehicle.Expr.Normalised (GluedExpr (..), NormExpr (..))
 
 -- | Substitutes meta-variables through the provided object, returning the
 -- updated object and the set of meta-variables within the object for which
 -- no subsitution was provided.
-substituteMetas ::
-  (MonadCompile m, MetaSubstitutable a) =>
-  DeclCtx BasicNormExpr ->
-  MetaSubstitution ->
-  a ->
-  m a
-substituteMetas declCtx sub e =
-  runReaderT (subst e) (sub, declCtx)
+substMetas :: (MonadCompile m, MetaSubstitutable m a) => a -> m a
+substMetas = subst
 
 --------------------------------------------------------------------------------
 -- Substitution operation
 
-type MonadSubst m =
-  ( MonadCompile m,
-    MonadReader (MetaSubstitution, DeclCtx BasicNormExpr) m
-  )
+class MetaSubstitutable m a where
+  subst :: MonadCompile m => a -> m a
 
-class MetaSubstitutable a where
-  subst :: MonadSubst m => a -> m a
-
-instance MetaSubstitutable a => MetaSubstitutable (a, a) where
+instance MetaSubstitutable m a => MetaSubstitutable m (a, a) where
   subst (e1, e2) = do
     e1' <- subst e1
     e2' <- subst e2
     return (e1', e2')
 
-instance MetaSubstitutable a => MetaSubstitutable [a] where
+instance MetaSubstitutable m a => MetaSubstitutable m [a] where
   subst = traverse subst
 
-instance MetaSubstitutable a => MetaSubstitutable (NonEmpty a) where
+instance MetaSubstitutable m a => MetaSubstitutable m (NonEmpty a) where
   subst = traverse subst
 
-instance MetaSubstitutable a => MetaSubstitutable (GenericArg a) where
+instance MetaSubstitutable m a => MetaSubstitutable m (GenericArg a) where
   subst = traverse subst
 
-instance MetaSubstitutable a => MetaSubstitutable (GenericBinder value a) where
+instance MetaSubstitutable m a => MetaSubstitutable m (GenericBinder value a) where
   subst = traverse subst
 
-instance MetaSubstitutable CheckedExpr where
+instance MonadNorm builtin m => MetaSubstitutable m (DBExpr builtin) where
   subst expr =
     -- logCompilerPass MaxDetail (prettyVerbose ex) $
     case expr of
@@ -82,27 +68,27 @@ instance MetaSubstitutable CheckedExpr where
 -- clogging up our program so this function detects meta applications and normalises
 -- them as it substitutes the meta in.
 substApp ::
-  forall m.
-  MonadSubst m =>
+  forall builtin m.
+  MonadNorm builtin m =>
   Provenance ->
-  (CheckedExpr, [CheckedArg]) ->
-  m CheckedExpr
+  (DBExpr builtin, [DBArg builtin]) ->
+  m (DBExpr builtin)
 substApp p (fun@(Meta _ m), mArgs) = do
-  (metaSubst, _declCtx) <- ask
+  metaSubst <- getMetaSubstitution
   case MetaMap.lookup m metaSubst of
     Just value -> subst =<< substArgs (unnormalised value) mArgs
     Nothing -> normAppList p fun <$> subst mArgs
   where
-    substArgs :: CheckedExpr -> [CheckedArg] -> m CheckedExpr
+    substArgs :: DBExpr builtin -> [DBArg builtin] -> m (DBExpr builtin)
     substArgs (Lam _ _ body) (arg : args) = do
       substArgs (argExpr arg `substDBInto` body) args
     substArgs e args = return $ normAppList p e args
 substApp p (fun, args) = normAppList p <$> subst fun <*> subst args
 
-instance MetaSubstitutable BasicNormExpr where
+instance MonadNorm builtin m => MetaSubstitutable m (NormExpr builtin) where
   subst expr = case expr of
     VMeta m args -> do
-      (metaSubst, declCtx) <- ask
+      metaSubst <- getMetaSubstitution
       case MetaMap.lookup m metaSubst of
         -- TODO do we need to subst through the args here?
         Nothing -> VMeta m <$> subst args
@@ -110,51 +96,50 @@ instance MetaSubstitutable BasicNormExpr where
           substValue <- subst $ normalised value
           case args of
             [] -> return substValue
-            (a : as) -> do
-              -- logDebug MaxDetail $ prettyVerbose substValue -- <+> prettyVerbose (fmap argExpr (a : as))
-              runReaderT (evalApp substValue (a : as)) (declCtx, metaSubst)
+            (a : as) -> evalApp substValue (a : as)
+    -- logDebug MaxDetail $ prettyVerbose substValue -- <+> prettyVerbose (fmap argExpr (a : as))
+
     VUniverse {} -> return expr
     VLiteral {} -> return expr
     VFreeVar v spine -> VFreeVar v <$> traverse subst spine
     VBoundVar v spine -> VBoundVar v <$> traverse subst spine
     VLVec xs spine -> VLVec <$> traverse subst xs <*> traverse subst spine
     VBuiltin b spine -> do
-      (metaSubst, declCtx) <- ask
       spine' <- traverse subst spine
-      runReaderT (evalBuiltin b spine') (declCtx, metaSubst)
+      evalBuiltin b spine'
 
     -- NOTE: no need to lift the substitutions here as we're passing under the binders
     -- because by construction every meta-variable solution is a closed term.
     VLam binder env body -> VLam <$> subst binder <*> subst env <*> subst body
     VPi binder body -> VPi <$> subst binder <*> subst body
 
-instance MetaSubstitutable GluedExpr where
+instance MonadNorm builtin m => MetaSubstitutable m (GluedExpr builtin) where
   subst (Glued a b) = Glued <$> subst a <*> subst b
 
-instance MetaSubstitutable expr => MetaSubstitutable (GenericDecl expr) where
+instance MetaSubstitutable m expr => MetaSubstitutable m (GenericDecl expr) where
   subst = traverse subst
 
-instance MetaSubstitutable expr => MetaSubstitutable (GenericProg expr) where
+instance MetaSubstitutable m expr => MetaSubstitutable m (GenericProg expr) where
   subst (Main ds) = Main <$> traverse subst ds
 
-instance MetaSubstitutable UnificationConstraint where
+instance MonadNorm builtin m => MetaSubstitutable m (UnificationConstraint builtin) where
   subst (Unify e1 e2) = Unify <$> subst e1 <*> subst e2
 
-instance MetaSubstitutable TypeClassConstraint where
+instance MonadNorm builtin m => MetaSubstitutable m (TypeClassConstraint builtin) where
   subst (Has m tc es) = Has m tc <$> subst es
 
-instance MetaSubstitutable Constraint where
+instance MonadNorm builtin m => MetaSubstitutable m (Constraint builtin) where
   subst = \case
     UnificationConstraint c -> UnificationConstraint <$> subst c
     TypeClassConstraint c -> TypeClassConstraint <$> subst c
 
-instance MetaSubstitutable constraint => MetaSubstitutable (Contextualised constraint ConstraintContext) where
+instance MetaSubstitutable m constraint => MetaSubstitutable m (Contextualised constraint (ConstraintContext builtin)) where
   subst (WithContext constraint context) = do
     newConstraint <- subst constraint
     return $ WithContext newConstraint context
 
-instance MetaSubstitutable a => MetaSubstitutable (MetaMap a) where
+instance MetaSubstitutable m a => MetaSubstitutable m (MetaMap a) where
   subst (MetaMap t) = MetaMap <$> traverse subst t
 
-instance MetaSubstitutable MetaInfo where
+instance MonadNorm builtin m => MetaSubstitutable m (MetaInfo builtin) where
   subst (MetaInfo p t ctx) = MetaInfo p <$> subst t <*> pure ctx

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
@@ -7,7 +7,7 @@ module Vehicle.Compile.Type.Monad.Instance
 where
 
 import Control.Monad.Except (MonadError (..))
-import Control.Monad.Reader (MonadReader (..), ReaderT (..), mapReaderT)
+import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks, mapReaderT)
 import Control.Monad.State
   ( MonadState (..),
     StateT (..),
@@ -17,22 +17,26 @@ import Control.Monad.State
   )
 import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Trans.Class (lift)
+import Data.Map qualified as Map
 import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Monad.Class
 import Vehicle.Compile.Type.VariableContext
+import Vehicle.Expr.DeBruijn (DBType)
+import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
 -- Implementation
 
-type TypeCheckerTInternals m =
-  ReaderT TypingDeclCtx (StateT TypeCheckerState m)
+type TypeCheckerTInternals builtin m =
+  ReaderT (TypingDeclCtx builtin) (StateT (TypeCheckerState builtin) m)
 
-clearFreshNamesInternal :: Monad m => TypeCheckerTInternals m ()
+clearFreshNamesInternal :: Monad m => TypeCheckerTInternals builtin m ()
 clearFreshNamesInternal =
   modify (\TypeCheckerState {..} -> TypeCheckerState {freshNameState = 0, ..})
 
-getFreshNameInternal :: Monad m => CheckedType -> TypeCheckerTInternals m Name
+getFreshNameInternal :: Monad m => DBType builtin -> TypeCheckerTInternals builtin2 m Name
 getFreshNameInternal _typ = do
   nameID <- gets freshNameState
   modify (\TypeCheckerState {..} -> TypeCheckerState {freshNameState = nameID + 1, ..})
@@ -41,40 +45,48 @@ getFreshNameInternal _typ = do
 --------------------------------------------------------------------------------
 -- The type-checking monad
 
-newtype TypeCheckerT m a = TypeCheckerT
-  { unTypeCheckerT :: TypeCheckerTInternals m a
+newtype TypeCheckerT builtin m a = TypeCheckerT
+  { unTypeCheckerT :: TypeCheckerTInternals builtin m a
   }
   deriving (Functor, Applicative, Monad)
 
-runTypeCheckerT :: Monad m => TypingDeclCtx -> TypeCheckerState -> TypeCheckerT m a -> m (a, TypeCheckerState)
+runTypeCheckerT :: Monad m => TypingDeclCtx builtin -> TypeCheckerState builtin -> TypeCheckerT builtin m a -> m (a, TypeCheckerState builtin)
 runTypeCheckerT declCtx metaCtx (TypeCheckerT e) =
   runStateT (runReaderT e declCtx) metaCtx
 
 mapTypeCheckerT ::
-  (m (a, TypeCheckerState) -> n (b, TypeCheckerState)) ->
-  TypeCheckerT m a ->
-  TypeCheckerT n b
+  (m (a, TypeCheckerState builtin) -> n (b, TypeCheckerState builtin)) ->
+  TypeCheckerT builtin m a ->
+  TypeCheckerT builtin n b
 mapTypeCheckerT f m = TypeCheckerT (mapReaderT (mapStateT f) (unTypeCheckerT m))
 
 --------------------------------------------------------------------------------
 -- Instances that TypeCheckerT satisfies
 
-instance MonadCompile m => MonadTypeChecker (TypeCheckerT m) where
+instance MonadCompile m => InternalMonadNorm builtin (TypeCheckerT builtin m) where
+  getDeclSubstitution = TypeCheckerT $ asks $ Map.mapMaybe (fmap normalised . snd)
+
+  getMetaSubstitution = TypeCheckerT (gets currentSubstitution)
+
+instance (MonadCompile m, NormalisableBuiltin builtin) => MonadTypeChecker builtin (TypeCheckerT builtin m) where
   getDeclContext = TypeCheckerT ask
   addDeclContext d s = TypeCheckerT $ local (addToDeclCtx d) (unTypeCheckerT s)
   getMetaState = TypeCheckerT get
   modifyMetaCtx f = TypeCheckerT $ modify f
   getFreshName typ = TypeCheckerT $ getFreshNameInternal typ
-  clearFreshNames = TypeCheckerT clearFreshNamesInternal
+  clearFreshNames _ = TypeCheckerT clearFreshNamesInternal
 
-instance MonadTrans TypeCheckerT where
+--------------------------------------------------------------------------------
+-- Monad inheritance laws that TypeCheckerT satisfies
+
+instance MonadTrans (TypeCheckerT builtin) where
   lift = TypeCheckerT . lift . lift
 
-instance MonadError e m => MonadError e (TypeCheckerT m) where
+instance MonadError e m => MonadError e (TypeCheckerT builtin m) where
   throwError = lift . throwError
   catchError m f = TypeCheckerT (catchError (unTypeCheckerT m) (unTypeCheckerT . f))
 
-instance MonadLogger m => MonadLogger (TypeCheckerT m) where
+instance MonadLogger m => MonadLogger (TypeCheckerT builtin m) where
   setCallDepth = lift . setCallDepth
   getCallDepth = lift getCallDepth
   incrCallDepth = lift incrCallDepth
@@ -82,6 +94,6 @@ instance MonadLogger m => MonadLogger (TypeCheckerT m) where
   getDebugLevel = lift getDebugLevel
   logMessage = lift . logMessage
 
-instance MonadReader r m => MonadReader r (TypeCheckerT m) where
+instance MonadReader r m => MonadReader r (TypeCheckerT builtin m) where
   ask = lift ask
   local = mapTypeCheckerT . local

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem.hs
@@ -1,0 +1,56 @@
+module Vehicle.Compile.Type.Subsystem
+  ( TypableBuiltin (..),
+  )
+where
+
+import Vehicle.Compile.Error (MonadCompile)
+import Vehicle.Compile.Normalise.NBE
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Constraint
+import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Type.Monad.Class
+import Vehicle.Expr.DeBruijn
+import Vehicle.Expr.Normalised
+
+-- | A class that provides an abstract interface for a set of builtins.
+class NormalisableBuiltin builtin => TypableBuiltin builtin where
+  -- | Construct a type for the builtin
+  typeBuiltin ::
+    Provenance -> builtin -> DBExpr builtin
+
+  typeLiteral ::
+    Provenance -> Literal -> DBExpr builtin
+
+  typeVectorLiteral ::
+    Provenance -> [CheckedType builtin] -> CheckedType builtin
+
+  typeResource ::
+    MonadTypeChecker builtin m =>
+    Resource ->
+    DeclProvenance ->
+    GluedType builtin ->
+    m (CheckedType builtin)
+
+  isAuxiliaryTypeClassConstraint :: TypeClassConstraint builtin -> Bool
+
+  addAuxiliaryInputOutputConstraints ::
+    MonadTypeChecker builtin m => CheckedDecl builtin -> m (CheckedDecl builtin)
+
+  generateDefaultConstraint ::
+    MonadTypeChecker builtin m =>
+    [WithContext (TypeClassConstraint builtin)] ->
+    m (Maybe (WithContext (Constraint builtin)))
+
+  insertHolesForAuxAnnotations ::
+    MonadTypeChecker builtin m => UncheckedExpr builtin -> m (UncheckedExpr builtin)
+
+  typeClassRelevancy :: MonadCompile m => builtin -> m Relevance
+
+  -- | Solves a type-class constraint
+  solveInstance ::
+    (MonadNorm builtin m, MonadTypeChecker builtin m) => WithContext (TypeClassConstraint builtin) -> m ()
+
+  getPropertyInfo :: MonadCompile m => TypedDecl builtin -> m PropertyInfo
+
+  handleTypingError ::
+    MonadCompile m => TypingError builtin -> m a

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
@@ -1,0 +1,38 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Vehicle.Compile.Type.Subsystem.Standard
+  ( module Core,
+  )
+where
+
+import Vehicle.Compile.Type.Auxiliary
+import Vehicle.Compile.Type.Subsystem
+import Vehicle.Compile.Type.Subsystem.Standard.Constraint.Core (isAuxTypeClassConstraint)
+import Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceSolver
+import Vehicle.Compile.Type.Subsystem.Standard.Constraint.TypeClassDefaults (generateConstraintUsingDefaults)
+import Vehicle.Compile.Type.Subsystem.Standard.Core as Core
+import Vehicle.Compile.Type.Subsystem.Standard.Normalisation ()
+import Vehicle.Compile.Type.Subsystem.Standard.Type
+import Vehicle.Compile.Type.Subsystem.Standard.TypeResource
+import Vehicle.Syntax.AST (Builtin)
+
+-----------------------------------------------------------------------------
+-- Standard builtins
+-----------------------------------------------------------------------------
+
+-- TODO Separate builtins from syntactic sugar
+--
+-- TODO Pass in the right number of arguments ensuring all literals
+instance TypableBuiltin Builtin where
+  typeBuiltin = typeStandardBuiltin
+  typeLiteral = standardTypeOfLiteral
+  typeVectorLiteral = standardTypeOfVectorLiteral
+  typeResource = checkResourceType
+  isAuxiliaryTypeClassConstraint = isAuxTypeClassConstraint
+  insertHolesForAuxAnnotations = insertHolesForAuxiliaryAnnotations
+  handleTypingError = handleStandardTypingError
+  typeClassRelevancy = relevanceOfTypeClass
+  solveInstance = solveInstanceConstraint
+  getPropertyInfo = getStandardPropertyInfo
+  addAuxiliaryInputOutputConstraints = addFunctionAuxiliaryInputOutputConstraints
+  generateDefaultConstraint = generateConstraintUsingDefaults

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/Core.hs
@@ -1,0 +1,103 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Vehicle.Compile.Type.Subsystem.Standard.Constraint.Core where
+
+import Vehicle.Compile.Error (MonadCompile, compilerDeveloperError)
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Constraint
+import Vehicle.Compile.Type.Meta (MetaSet)
+import Vehicle.Compile.Type.Monad
+import Vehicle.Compile.Type.Subsystem.Standard.Core
+import Vehicle.Expr.Normalised
+
+--------------------------------------------------------------------------------
+-- Instance constraints
+
+type MonadInstance m =
+  (TCM Builtin m)
+
+-- | Function signature for constraints solved by instance search.
+type InstanceSolver =
+  forall m.
+  MonadInstance m =>
+  StandardConstraintContext ->
+  MetaID ->
+  StandardSpine ->
+  m ()
+
+type TypeClassProgress = Either MetaSet ([WithContext (Constraint Builtin)], StandardNormExpr)
+
+-- | Function signature for constraints solved by type class resolution.
+-- This should eventually be refactored out so all are solved by instance
+-- search.
+type TypeClassSolver =
+  forall m.
+  MonadInstance m =>
+  WithContext (TypeClassConstraint Builtin) ->
+  [StandardNormType] ->
+  m TypeClassProgress
+
+-- | Function signature for auxiliary constraints solved by type class resolution.
+type AuxiliaryTypeClassSolver =
+  forall m.
+  MonadInstance m =>
+  WithContext (TypeClassConstraint Builtin) ->
+  [StandardNormType] ->
+  m StandardConstraintProgress
+
+mkVAnnBoolType :: StandardNormExpr -> StandardNormExpr -> StandardNormExpr
+mkVAnnBoolType lin pol = VConstructor Bool [IrrelevantImplicitArg mempty lin, IrrelevantImplicitArg mempty pol]
+
+mkVAnnRatType :: StandardNormExpr -> StandardNormExpr
+mkVAnnRatType lin = VConstructor Rat [IrrelevantImplicitArg mempty lin]
+
+mkVIndexType :: StandardNormExpr -> StandardNormExpr
+mkVIndexType size = VConstructor Index [ExplicitArg mempty size]
+
+mkVListType :: StandardNormType -> StandardNormExpr
+mkVListType tElem = VConstructor List [ExplicitArg mempty tElem]
+
+mkVVecType :: StandardNormType -> StandardNormExpr -> StandardNormExpr
+mkVVecType tElem dim = VConstructor Vector [ExplicitArg mempty tElem, ExplicitArg mempty dim]
+
+isBoolType :: StandardNormExpr -> Bool
+isBoolType (VConstructor Bool _) = True
+isBoolType _ = False
+
+isIndexType :: StandardNormExpr -> Bool
+isIndexType (VConstructor Index _) = True
+isIndexType _ = False
+
+isNatType :: StandardNormExpr -> Bool
+isNatType (VConstructor Nat _) = True
+isNatType _ = False
+
+isIntType :: StandardNormExpr -> Bool
+isIntType (VConstructor Int _) = True
+isIntType _ = False
+
+isRatType :: StandardNormExpr -> Bool
+isRatType (VConstructor Rat _) = True
+isRatType _ = False
+
+isListType :: StandardNormExpr -> Bool
+isListType (VConstructor List _) = True
+isListType _ = False
+
+isVectorType :: StandardNormExpr -> Bool
+isVectorType (VConstructor Vector _) = True
+isVectorType _ = False
+
+isBoundVar :: StandardNormExpr -> Bool
+isBoundVar VBoundVar {} = True
+isBoundVar _ = False
+
+isAuxTypeClassConstraint :: TypeClassConstraint Builtin -> Bool
+isAuxTypeClassConstraint (Has _ b _) = case b of
+  Constructor (TypeClass tc) -> isAuxiliaryTypeClass tc
+  _ -> False
+
+getTypeClass :: MonadCompile m => Builtin -> m TypeClass
+getTypeClass = \case
+  Constructor (TypeClass tc) -> return tc
+  _ -> compilerDeveloperError "Unexpected non-type-class instance argument found."

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/InstanceBuiltins.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/InstanceBuiltins.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {-# HLINT ignore "Avoid lambda using `infix`" #-}
-module Vehicle.Compile.Type.Constraint.InstanceBuiltins
+module Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceBuiltins
   ( declaredCandidates,
     findTypeClassOfCandidate,
   )
@@ -13,6 +13,7 @@ import Data.HashMap.Strict qualified as HashMap
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Constraint (InstanceCandidate (..))
+import Vehicle.Compile.Type.Subsystem.Standard.Core ()
 import Vehicle.Expr.DSL hiding (builtin)
 import Vehicle.Libraries.StandardLibrary.Names (StdLibFunction (..))
 
@@ -21,7 +22,7 @@ declaredCandidates = do
   let tcAndCandidates = fmap (second (: []) . processCandidate) candidates
   HashMap.fromListWith (<>) tcAndCandidates
 
-findTypeClassOfCandidate :: CheckedExpr -> Either CheckedExpr TypeClass
+findTypeClassOfCandidate :: TypeCheckedExpr -> Either TypeCheckedExpr TypeClass
 findTypeClassOfCandidate = \case
   Pi _ binder body
     | not (isExplicit binder) -> findTypeClassOfCandidate body

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
@@ -1,0 +1,116 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Vehicle.Compile.Type.Subsystem.Standard.Core where
+
+import Data.Serialize
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Constraint
+import Vehicle.Expr.Normalised
+import Vehicle.Libraries.StandardLibrary
+
+-----------------------------------------------------------------------------
+-- Constraints
+
+type StandardConstraintProgress = ConstraintProgress Builtin
+
+type StandardTypeClassConstraint = TypeClassConstraint Builtin
+
+type StandardUnificationConstraint = UnificationConstraint Builtin
+
+type StandardConstraintContext = ConstraintContext Builtin
+
+type StandardConstraint = Constraint Builtin
+
+-----------------------------------------------------------------------------
+-- Norm expressions
+
+type StandardNormExpr = NormExpr Builtin
+
+type StandardNormBinder = NormBinder Builtin
+
+type StandardNormArg = NormArg Builtin
+
+type StandardNormType = NormType Builtin
+
+type StandardSpine = Spine Builtin
+
+type StandardEnv = Env Builtin
+
+pattern VBuiltinFunction :: BuiltinFunction -> StandardSpine -> StandardNormExpr
+pattern VBuiltinFunction f spine = VBuiltin (BuiltinFunction f) spine
+
+pattern VConstructor :: BuiltinConstructor -> StandardSpine -> StandardNormExpr
+pattern VConstructor c args = VBuiltin (Constructor c) args
+
+pattern VLinearityExpr :: Linearity -> StandardNormExpr
+pattern VLinearityExpr l <- VConstructor (Linearity l) []
+  where
+    VLinearityExpr l = VConstructor (Linearity l) []
+
+pattern VPolarityExpr :: Polarity -> StandardNormExpr
+pattern VPolarityExpr l <- VConstructor (Polarity l) []
+  where
+    VPolarityExpr l = VConstructor (Polarity l) []
+
+pattern VAnnBoolType :: StandardNormExpr -> StandardNormExpr -> StandardNormType
+pattern VAnnBoolType lin pol <- VConstructor Bool [IrrelevantImplicitArg _ lin, IrrelevantImplicitArg _ pol]
+
+pattern VBoolType :: StandardNormType
+pattern VBoolType <- VConstructor Bool []
+  where
+    VBoolType = VConstructor Bool []
+
+pattern VIndexType :: StandardNormType -> StandardNormType
+pattern VIndexType size <- VConstructor Index [ExplicitArg _ size]
+
+pattern VNatType :: StandardNormType
+pattern VNatType <- VConstructor Nat []
+  where
+    VNatType = VConstructor Nat []
+
+pattern VIntType :: StandardNormType
+pattern VIntType <- VConstructor Int []
+  where
+    VIntType = VConstructor Int []
+
+pattern VAnnRatType :: StandardNormExpr -> StandardNormType
+pattern VAnnRatType lin <- VConstructor Rat [IrrelevantImplicitArg _ lin]
+
+pattern VRatType :: StandardNormType
+pattern VRatType <- VConstructor Rat []
+  where
+    VRatType = VConstructor Rat []
+
+pattern VListType :: StandardNormType -> StandardNormType
+pattern VListType tElem <- VConstructor List [ExplicitArg _ tElem]
+
+pattern VVectorType :: StandardNormType -> StandardNormType -> StandardNormType
+pattern VVectorType tElem dim <- VConstructor Vector [ExplicitArg _ tElem, ExplicitArg _ dim]
+
+pattern VTensorType :: StandardNormType -> StandardNormType -> StandardNormType
+pattern VTensorType tElem dims <- VFreeVar TensorIdent [ExplicitArg _ tElem, ExplicitArg _ dims]
+
+mkVList :: StandardNormType -> [StandardNormExpr] -> StandardNormExpr
+mkVList tElem = foldr cons nil
+  where
+    p = mempty
+    t = ImplicitArg p tElem
+    nil = VConstructor Nil [t]
+    cons y ys = VConstructor Cons [t, ExplicitArg p y, ExplicitArg p ys]
+
+-----------------------------------------------------------------------------
+-- Glued expressions
+
+type StandardGluedExpr = GluedExpr Builtin
+
+type StandardGluedType = GluedType Builtin
+
+type StandardTypedExpr = TypedExpr Builtin
+
+instance Serialize StandardTypedExpr
+
+type StandardTypedProg = GenericProg StandardTypedExpr
+
+type StandardTypedDecl = GenericDecl StandardTypedExpr
+
+type ImportedModules = [StandardTypedProg]

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Normalisation.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Normalisation.hs
@@ -1,0 +1,410 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Vehicle.Compile.Type.Subsystem.Standard.Normalisation where
+
+import Data.Foldable (foldrM)
+import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.NBE
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Meta (MetaSet)
+import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
+import Vehicle.Compile.Type.Subsystem.Standard.Core
+import Vehicle.Expr.Normalised
+
+-----------------------------------------------------------------------------
+-- Normalisation of builtins
+-----------------------------------------------------------------------------
+
+instance NormalisableBuiltin Builtin where
+  evalBuiltin = evalStandardBuiltin
+  forceBuiltin = forceStandardBuiltin
+
+type MonadBasicNorm m = MonadNorm Builtin m
+
+evalStandardBuiltin ::
+  MonadBasicNorm m =>
+  Builtin ->
+  StandardSpine ->
+  m StandardNormExpr
+evalStandardBuiltin b args = case b of
+  Constructor {} -> return $ VBuiltin b args
+  TypeClassOp op -> evalTypeClassOp op args
+  BuiltinFunction f -> evalBuiltinFunction f args
+
+evalBuiltinFunction :: MonadBasicNorm m => BuiltinFunction -> StandardSpine -> m StandardNormExpr
+evalBuiltinFunction b args
+  | isDerived b = evalDerivedBuiltin b args
+  | otherwise = do
+      let relevantArgs = filter isRelevant args
+
+      let result = case b of
+            Quantifier {} -> Nothing
+            Not -> evalNot relevantArgs
+            And -> evalAnd relevantArgs
+            Or -> evalOr relevantArgs
+            Neg dom -> evalNeg dom relevantArgs
+            Add dom -> evalAdd dom relevantArgs
+            Sub dom -> evalSub dom relevantArgs
+            Mul dom -> evalMul dom relevantArgs
+            Div dom -> evalDiv dom relevantArgs
+            Equals dom op -> evalEquals dom op relevantArgs
+            Order dom op -> evalOrder dom op relevantArgs
+            If -> evalIf relevantArgs
+            At -> evalAt relevantArgs
+            Fold dom -> evalFold dom relevantArgs
+            Foreach -> evalForeach relevantArgs
+            FromNat _ dom -> evalFromNat dom relevantArgs
+            FromRat dom -> evalFromRat dom relevantArgs
+            FromVec _n dom -> evalFromVec dom relevantArgs
+            Implies -> Just $ compilerDeveloperError $ "Found derived builtin" <+> pretty b
+            Map {} -> Just $ compilerDeveloperError $ "Found derived builtin" <+> pretty b
+
+      -- when (b == And) $ do
+      --   logDebug MaxDetail $ prettyVerbose (VBuiltin b args)
+      --   case result of
+      --     Nothing -> logDebug MaxDetail "not normalised"
+      --     Just x -> do
+      --       x' <- x
+      --       logDebug MaxDetail (prettyVerbose x')
+
+      case result of
+        Nothing -> return $ VBuiltinFunction b args
+        Just r -> r
+
+isDerived :: BuiltinFunction -> Bool
+isDerived = \case
+  Implies {} -> True
+  Map {} -> True
+  _ -> False
+
+evalDerivedBuiltin :: MonadBasicNorm m => BuiltinFunction -> StandardSpine -> m StandardNormExpr
+evalDerivedBuiltin b args = case b of
+  Implies -> evalImplies args
+  Map dom -> evalMap dom args
+  _ -> compilerDeveloperError $ "Invalid derived builtin" <+> quotePretty b
+
+-----------------------------------------------------------------------------
+-- Indvidual builtins
+
+type EvalBuiltin m = StandardSpine -> Maybe (m StandardNormExpr)
+
+pattern VBool :: Bool -> StandardNormArg
+pattern VBool x <- ExplicitArg _ (VLiteral (LBool x))
+
+pattern VIndex :: Int -> StandardNormArg
+pattern VIndex x <- ExplicitArg _ (VLiteral (LIndex _ x))
+
+pattern VNat :: Int -> StandardNormArg
+pattern VNat x <- ExplicitArg _ (VLiteral (LNat x))
+
+pattern VInt :: Int -> StandardNormArg
+pattern VInt x <- ExplicitArg _ (VLiteral (LInt x))
+
+pattern VRat :: Rational -> StandardNormArg
+pattern VRat x <- ExplicitArg _ (VLiteral (LRat x))
+
+-- TODO a lot of duplication in the below. Once we have separated out the
+-- derived builtins we should be able to
+
+evalNot :: MonadBasicNorm m => EvalBuiltin m
+evalNot e = case e of
+  [VBool x] -> Just $ return $ VLiteral (LBool (not x))
+  _ -> Nothing
+
+evalAnd :: MonadBasicNorm m => EvalBuiltin m
+evalAnd = \case
+  [VBool x, VBool y] -> Just $ return $ VLiteral (LBool (x && y))
+  _ -> Nothing
+
+evalOr :: MonadBasicNorm m => EvalBuiltin m
+evalOr = \case
+  [VBool x, VBool y] -> Just $ return $ VLiteral (LBool (x && y))
+  _ -> Nothing
+
+evalNeg :: MonadBasicNorm m => NegDomain -> EvalBuiltin m
+evalNeg = \case
+  NegInt -> evalNegInt
+  NegRat -> evalNegRat
+
+evalNegInt :: MonadBasicNorm m => EvalBuiltin m
+evalNegInt = \case
+  [VInt x] -> Just $ return $ VLiteral (LInt (-x))
+  _ -> Nothing
+
+evalNegRat :: MonadBasicNorm m => EvalBuiltin m
+evalNegRat = \case
+  [VRat x] -> Just $ return $ VLiteral (LRat (-x))
+  _ -> Nothing
+
+evalAdd :: MonadBasicNorm m => AddDomain -> EvalBuiltin m
+evalAdd = \case
+  AddNat -> evalAddNat
+  AddInt -> evalAddInt
+  AddRat -> evalAddRat
+
+evalAddNat :: MonadBasicNorm m => EvalBuiltin m
+evalAddNat = \case
+  [VNat x, VNat y] -> Just $ return $ VLiteral (LNat (x + y))
+  _ -> Nothing
+
+evalAddInt :: MonadBasicNorm m => EvalBuiltin m
+evalAddInt = \case
+  [VInt x, VInt y] -> Just $ return $ VLiteral (LInt (x + y))
+  _ -> Nothing
+
+evalAddRat :: MonadBasicNorm m => EvalBuiltin m
+evalAddRat = \case
+  [VRat x, VRat y] -> Just $ return $ VLiteral (LRat (x + y))
+  _ -> Nothing
+
+evalSub :: MonadBasicNorm m => SubDomain -> EvalBuiltin m
+evalSub = \case
+  SubInt -> evalSubInt
+  SubRat -> evalSubRat
+
+evalSubInt :: MonadBasicNorm m => EvalBuiltin m
+evalSubInt = \case
+  [VInt x, VInt y] -> Just $ return $ VLiteral (LInt (x - y))
+  _ -> Nothing
+
+evalSubRat :: MonadBasicNorm m => EvalBuiltin m
+evalSubRat = \case
+  [VRat x, VRat y] -> Just $ return $ VLiteral (LRat (x - y))
+  _ -> Nothing
+
+evalMul :: MonadBasicNorm m => MulDomain -> EvalBuiltin m
+evalMul = \case
+  MulNat -> evalMulNat
+  MulInt -> evalMulInt
+  MulRat -> evalMulRat
+
+evalMulNat :: MonadBasicNorm m => EvalBuiltin m
+evalMulNat = \case
+  [VNat x, VNat y] -> Just $ return $ VLiteral (LNat (x * y))
+  _ -> Nothing
+
+evalMulInt :: MonadBasicNorm m => EvalBuiltin m
+evalMulInt = \case
+  [VInt x, VInt y] -> Just $ return $ VLiteral (LInt (x * y))
+  _ -> Nothing
+
+evalMulRat :: MonadBasicNorm m => EvalBuiltin m
+evalMulRat = \case
+  [VRat x, VRat y] -> Just $ return $ VLiteral (LRat (x * y))
+  _ -> Nothing
+
+evalDiv :: MonadBasicNorm m => DivDomain -> EvalBuiltin m
+evalDiv = \case
+  DivRat -> evalDivRat
+
+evalDivRat :: MonadBasicNorm m => EvalBuiltin m
+evalDivRat = \case
+  [VRat x, VRat y] -> Just $ return $ VLiteral (LRat (x * y))
+  _ -> Nothing
+
+evalOrder :: MonadBasicNorm m => OrderDomain -> OrderOp -> EvalBuiltin m
+evalOrder = \case
+  OrderIndex -> evalOrderIndex
+  OrderNat -> evalOrderNat
+  OrderInt -> evalOrderInt
+  OrderRat -> evalOrderRat
+
+evalOrderIndex :: MonadBasicNorm m => OrderOp -> EvalBuiltin m
+evalOrderIndex op = \case
+  [VIndex x, VIndex y] -> Just $ return $ VLiteral (LBool (orderOp op x y))
+  _ -> Nothing
+
+evalOrderNat :: MonadBasicNorm m => OrderOp -> EvalBuiltin m
+evalOrderNat op = \case
+  [VNat x, VNat y] -> Just $ return $ VLiteral (LBool (orderOp op x y))
+  _ -> Nothing
+
+evalOrderInt :: MonadBasicNorm m => OrderOp -> EvalBuiltin m
+evalOrderInt op = \case
+  [VInt x, VInt y] -> Just $ return $ VLiteral (LBool (orderOp op x y))
+  _ -> Nothing
+
+evalOrderRat :: MonadBasicNorm m => OrderOp -> EvalBuiltin m
+evalOrderRat op = \case
+  [VRat x, VRat y] -> Just $ return $ VLiteral (LBool (orderOp op x y))
+  _ -> Nothing
+
+evalEquals :: MonadBasicNorm m => EqualityDomain -> EqualityOp -> EvalBuiltin m
+evalEquals = \case
+  EqIndex -> evalEqualityIndex
+  EqNat -> evalEqualityNat
+  EqInt -> evalEqualityInt
+  EqRat -> evalEqualityRat
+
+evalEqualityIndex :: MonadBasicNorm m => EqualityOp -> EvalBuiltin m
+evalEqualityIndex op = \case
+  [_, _, VIndex x, VIndex y] -> Just $ return $ VLiteral (LBool (equalityOp op x y))
+  _ -> Nothing
+
+evalEqualityNat :: MonadBasicNorm m => EqualityOp -> EvalBuiltin m
+evalEqualityNat op = \case
+  [VNat x, VNat y] -> Just $ return $ VLiteral (LBool (equalityOp op x y))
+  _ -> Nothing
+
+evalEqualityInt :: MonadBasicNorm m => EqualityOp -> EvalBuiltin m
+evalEqualityInt op = \case
+  [VInt x, VInt y] -> Just $ return $ VLiteral (LBool (equalityOp op x y))
+  _ -> Nothing
+
+evalEqualityRat :: MonadBasicNorm m => EqualityOp -> EvalBuiltin m
+evalEqualityRat op = \case
+  [VRat x, VRat y] -> Just $ return $ VLiteral (LBool (equalityOp op x y))
+  _ -> Nothing
+
+evalFromNat :: MonadBasicNorm m => FromNatDomain -> EvalBuiltin m
+evalFromNat = \case
+  FromNatToIndex -> evalFromNatToIndex
+  FromNatToNat -> evalFromNatToNat
+  FromNatToInt -> evalFromNatToInt
+  FromNatToRat -> evalFromNatToRat
+
+evalFromNatToIndex :: MonadBasicNorm m => EvalBuiltin m
+evalFromNatToIndex = \case
+  [ImplicitArg _ (VLiteral (LNat n)), VNat x] -> Just $ return $ VLiteral $ LIndex n x
+  _ -> Nothing
+
+evalFromNatToNat :: MonadBasicNorm m => EvalBuiltin m
+evalFromNatToNat = \case
+  [ExplicitArg _ x] -> Just $ return x
+  _ -> Nothing
+
+evalFromNatToInt :: MonadBasicNorm m => EvalBuiltin m
+evalFromNatToInt = \case
+  [VNat x] -> Just $ return $ VLiteral $ LInt x
+  _ -> Nothing
+
+evalFromNatToRat :: MonadBasicNorm m => EvalBuiltin m
+evalFromNatToRat = \case
+  [VNat x] -> Just $ return $ VLiteral $ LRat (fromIntegral x)
+  _ -> Nothing
+
+evalFromRat :: MonadBasicNorm m => FromRatDomain -> EvalBuiltin m
+evalFromRat = \case
+  FromRatToRat -> evalFromRatToRat
+
+evalFromRatToRat :: MonadBasicNorm m => EvalBuiltin m
+evalFromRatToRat = \case
+  [ExplicitArg _ x] -> Just $ return x
+  _ -> Nothing
+
+evalIf :: MonadBasicNorm m => EvalBuiltin m
+evalIf = \case
+  [_, VBool True, e1, _e2] -> Just $ return $ argExpr e1
+  [_, VBool False, _e1, e2] -> Just $ return $ argExpr e2
+  _ -> Nothing
+
+evalAt :: MonadBasicNorm m => EvalBuiltin m
+evalAt = \case
+  [_, _, ExplicitArg _ (VLVec es _), VIndex i] -> Just $ return $ es !! fromIntegral i
+  _ -> Nothing
+
+evalFold :: MonadBasicNorm m => FoldDomain -> EvalBuiltin m
+evalFold = \case
+  FoldList -> evalFoldList
+  FoldVector -> evalFoldVector
+
+evalFoldList :: MonadBasicNorm m => EvalBuiltin m
+evalFoldList = \case
+  [_, _, _f, e, ExplicitArg _ (VConstructor Nil [_])] ->
+    Just $ return $ argExpr e
+  [toT, fromT, f, e, ExplicitArg _ (VConstructor Cons [_, x, xs'])] -> Just $ do
+    r <- evalBuiltinFunction (Fold FoldList) [toT, fromT, f, e, xs']
+    evalApp (argExpr f) [x, ExplicitArg mempty r]
+  _ -> Nothing
+
+evalFoldVector :: MonadBasicNorm m => EvalBuiltin m
+evalFoldVector = \case
+  [_, _, _, f, e, ExplicitArg _ (VLVec v _)] ->
+    Just $
+      foldrM f' (argExpr e) v
+    where
+      f' x r = evalApp (argExpr f) [ExplicitArg mempty x, ExplicitArg mempty r]
+  _ -> Nothing
+
+evalForeach :: MonadBasicNorm m => EvalBuiltin m
+evalForeach = \case
+  [tRes, ImplicitArg _ (VLiteral (LNat n)), ExplicitArg _ f] -> Just $ do
+    let fn i = evalApp f [ExplicitArg mempty (VLiteral (LIndex n i))]
+    xs <- traverse fn [0 .. (n - 1 :: Int)]
+    return $ mkVLVec xs (argExpr tRes)
+  _ -> Nothing
+
+evalFromVec :: MonadBasicNorm m => FromVecDomain -> EvalBuiltin m
+evalFromVec = \case
+  FromVecToVec -> evalFromVecToVec
+  FromVecToList -> evalFromVecToList
+
+evalFromVecToList :: MonadBasicNorm m => EvalBuiltin m
+evalFromVecToList args = case args of
+  [tElem, ExplicitArg _ (VLVec xs _)] -> Just $ return $ mkVList (argExpr tElem) xs
+  _ -> Nothing
+
+evalFromVecToVec :: MonadBasicNorm m => EvalBuiltin m
+evalFromVecToVec = \case
+  [_, ExplicitArg _ e] -> Just $ return e
+  _ -> Nothing
+
+-----------------------------------------------------------------------------
+-- Derived
+
+type EvalDerived m = StandardSpine -> m StandardNormExpr
+
+-- TODO define in terms of language
+
+evalTypeClassOp :: MonadBasicNorm m => TypeClassOp -> EvalDerived m
+evalTypeClassOp _op args = do
+  let (inst, remainingArgs) = findInstanceArg args
+  evalApp inst remainingArgs
+
+evalImplies :: MonadBasicNorm m => EvalDerived m
+evalImplies = \case
+  [e1, e2] -> do
+    ne1 <- ExplicitArg mempty <$> evalBuiltinFunction Not [e1]
+    evalBuiltinFunction Or [ne1, e2]
+  args -> return $ VBuiltinFunction Implies args
+
+evalMap :: MonadBasicNorm m => MapDomain -> EvalDerived m
+evalMap = \case
+  MapList -> evalMapList
+  MapVector -> evalMapVec
+
+evalMapList :: MonadBasicNorm m => EvalDerived m
+evalMapList = \case
+  [_, tTo, _f, ExplicitArg _ (VConstructor Nil _)] ->
+    return $ VConstructor Nil [tTo]
+  [tFrom, tTo, f, ExplicitArg _ (VConstructor Cons [x, xs])] -> do
+    x' <- ExplicitArg mempty <$> evalApp (argExpr f) [x]
+    xs' <- ExplicitArg mempty <$> evalMapList [tFrom, tTo, f, xs]
+    return $ VConstructor Cons [tTo, x', xs']
+  args -> return $ VBuiltinFunction (Map MapList) args
+
+evalMapVec :: MonadBasicNorm m => EvalDerived m
+evalMapVec = \case
+  [_n, _t1, t2, ExplicitArg _ f, ExplicitArg _ (VLVec xs _)] -> do
+    xs' <- traverse (\x -> evalApp f [ExplicitArg mempty x]) xs
+    return $ mkVLVec xs' (argExpr t2)
+  args -> return $ VBuiltinFunction (Map MapVector) args
+
+-----------------------------------------------------------------------------
+-- Forcing
+
+forceStandardBuiltin :: MonadBasicNorm m => Builtin -> StandardSpine -> m (Maybe StandardNormExpr, MetaSet)
+forceStandardBuiltin b spine = case b of
+  Constructor {} -> return (Nothing, mempty)
+  BuiltinFunction Foreach -> return (Nothing, mempty)
+  TypeClassOp {} -> return (Nothing, mempty)
+  _ -> do
+    (argResults, argsReduced, argBlockingMetas) <- unzip3 <$> traverse forceArg spine
+    let anyArgsReduced = or argsReduced
+    let blockingMetas = MetaSet.unions argBlockingMetas
+    result <-
+      if not anyArgsReduced
+        then return Nothing
+        else do
+          Just <$> evalStandardBuiltin b argResults
+    return (result, blockingMetas)

--- a/vehicle/src/Vehicle/Compile/Type/VariableContext.hs
+++ b/vehicle/src/Vehicle/Compile/Type/VariableContext.hs
@@ -5,29 +5,30 @@ module Vehicle.Compile.Type.VariableContext where
 import Data.Map qualified as Map
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Meta.Map (MetaMap)
+import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
 -- Declaration context
 
-type MetaSubstitution = MetaMap GluedExpr
+type MetaSubstitution builtin = MetaMap (GluedExpr builtin)
 
-type DeclSubstitution = DeclCtx BasicNormExpr
+type DeclSubstitution builtin = DeclCtx (NormExpr builtin)
 
-type TypingDeclCtxEntry = (CheckedType, Maybe GluedExpr)
+type TypingDeclCtxEntry builtin = (DBType builtin, Maybe (GluedExpr builtin))
 
-type TypingDeclCtx = DeclCtx TypingDeclCtxEntry
+type TypingDeclCtx builtin = DeclCtx (TypingDeclCtxEntry builtin)
 
-toNormalisationDeclContext :: TypingDeclCtx -> DeclCtx CheckedExpr
+toNormalisationDeclContext :: TypingDeclCtx builtin -> DeclCtx (DBExpr builtin)
 toNormalisationDeclContext = Map.mapMaybe (fmap unnormalised . snd)
 
-toDeclCtxEntry :: TypedDecl -> TypingDeclCtxEntry
+toDeclCtxEntry :: TypedDecl builtin -> TypingDeclCtxEntry builtin
 toDeclCtxEntry decl = do
   let declType = unnormalised $ glued (typeOf decl)
   let declBody = fmap glued (bodyOf decl)
   (declType, declBody)
 
-addToDeclCtx :: TypedDecl -> TypingDeclCtx -> TypingDeclCtx
+addToDeclCtx :: TypedDecl builtin -> TypingDeclCtx builtin -> TypingDeclCtx builtin
 addToDeclCtx decl = Map.insert (identifierOf decl) (toDeclCtxEntry decl)
 
 --------------------------------------------------------------------------------
@@ -35,12 +36,12 @@ addToDeclCtx decl = Map.insert (identifierOf decl) (toDeclCtxEntry decl)
 
 -- | The names, types and values if known of the variables that are in
 -- currently in scope, indexed into via De Bruijn expressions.
-type TypingBoundCtxEntry = (Maybe Name, CheckedType, Maybe CheckedExpr)
+type TypingBoundCtxEntry builtin = (Maybe Name, DBType builtin, Maybe (DBExpr builtin))
 
-mkTypingBoundCtxEntry :: CheckedBinder -> TypingBoundCtxEntry
+mkTypingBoundCtxEntry :: DBBinder builtin -> TypingBoundCtxEntry builtin
 mkTypingBoundCtxEntry binder = (nameOf binder, binderType binder, Nothing)
 
-type TypingBoundCtx = BoundCtx TypingBoundCtxEntry
+type TypingBoundCtx builtin = BoundCtx (TypingBoundCtxEntry builtin)
 
-instance HasBoundCtx TypingBoundCtx where
+instance HasBoundCtx (TypingBoundCtx builtin) where
   boundContextOf = map (\(n, _, _) -> n)

--- a/vehicle/src/Vehicle/Expr/AlphaEquivalence.hs
+++ b/vehicle/src/Vehicle/Expr/AlphaEquivalence.hs
@@ -7,20 +7,20 @@ where
 
 import Data.Hashable (Hashable (..))
 import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.CoDeBruijn
 import Vehicle.Expr.CoDeBruijn.Conversion
-import Vehicle.Expr.Normalised
 
-instance Hashable CheckedArg
+instance Hashable TypeCheckedArg
 
-instance Hashable CheckedExpr where
+instance Hashable TypeCheckedExpr where
   hashWithSalt s e = hashWithSalt s (toCoDBExpr e)
 
-instance Hashable BasicNormArg
+instance Hashable StandardNormArg
 
-instance Hashable BasicNormBinder
+instance Hashable StandardNormBinder
 
-instance Hashable BasicNormExpr
+instance Hashable StandardNormExpr
 
 class AlphaEquivalence a where
   alphaEq :: a -> a -> Bool
@@ -28,5 +28,5 @@ class AlphaEquivalence a where
 instance AlphaEquivalence CoDBExpr where
   alphaEq e1 e2 = hash e1 == hash e2
 
-instance AlphaEquivalence CheckedExpr where
+instance AlphaEquivalence TypeCheckedExpr where
   alphaEq e1 e2 = hash e1 == hash e2

--- a/vehicle/src/Vehicle/Expr/CoDeBruijn/Conversion.hs
+++ b/vehicle/src/Vehicle/Expr/CoDeBruijn/Conversion.hs
@@ -19,7 +19,7 @@ import Vehicle.Expr.DeBruijn as DB
 --------------------------------------------------------------------------------
 -- Forwards direction
 
-toCoDBExpr :: CheckedExpr -> CoDBExpr
+toCoDBExpr :: TypeCheckedExpr -> CoDBExpr
 toCoDBExpr = cata $ \case
   UniverseF p l -> (Universe p l, mempty)
   HoleF p n -> (Hole p n, mempty)
@@ -60,7 +60,7 @@ toCoDBBinder binder mpt =
 --------------------------------------------------------------------------------
 -- Backwards
 
-fromCoDB :: CoDBExpr -> CheckedExpr
+fromCoDB :: CoDBExpr -> TypeCheckedExpr
 fromCoDB expr = case recCoDB expr of
   UniverseC p l -> Universe p l
   HoleC p n -> Hole p n
@@ -75,9 +75,9 @@ fromCoDB expr = case recCoDB expr of
   LetC p bound binder body -> Let p (fromCoDB bound) (fromCoDBBinder binder) (fromCoDB body)
   LamC p binder body -> Lam p (fromCoDBBinder binder) (fromCoDB body)
 
-fromCoDBBinder :: RecCoDB a BinderC => a -> CheckedBinder
+fromCoDBBinder :: RecCoDB a BinderC => a -> TypeCheckedBinder
 fromCoDBBinder binder = case recCoDB binder of
   Binder p u v r (CoDBBinding _) t -> Binder p u v r () $ fromCoDB t
 
-fromCoDBArg :: RecCoDB a ArgC => a -> CheckedArg
+fromCoDBArg :: RecCoDB a ArgC => a -> TypeCheckedArg
 fromCoDBArg arg = fromCoDB <$> recCoDB arg

--- a/vehicle/src/Vehicle/Expr/DSL.hs
+++ b/vehicle/src/Vehicle/Expr/DSL.hs
@@ -63,9 +63,7 @@ module Vehicle.Expr.DSL
     negPolarity,
     eqPolarity,
     natLit,
-    tMax,
     tHole,
-    piType,
     nil,
     cons,
     unquantified,
@@ -94,10 +92,10 @@ class DSL expr where
   free :: Identifier -> expr
 
 newtype DSLExpr = DSL
-  { unDSL :: Provenance -> DBLevel -> CheckedExpr
+  { unDSL :: Provenance -> DBLevel -> TypeCheckedExpr
   }
 
-fromDSL :: Provenance -> DSLExpr -> CheckedExpr
+fromDSL :: Provenance -> DSLExpr -> TypeCheckedExpr
 fromDSL p e = unDSL e p 0
 
 boundVar :: DBLevel -> DSLExpr
@@ -142,21 +140,6 @@ instance DSL DSLExpr where
 
   free ident = DSL $ \p _i ->
     FreeVar p ident
-
-piType :: CheckedExpr -> CheckedExpr -> CheckedExpr
-piType t1 t2 = t1 `tMax` t2
-
-universeLevel :: CheckedExpr -> UniverseLevel
-universeLevel (Universe _ (TypeUniv l)) = l
-universeLevel (Meta _ _) = 0 -- This is probably going to bite us, apologies.
-universeLevel (App _ (Meta _ _) _) = 0 -- This is probably going to bite us, apologies.
-universeLevel (Pi _ _ r) = universeLevel r -- This is probably going to bite us, apologies.
-universeLevel t =
-  developerError $
-    "Expected argument of type Type. Found" <+> pretty (show t) <> "."
-
-tMax :: CheckedExpr -> CheckedExpr -> CheckedExpr
-tMax t1 t2 = if universeLevel t1 > universeLevel t2 then t1 else t2
 
 builtin :: Builtin -> DSLExpr
 builtin b = DSL $ \p _ -> Builtin p b

--- a/vehicle/src/Vehicle/Expr/DeBruijn.hs
+++ b/vehicle/src/Vehicle/Expr/DeBruijn.hs
@@ -9,9 +9,11 @@ module Vehicle.Expr.DeBruijn
     DBLevelVar,
     DBBinder,
     DBArg,
+    DBType,
     DBExpr,
     DBDecl,
     DBProg,
+    DBTelescope,
     Substitution,
     substituteDB,
     substDBInto,
@@ -114,11 +116,15 @@ type DBBinder builtin = Binder DBBinding DBIndexVar builtin
 
 type DBArg builtin = Arg DBBinding DBIndexVar builtin
 
+type DBType builtin = DBExpr builtin
+
 type DBExpr builtin = Expr DBBinding DBIndexVar builtin
 
 type DBDecl builtin = Decl DBBinding DBIndexVar builtin
 
 type DBProg builtin = Prog DBBinding DBIndexVar builtin
+
+type DBTelescope builtin = [DBBinder builtin]
 
 --------------------------------------------------------------------------------
 -- Substitution

--- a/vehicle/src/Vehicle/Expr/Patterns.hs
+++ b/vehicle/src/Vehicle/Expr/Patterns.hs
@@ -9,13 +9,13 @@ import Vehicle.Syntax.AST
 -- Universes
 --------------------------------------------------------------------------------
 
-pattern TypeUniverse :: Provenance -> UniverseLevel -> Expr binder var Builtin
+pattern TypeUniverse :: Provenance -> UniverseLevel -> Expr binder var builtin
 pattern TypeUniverse p l = Universe p (TypeUniv l)
 
-pattern LinearityUniverse :: Provenance -> Expr binder var Builtin
+pattern LinearityUniverse :: Provenance -> Expr binder var builtin
 pattern LinearityUniverse p = Universe p LinearityUniv
 
-pattern PolarityUniverse :: Provenance -> Expr binder var Builtin
+pattern PolarityUniverse :: Provenance -> Expr binder var builtin
 pattern PolarityUniverse p = Universe p PolarityUniv
 
 --------------------------------------------------------------------------------
@@ -34,9 +34,9 @@ pattern BoundVar p index = Var p (Bound index)
 
 pattern BuiltinExpr ::
   Provenance ->
-  Builtin ->
-  NonEmpty (Arg binder var Builtin) ->
-  Expr binder var Builtin
+  builtin ->
+  NonEmpty (Arg binder var builtin) ->
+  Expr binder var builtin
 pattern BuiltinExpr p b args <- App p (Builtin _ b) args
   where
     BuiltinExpr p b args = App p (Builtin p b) args
@@ -329,29 +329,29 @@ pattern HasEqExpr p eq arg1Type arg2Type resType <-
 -- Literals
 --------------------------------------------------------------------------------
 
-pattern UnitLiteral :: Provenance -> Expr binder var Builtin
+pattern UnitLiteral :: Provenance -> Expr binder var builtin
 pattern UnitLiteral p = Literal p LUnit
 
-pattern BoolLiteral :: Provenance -> Bool -> Expr binder var Builtin
+pattern BoolLiteral :: Provenance -> Bool -> Expr binder var builtin
 pattern BoolLiteral p n = Literal p (LBool n)
 
-pattern IndexLiteral :: Provenance -> Int -> Int -> Expr binder var Builtin
+pattern IndexLiteral :: Provenance -> Int -> Int -> Expr binder var builtin
 pattern IndexLiteral p n x = Literal p (LIndex n x)
 
-pattern NatLiteral :: Provenance -> Int -> Expr binder var Builtin
+pattern NatLiteral :: Provenance -> Int -> Expr binder var builtin
 pattern NatLiteral p n = Literal p (LNat n)
 
-pattern IntLiteral :: Provenance -> Int -> Expr binder var Builtin
+pattern IntLiteral :: Provenance -> Int -> Expr binder var builtin
 pattern IntLiteral p n = Literal p (LInt n)
 
-pattern RatLiteral :: Provenance -> Rational -> Expr binder var Builtin
+pattern RatLiteral :: Provenance -> Rational -> Expr binder var builtin
 pattern RatLiteral p n = Literal p (LRat n)
 
 pattern VecLiteral ::
   Provenance ->
-  Expr binder var Builtin ->
-  [Expr binder var Builtin] ->
-  Expr binder var Builtin
+  Expr binder var builtin ->
+  [Expr binder var builtin] ->
+  Expr binder var builtin
 pattern VecLiteral p tElem xs <- App p (LVec _ xs) [ImplicitArg _ tElem]
 
 -- | During type-checking VecLiterals may have an extra irrelevant instance argument
@@ -363,10 +363,10 @@ pattern AnnVecLiteral ::
   Expr binder var Builtin
 pattern AnnVecLiteral p tElem xs <- App p (LVec _ xs) (ImplicitArg _ tElem :| _)
 
-pattern TrueExpr :: Provenance -> Expr binder var Builtin
+pattern TrueExpr :: Provenance -> Expr binder var builtin
 pattern TrueExpr p = BoolLiteral p True
 
-pattern FalseExpr :: Provenance -> Expr binder var Builtin
+pattern FalseExpr :: Provenance -> Expr binder var builtin
 pattern FalseExpr p = BoolLiteral p False
 
 --------------------------------------------------------------------------------

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Common.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Common.hs
@@ -3,7 +3,7 @@
 module Vehicle.Test.Unit.Common where
 
 import Control.Monad.Except (ExceptT)
-import Data.Data (Proxy (Proxy))
+import Data.Data (Proxy (..))
 import Data.Functor.Foldable (Recursive (cata))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Tagged (Tagged (Tagged))
@@ -21,10 +21,10 @@ import Vehicle.Compile.Error.Message
 import Vehicle.Compile.Normalise (nfTypeClassOp)
 import Vehicle.Compile.Prelude
   ( Builtin (TypeClassOp),
-    CheckedExpr,
     Expr (..),
     ExprF (..),
     LoggingLevel,
+    TypeCheckedExpr,
     normApp,
   )
 import Vehicle.Prelude
@@ -70,7 +70,7 @@ unitTestCase testName errorOrAssertionWithLogs =
         Left x -> developerError $ pretty $ details x
         Right y -> y
 
-normTypeClasses :: MonadCompile m => CheckedExpr -> m CheckedExpr
+normTypeClasses :: MonadCompile m => TypeCheckedExpr -> m TypeCheckedExpr
 normTypeClasses = cata $ \case
   AppF p fun args -> do
     fun' <- fun

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/DeBruijn.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/DeBruijn.hs
@@ -6,14 +6,14 @@ import Vehicle.Compile.Prelude
   ( BinderDisplayForm (BinderDisplayForm),
     BinderNamingForm (OnlyName),
     Builtin,
-    CheckedBinder,
-    CheckedExpr,
-    CheckedType,
     Expr (Lam),
     GenericBinder (Binder),
     Pretty (pretty),
     Provenance,
     Relevance (Relevant),
+    TypeCheckedBinder,
+    TypeCheckedExpr,
+    TypeCheckedType,
     Visibility (Explicit),
     indent,
     layoutAsString,
@@ -91,8 +91,8 @@ liftingTests =
 data SubstitutionTest = SubstitutionTest
   { name :: String,
     value :: DBExpr Builtin,
-    expr :: CheckedExpr,
-    expected :: CheckedExpr
+    expr :: TypeCheckedExpr,
+    expected :: TypeCheckedExpr
   }
 
 substTest :: SubstitutionTest -> TestTree
@@ -126,8 +126,8 @@ substTest SubstitutionTest {..} =
 data LiftingTest = LiftingTest
   { name :: String,
     amount :: DBLevel,
-    input :: CheckedExpr,
-    expected :: CheckedExpr
+    input :: TypeCheckedExpr,
+    expected :: TypeCheckedExpr
   }
 
 liftTest :: LiftingTest -> TestTree
@@ -156,5 +156,5 @@ liftTest LiftingTest {..} =
 p :: Provenance
 p = mempty
 
-binding :: CheckedType -> CheckedBinder
+binding :: TypeCheckedType -> TypeCheckedBinder
 binding = Binder p (BinderDisplayForm (OnlyName "x") False) Explicit Relevant ()

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -5,10 +5,11 @@ where
 
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool)
-import Vehicle.Compile.Normalise.NBE (whnf)
+import Vehicle.Compile.Normalise.NBE (runEmptyNormT, whnf)
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
+import Vehicle.Compile.Type.Subsystem.Standard ()
 import Vehicle.Expr.AlphaEquivalence ()
 import Vehicle.Expr.DeBruijn (DBLevel)
 import Vehicle.Test.Unit.Common (unitTestCase)
@@ -56,14 +57,14 @@ normalisationTests =
 data NBETest = NBETest
   { name :: String,
     dbLevel :: DBLevel,
-    input :: CheckedExpr,
-    expected :: CheckedExpr
+    input :: TypeCheckedExpr,
+    expected :: TypeCheckedExpr
   }
 
 normalisationTest :: NBETest -> TestTree
 normalisationTest NBETest {..} =
   unitTestCase ("normalise" <> name) $ do
-    normInput <- whnf dbLevel mempty mempty input
+    normInput <- runEmptyNormT @Builtin $ whnf dbLevel input
     actual <- quote mempty dbLevel normInput
 
     let errorMessage =
@@ -85,5 +86,5 @@ normalisationTest NBETest {..} =
 p :: Provenance
 p = mempty
 
-binding :: CheckedType -> CheckedBinder
+binding :: TypeCheckedType -> TypeCheckedBinder
 binding = Binder p (BinderDisplayForm (OnlyName "x") False) Explicit Relevant ()

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -130,6 +130,7 @@ library
     Vehicle.Compile.Scope
     Vehicle.Compile.Simplify
     Vehicle.Compile.Type
+    Vehicle.Compile.Type.Subsystem.Standard
     Vehicle.Export
     Vehicle.Expr.AlphaEquivalence
     Vehicle.Expr.Boolean
@@ -171,16 +172,10 @@ library
     Vehicle.Compile.Queries
     Vehicle.Compile.Type.Auxiliary
     Vehicle.Compile.Type.Bidirectional
-    Vehicle.Compile.Type.Builtin
     Vehicle.Compile.Type.Constraint
     Vehicle.Compile.Type.Constraint.Core
-    Vehicle.Compile.Type.Constraint.InstanceBuiltins
-    Vehicle.Compile.Type.Constraint.InstanceSolver
-    Vehicle.Compile.Type.Constraint.LinearitySolver
-    Vehicle.Compile.Type.Constraint.PolaritySolver
-    Vehicle.Compile.Type.Constraint.TypeClassDefaults
-    Vehicle.Compile.Type.Constraint.TypeClassSolver
     Vehicle.Compile.Type.Constraint.UnificationSolver
+    Vehicle.Compile.Type.Core
     Vehicle.Compile.Type.Generalise
     Vehicle.Compile.Type.Irrelevance
     Vehicle.Compile.Type.Meta
@@ -191,7 +186,18 @@ library
     Vehicle.Compile.Type.Monad
     Vehicle.Compile.Type.Monad.Class
     Vehicle.Compile.Type.Monad.Instance
-    Vehicle.Compile.Type.Resource
+    Vehicle.Compile.Type.Subsystem
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.Core
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceBuiltins
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceSolver
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.LinearitySolver
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.PolaritySolver
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.TypeClassDefaults
+    Vehicle.Compile.Type.Subsystem.Standard.Constraint.TypeClassSolver
+    Vehicle.Compile.Type.Subsystem.Standard.Core
+    Vehicle.Compile.Type.Subsystem.Standard.Normalisation
+    Vehicle.Compile.Type.Subsystem.Standard.Type
+    Vehicle.Compile.Type.Subsystem.Standard.TypeResource
     Vehicle.Compile.Type.VariableContext
     Vehicle.Debug
     Vehicle.Prelude.IO


### PR DESCRIPTION
This PR parameterises the type-checker itself by a typing subsystem that dictates how the builtins are typed. While this temporarily adds more code, it should allow the separation of the linearity and polarity type systems in the next PR which will drastically simplify things.