### PR TITLE
Cache the results of Gaussian elimination to avoid re-solving the same equations repeatedly

### DIFF
--- a/vehicle/src/Vehicle/Compile/Queries/FourierMotzkinElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/FourierMotzkinElimination.hs
@@ -27,7 +27,7 @@ fourierMotzkinElimination ::
   [Assertion linexp] ->
   m ([Solution], [Assertion linexp])
 fourierMotzkinElimination varNames varsToSolve assertions =
-  logCompilerPass MinDetail currentPass $ do
+  logCompilerPass MidDetail currentPass $ do
     logDebug MaxDetail $ prettyAssertions varNames assertions
     let numberedVars = zip [1 ..] (Set.toList varsToSolve)
     foldM (solveVar varNames) ([], assertions) numberedVars

--- a/vehicle/src/Vehicle/Compile/Queries/GaussianElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/GaussianElimination.hs
@@ -23,7 +23,7 @@ gaussianElimination ::
   Int ->
   m ([(LinearVar, GaussianVariableSolution)], [linexp])
 gaussianElimination varNames exprs numberOfRowsToReduce =
-  logCompilerPass MinDetail currentPhase $ do
+  logCompilerPass MidDetail currentPhase $ do
     logDebug MaxDetail $ prettyExprs varNames exprs
     let maxIterations = min (length exprs) numberOfRowsToReduce
     let iterations :: [Int] = [0 .. maxIterations - 1]

--- a/vehicle/src/Vehicle/Compile/Queries/LinearExpr.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearExpr.hs
@@ -29,6 +29,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Bifunctor (Bifunctor (..))
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HashMap
+import Data.Hashable (Hashable)
 import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe)
@@ -49,6 +50,8 @@ data Relation
   | LessThan
   | LessThanOrEqualTo
   deriving (Show, Eq, Generic)
+
+instance Hashable Relation
 
 instance ToJSON Relation
 
@@ -148,11 +151,13 @@ data SparseLinearExpr = Sparse
     coefficients :: HashMap LinearVar Coefficient,
     constantValue :: Coefficient
   }
-  deriving (Show, Generic)
+  deriving (Show, Eq, Generic)
 
 instance ToJSON SparseLinearExpr
 
 instance FromJSON SparseLinearExpr
+
+instance Hashable SparseLinearExpr
 
 instance LinearExpression SparseLinearExpr where
   addExprs ::
@@ -282,7 +287,9 @@ data Assertion linexp = Assertion
     assertionRel :: Relation,
     assertionExpr :: linexp
   }
-  deriving (Show, Functor, Generic)
+  deriving (Show, Eq, Functor, Generic)
+
+instance (Hashable linexp) => Hashable (Assertion linexp)
 
 instance (ToJSON linexp) => ToJSON (Assertion linexp)
 

--- a/vehicle/src/Vehicle/Prelude/Supply.hs
+++ b/vehicle/src/Vehicle/Prelude/Supply.hs
@@ -58,3 +58,7 @@ instance (MonadError e m) => MonadError e (SupplyT s m) where
 instance (MonadReader e m) => MonadReader e (SupplyT s m) where
   ask = lift ask
   local f x = SupplyT $ local f $ unsupplyT x
+
+instance (MonadState e m) => MonadState e (SupplyT s m) where
+  get = lift get
+  put = lift . put


### PR DESCRIPTION
Partially addresses #479. Performance speed up of approximately ~40% on MNIST-robustness spec but will get progressively larger the more output classes you have.