### PR TITLE
Implemented object file versioning and general versioning improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,9 @@
 
 * Fixed erroneous evaluation of when dividing two rationals together.
 
+* Fixed bug where the compiler would sometimes hang when reading `.vclo` files created with an
+  older version of Vehicle.
+
 ## Version 0.2.0
 
 ### General enhancements

--- a/py-vehicle-lang-tensorflow/pyproject.toml
+++ b/py-vehicle-lang-tensorflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vehicle_lang_tensorflow"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python bindings for the Vehicle language."
 authors = [
   { name = "Marco Casadio", email = "tgl70@users.noreply.github.com" },
@@ -14,7 +14,7 @@ license = { file = 'LICENSE' }
 readme = "README.md"
 requires-python = ">=3.8,<3.12"
 dependencies = [
-  "vehicle_lang>=0.2.0a4",
+  "vehicle_lang>=0.3.0a4",
   # TODO: lowest possible tensorflow bound?
   "tensorflow>=2.11",
   # TODO: lowest possible numpy bound?

--- a/py-vehicle-lang-tensorflow/pyproject.toml
+++ b/py-vehicle-lang-tensorflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vehicle_lang_tensorflow"
-version = "0.3.0"
+version = "0.2.0"
 description = "Python bindings for the Vehicle language."
 authors = [
   { name = "Marco Casadio", email = "tgl70@users.noreply.github.com" },
@@ -14,7 +14,7 @@ license = { file = 'LICENSE' }
 readme = "README.md"
 requires-python = ">=3.8,<3.12"
 dependencies = [
-  "vehicle_lang>=0.3.0a4",
+  "vehicle_lang>=0.2.0a4",
   # TODO: lowest possible tensorflow bound?
   "tensorflow>=2.11",
   # TODO: lowest possible numpy bound?

--- a/py-vehicle-lang/src/vehicle_lang/_version.py
+++ b/py-vehicle-lang/src/vehicle_lang/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.3.0a4"
+VERSION: str = "0.3.0"

--- a/py-vehicle-lang/src/vehicle_lang/_version.py
+++ b/py-vehicle-lang/src/vehicle_lang/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.2.0a4"
+VERSION: str = "0.3.0a4"

--- a/py-vehicle-lang/vehicle-python-binding.cabal
+++ b/py-vehicle-lang/vehicle-python-binding.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            vehicle-python-binding
-version:         0.2.0
+version:         0.3.0
 description:
   Please see the README on GitHub at <https://github.com/wenkokke/vehicle#readme>
 

--- a/vehicle-syntax/vehicle-syntax.cabal
+++ b/vehicle-syntax/vehicle-syntax.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               vehicle-syntax
-version:            0.2.0
+version:            0.3.0
 description:
   Please see the README on GitHub at <https://github.com/vehicle-lang/vehicle#readme>
 

--- a/vehicle/src/Vehicle.hs
+++ b/vehicle/src/Vehicle.hs
@@ -7,7 +7,6 @@ module Vehicle
 where
 
 import Control.Exception (bracket, handle)
-import Data.Version (showVersion)
 import GHC.IO.Encoding (setLocaleEncoding)
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import Options.Applicative (ParserInfo, defaultPrefs, execParserPure, handleParseResult)
@@ -49,7 +48,7 @@ runVehicle Options {..} = do
   redirections globalOptions $ \ioSettings -> do
     -- Handle --version
     if version globalOptions
-      then putStrLn $ showVersion vehicleVersion
+      then putStrLn preciseVehicleVersion
       else case modeOptions of
         Nothing ->
           fatalError

--- a/vehicle/src/Vehicle/Backend/Prelude.hs
+++ b/vehicle/src/Vehicle/Backend/Prelude.hs
@@ -2,7 +2,6 @@ module Vehicle.Backend.Prelude where
 
 import Control.Monad.IO.Class
 import Data.Text.IO qualified as TIO
-import Paths_vehicle qualified as VehiclePath
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
 import Vehicle.Prelude
@@ -92,7 +91,7 @@ prependfileHeader doc format = case format of
             "and should not be modified manually!",
             "Metadata:",
             " -" <+> formatName <> " version:" <+> targetVersion,
-            " - Vehicle version:" <+> pretty VehiclePath.version
+            " - Vehicle version:" <+> pretty impreciseVehicleVersion
           ]
       )
       <> line

--- a/vehicle/src/Vehicle/Compile/ObjectFile.hs
+++ b/vehicle/src/Vehicle/Compile/ObjectFile.hs
@@ -4,19 +4,17 @@ module Vehicle.Compile.ObjectFile
   )
 where
 
-import Control.Exception
 import Control.Monad.IO.Class
-import Data.ByteString qualified as BIO
 import Data.Hashable (Hashable (..))
-import Data.Serialize (Serialize, decode, encode)
+import Data.Serialize (Serialize)
 import GHC.Generics (Generic)
 import System.FilePath (dropExtension)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Subsystem.Standard
 
 data ObjectFileContents = ObjectFileContents
-  { _fileHash :: Int,
-    _typeResult :: StandardGluedProg
+  { fileHash :: Int,
+    typeResult :: StandardGluedProg
   }
   deriving (Generic)
 
@@ -33,24 +31,42 @@ readObjectFile ::
   m (Maybe StandardGluedProg)
 readObjectFile specificationFile spec = do
   let interfaceFile = getObjectFileFromSpecificationFile specificationFile
-  errorOrContents <- liftIO $ do
-    (Right <$> BIO.readFile interfaceFile) `catch` \(e :: IOException) -> return (Left e)
+  errorOrContents <- readAndDecodeVersioned interfaceFile
 
+  let errString = "Unable to restore interface file" <+> quotePretty specificationFile
   case errorOrContents of
-    Left _error -> do
-      logDebug MinDetail $ "No interface file found for" <+> quotePretty specificationFile
+    IOError err -> do
+      logDebug MinDetail $
+        errString
+          <+> "as the following IO error was thrown:"
+            <> line
+            <> indent 2 (pretty $ show err)
       return Nothing
-    Right contents -> case decode contents of
-      Left _ -> do
-        logDebug MinDetail $ "Unable to restore found interface file for" <+> quotePretty specificationFile
-        return Nothing
-      Right (ObjectFileContents specHash result)
-        | specHash /= hash spec -> do
-            logDebug MinDetail $ "Outdated interface file found for" <+> quotePretty specificationFile
-            return Nothing
-        | otherwise -> do
-            logDebug MinDetail $ "Loaded interface file for" <+> quotePretty specificationFile
-            return $ Just result
+    InexplicableDecodingError err -> do
+      logDebug MinDetail $
+        errString
+          <+> "as it was unreadable for the unexpected reason:"
+            <> line
+            <> indent 2 (pretty err)
+      return Nothing
+    VersionMismatchError currentVersion writtenVersion err -> do
+      logDebug MinDetail $
+        errString
+          <+> "as it was written with Vehicle version"
+          <+> pretty writtenVersion
+          <+> "which is apparently unreadable with the current Vehicle version"
+          <+> pretty currentVersion <> "."
+          <+> "In particular decoding threw the error:"
+            <> line
+            <> indent 2 (pretty err)
+      return Nothing
+    SuccessfulDecoding ObjectFileContents {..}
+      | fileHash /= hash spec -> do
+          logDebug MinDetail $ "Outdated interface file found for" <+> quotePretty specificationFile
+          return Nothing
+      | otherwise -> do
+          logDebug MinDetail $ "Loaded interface file for" <+> quotePretty specificationFile
+          return $ Just typeResult
 
 writeObjectFile ::
   (MonadIO m) =>
@@ -62,4 +78,4 @@ writeObjectFile specificationFile spec result = do
   let interfaceFile = getObjectFileFromSpecificationFile specificationFile
   let specHash = hash spec
   let contents = ObjectFileContents specHash result
-  liftIO $ BIO.writeFile interfaceFile (encode contents)
+  encodeAndWriteVersioned interfaceFile contents

--- a/vehicle/src/Vehicle/Libraries.hs
+++ b/vehicle/src/Vehicle/Libraries.hs
@@ -14,7 +14,6 @@ import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString.Lazy qualified as BIO
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
-import Data.Version (Version)
 import GHC.Generics (Generic)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((<.>), (</>))
@@ -24,7 +23,7 @@ type LibraryName = String
 
 data LibraryInfo = LibraryInfo
   { libraryName :: LibraryName,
-    libraryVersion :: Version
+    libraryVersion :: VersionString
   }
   deriving (Generic)
 

--- a/vehicle/src/Vehicle/Libraries/StandardLibrary.hs
+++ b/vehicle/src/Vehicle/Libraries/StandardLibrary.hs
@@ -14,9 +14,8 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (pack)
 import Data.Text.Encoding (decodeUtf8)
-import Paths_vehicle (version)
-import Prettyprinter (Pretty (..))
 import Vehicle.Libraries
+import Vehicle.Prelude
 import Vehicle.Syntax.AST
 
 standardLibraryContentBS :: ByteString
@@ -28,7 +27,7 @@ standardLibrary =
     { libraryInfo =
         LibraryInfo
           { libraryName = "std",
-            libraryVersion = version
+            libraryVersion = preciseVehicleVersion
           },
       libraryContent = decodeUtf8 standardLibraryContentBS
     }

--- a/vehicle/src/Vehicle/Prelude.hs
+++ b/vehicle/src/Vehicle/Prelude.hs
@@ -8,4 +8,5 @@ import Vehicle.Prelude.Logging as X
 import Vehicle.Prelude.Misc as X
 import Vehicle.Prelude.Prettyprinter as X
 import Vehicle.Prelude.Supply as X
+import Vehicle.Prelude.Version as X
 import Vehicle.Syntax.Prelude as X

--- a/vehicle/src/Vehicle/Prelude/Misc.hs
+++ b/vehicle/src/Vehicle/Prelude/Misc.hs
@@ -14,13 +14,8 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Version (Version)
-import Paths_vehicle qualified as Cabal (version)
 import Vehicle.Prelude.Prettyprinter (Pretty (pretty))
 import Vehicle.Syntax.AST
-
-vehicleVersion :: Version
-vehicleVersion = Cabal.version
 
 data VehicleLang = External | Internal
   deriving (Show)

--- a/vehicle/src/Vehicle/Prelude/Version.hs
+++ b/vehicle/src/Vehicle/Prelude/Version.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module Vehicle.Prelude.Version
+  ( VersionString,
+    preciseVehicleVersion,
+    impreciseVehicleVersion,
+    DecodeResult (..),
+    encodeAndWriteVersioned,
+    readAndDecodeVersioned,
+  )
+where
+
+import Control.Exception (IOException, catch)
+import Control.Monad.Trans (MonadIO (..))
+import Data.ByteString qualified as BIO
+import Data.Serialize (Serialize, decode, encode)
+import Data.Version (showVersion)
+import Development.GitRev
+import GHC.Generics (Generic)
+import Paths_vehicle qualified as Cabal (version)
+import System.Timeout (timeout)
+
+--------------------------------------------------------------------------------
+-- Current versions
+
+-- | The imprecise current version of Vehicle. This can be used whenever the
+-- precise version doesn't really matters. This is used when writing out the
+-- Vehicle version number at the top of compiled files for example, and avoids
+-- the golden file tests from complaining every time we make a fresh commit.
+--
+-- This uses Template Haskell to append `dev` to the version in the Cabal file
+-- for all builds, unless the flag `release-build` is set in the Cabal file.
+impreciseVehicleVersion :: String
+impreciseVehicleVersion = showVersion Cabal.version
+#if releaseBuild
+#else
+  <> "-dev"
+#endif
+
+-- | The precise current version of Vehicle. This should be used whenever the
+-- exact version really matters, e.g. serialisation compatability.
+--
+-- This uses Template Haskell to append the github commit to the version in
+-- the Cabal file for all builds, unless the flag `release-build` is set in the
+-- Cabal file.
+preciseVehicleVersion :: String
+preciseVehicleVersion = showVersion Cabal.version
+#if releaseBuild
+#else
+  <> maybe "" ("-" ++) commitInfo
+  where
+  -- Taken from src/full/Agda/VersionCommit.hs
+  commitInfo :: Maybe String
+  commitInfo
+    | hash == "UNKNOWN" = Nothing
+    | otherwise         = Just $ abbrev hash ++ dirty
+    where
+      hash = $(gitHash)
+
+      -- Check if any tracked files have uncommitted changes
+      dirty | $(gitDirtyTracked) = "-dirty"
+            | otherwise          = ""
+
+      -- Abbreviate a commit hash while keeping it unambiguous
+      abbrev = take 7
+#endif
+
+--------------------------------------------------------------------------------
+-- Versioned objects
+
+-- | Encodes a serialisable object along with the precise version of Vehicle
+-- that was used. This version includes the commit hash.
+encodeAndWriteVersioned :: (MonadIO m, Serialize a) => FilePath -> a -> m ()
+encodeAndWriteVersioned filepath payload = do
+  let encodedPayload = encode payload
+  let versionedPayload = Versioned preciseVehicleVersion encodedPayload
+  let encodedVersionedPayload = encode versionedPayload
+  liftIO $ BIO.writeFile filepath encodedVersionedPayload
+
+-- | Attempts to deserialise a file that was encoded with `encodeAndWriteVersioned`.
+readAndDecodeVersioned :: (MonadIO m, Serialize a) => FilePath -> m (DecodeResult a)
+readAndDecodeVersioned filepath = do
+  errorOrContents <- liftIO $ do
+    (Right <$> BIO.readFile filepath) `catch` \(e :: IOException) -> return (Left e)
+
+  case errorOrContents of
+    Left err -> return $ IOError err
+    Right bytestring -> case decode bytestring of
+      Left err -> return $ InexplicableDecodingError err
+      Right Versioned {..} -> do
+        -- The version is always potentially out of sync if the Github repo is
+        -- in a dirty state
+        let isOutOfSync = $(gitDirtyTracked) || version /= preciseVehicleVersion
+        if isOutOfSync
+          then do
+            -- If we are out of sync then we still try to restore the payload but
+            -- we need to attach a timeout to it as unfortunately the deserializer
+            -- can potentially loop reading malformed data.
+            maybeResult <- liftIO $ timeout 1000000 $ return (decode payload)
+            let mkMismatchError = VersionMismatchError preciseVehicleVersion version
+            case maybeResult of
+              Nothing -> return $ mkMismatchError "Decoding timed out"
+              Just (Left err) -> return $ mkMismatchError err
+              Just (Right v) -> return $ SuccessfulDecoding v
+          else case decode payload of
+            Left err -> return $ InexplicableDecodingError err
+            Right v -> return $ SuccessfulDecoding v
+
+data DecodeResult a
+  = IOError IOException
+  | InexplicableDecodingError String
+  | VersionMismatchError VersionString VersionString String
+  | SuccessfulDecoding a
+
+data Versioned a = Versioned
+  { version :: VersionString,
+    payload :: a
+  }
+  deriving (Generic)
+
+instance (Serialize a) => Serialize (Versioned a)
+
+-- `Data.Version` tags feature is deprecated so we can't use it.
+type VersionString = String

--- a/vehicle/src/Vehicle/Prelude/Version.hs
+++ b/vehicle/src/Vehicle/Prelude/Version.hs
@@ -36,7 +36,7 @@ impreciseVehicleVersion :: String
 impreciseVehicleVersion = showVersion Cabal.version
 #if releaseBuild
 #else
-  <> "-dev"
+  <> "+dev"
 #endif
 
 -- | The precise current version of Vehicle. This should be used whenever the
@@ -49,7 +49,9 @@ preciseVehicleVersion :: String
 preciseVehicleVersion = showVersion Cabal.version
 #if releaseBuild
 #else
-  <> maybe "" ("-" ++) commitInfo
+  -- Note this needs to be compliant with
+  -- https://peps.python.org/pep-0440/#local-version-identifiers
+  <> maybe "" ("+" ++) commitInfo
   where
   -- Taken from src/full/Agda/VersionCommit.hs
   commitInfo :: Maybe String
@@ -60,7 +62,7 @@ preciseVehicleVersion = showVersion Cabal.version
       hash = $(gitHash)
 
       -- Check if any tracked files have uncommitted changes
-      dirty | $(gitDirtyTracked) = "-dirty"
+      dirty | $(gitDirtyTracked) = ".dirty"
             | otherwise          = ""
 
       -- Abbreviate a commit hash while keeping it unambiguous

--- a/vehicle/src/Vehicle/Verify.hs
+++ b/vehicle/src/Vehicle/Verify.hs
@@ -40,7 +40,7 @@ verify _loggingSettings VerifyOptions {..} = do
     Just proofCachePath ->
       writeProofCache proofCachePath $
         ProofCache
-          { proofCacheVersion = vehicleVersion,
+          { proofCacheVersion = preciseVehicleVersion,
             resourcesIntegrityInfo = resourceIntegrity,
             originalProperties = specificationPropertyNames specificationPlan,
             status = status

--- a/vehicle/src/Vehicle/Verify/ProofCache.hs
+++ b/vehicle/src/Vehicle/Verify/ProofCache.hs
@@ -4,19 +4,23 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString.Lazy qualified as ByteString
-import Data.Version (Version)
 import GHC.Generics (Generic)
 import System.Exit (exitFailure)
 import System.FilePath (dropExtension)
 import System.IO (hPutStrLn, stderr)
-import Vehicle.Compile.Prelude
+import Vehicle.Prelude
+  ( PropertyNames,
+    VersionString,
+    vehicleProofCacheFileExtension,
+  )
+import Vehicle.Resource (ResourcesIntegrityInfo)
 import Vehicle.Verify.Specification.Status (SpecificationStatus)
 
 --------------------------------------------------------------------------------
 -- Overall status of the specification
 
 data ProofCache = ProofCache
-  { proofCacheVersion :: Version,
+  { proofCacheVersion :: VersionString,
     status :: SpecificationStatus,
     resourcesIntegrityInfo :: ResourcesIntegrityInfo,
     originalProperties :: PropertyNames

--- a/vehicle/tests/golden/compile/acasXu/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/acasXu/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/acasXu/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/acasXu/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property1-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 1500.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property1-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 1500.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property10-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property2-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 -y0 +y2 <= 0.0
 -y0 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property2-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 -y0 +y2 <= 0.0
 -y0 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property3-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property3-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 +y0 -y2 <= 0.0
 +y0 -y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property3-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property3-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 +y0 -y2 <= 0.0
 +y0 -y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property4-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property4-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 +y0 -y2 <= 0.0
 +y0 -y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property4-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property4-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 +y0 -y2 <= 0.0
 +y0 -y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y1 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y1 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y3 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property5-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y3 -y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query5.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query5.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query6.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query6.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query7.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query7.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query8.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query8.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property6-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 -y1 +y3 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 -y1 +y3 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 -y1 +y4 <= 0.0
 -y2 +y4 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property7-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 -y1 +y4 <= 0.0
 -y2 +y4 <= 0.0

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query10.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query10.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query10.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query10.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query11.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query11.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query11.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query11.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query12.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query12.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query12.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query12.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query13.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query13.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query13.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query13.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query14.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query14.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query14.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query14.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query15.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query15.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query15.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query15.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query16.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query16.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y4 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query16.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query16.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y4 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query5.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query5.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query6.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query6.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 -y1 +y2 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query7.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query7.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 -y1 +y3 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query8.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query8.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 -y1 +y4 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query9.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y3 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query9.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property8-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y3 <= 0.0
 +y0 -y1 <= 0.0
 x0 >= -0.32842287715105956

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query1.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y1 -y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query2.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y1 -y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query3.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y3 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query4.txt.golden
+++ b/vehicle/tests/golden/compile/acasXu/Marabou.queries/property9-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +y4 <= 0.0
 x0 >= -0.32842287715105956
 x0 <= 0.6715771228489404

--- a/vehicle/tests/golden/compile/andGate/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/andGate/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/andGate/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/andGate/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query1.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query1.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query2.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query2.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query3.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query3.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query4.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query4.txt.golden
+++ b/vehicle/tests/golden/compile/andGate/Marabou.queries/andGateCorrect-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.5
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/autoencoderError/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/autoencoderError/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query1.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -x0 +x4 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query1.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -x0 +x4 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query10.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query10.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +y2 -y6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query10.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query10.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +y2 -y6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query2.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +x0 -x4 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query2.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +x0 -x4 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query3.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -x1 +x5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query3.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -x1 +x5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query4.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +x1 -x5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query4.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +x1 -x5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query5.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -y0 +x6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query5.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -y0 +x6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query6.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +y0 -x6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query6.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +y0 -x6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query7.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -y1 +y5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query7.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -y1 +y5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query8.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +y1 -y5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query8.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 +y1 -y5 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query9.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -y2 +y6 <= -0.1

--- a/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query9.txt.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Marabou.queries/identity-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +x2 = 0.0
 -y4 +x3 = 0.0
 -y2 +y6 <= -0.1

--- a/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query1.txt.golden
+++ b/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.0
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query1.txt.golden
+++ b/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.0
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query2.txt.golden
+++ b/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 1.0
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query2.txt.golden
+++ b/vehicle/tests/golden/compile/bounded/Marabou.queries/bounded-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 1.0
 x0 >= 0.0
 x0 <= 1.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/dogsHierarchy/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/.vcl-plan.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/.vcl-plan.golden
@@ -6894,7 +6894,7 @@
     "specificationSummary": {
       "name": "specification",
       "filePath": "spec.vcl",
-      "fileHash": 7957634141695544348
+      "fileHash": 2831950783347411601
     },
     "parameterSummaries": {},
     "networkSummaries": [

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query1.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query1.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query10.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query10.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query10.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query10.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query11.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query11.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query11.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query11.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query12.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query12.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query12.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query12.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query13.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query13.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query13.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query13.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query14.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query14.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query14.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query14.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query15.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query15.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query15.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query15.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query16.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query16.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query16.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query16.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query17.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query17.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query17.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query17.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query18.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query18.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query18.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query18.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query19.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query19.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query19.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query19.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query2.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query2.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query20.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query20.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query20.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query20.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query21.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query21.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query21.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query21.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query22.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query22.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query22.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query22.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query23.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query23.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query23.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query23.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query24.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query24.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query24.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query24.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y2 <= 0.0
 +y1 -y2 <= 0.0
 -y2 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query3.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query3.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query4.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query4.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query5.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query5.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query6.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query6.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query7.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query7.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query8.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query8.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query9.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query9.txt.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Marabou.queries/doesNotConfuseBigAndSmall-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0
 -y1 +y2 <= 0.0
 -y1 +y3 <= 0.0

--- a/vehicle/tests/golden/compile/increasing/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/increasing/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/increasing/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/increasing/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/increasing/Marabou.queries/increasing-query1.txt.golden
+++ b/vehicle/tests/golden/compile/increasing/Marabou.queries/increasing-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -x0 +y0 <= 0.0

--- a/vehicle/tests/golden/compile/increasing/Marabou.queries/increasing-query1.txt.golden
+++ b/vehicle/tests/golden/compile/increasing/Marabou.queries/increasing-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -x0 +y0 <= 0.0

--- a/vehicle/tests/golden/compile/mnist-robustness/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/mnist-robustness/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query1.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query1.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query2.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y1 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query2.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y1 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query3.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y2 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query3.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y2 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query4.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y3 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query4.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y3 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query5.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y4 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query5.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y4 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query6.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y5 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query6.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y5 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query7.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y6 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query7.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y6 +y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query8.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y7 -y8 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query8.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y7 -y8 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query9.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y7 -y9 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query9.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!0-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y7 -y9 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y2 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y2 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query2.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y1 +y2 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query2.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y1 +y2 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query3.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y3 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query3.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y3 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query4.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y4 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query4.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y4 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query5.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y5 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query5.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query5.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y5 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query6.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y6 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query6.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query6.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y6 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query7.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query7.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query7.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y7 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query8.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y8 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query8.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query8.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y8 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query9.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y2 -y9 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query9.txt.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Marabou.queries/robust!1-query9.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y2 -y9 <= 0.0
 x0 <= 0.1
 x0 >= -0.1

--- a/vehicle/tests/golden/compile/monotonicity/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/monotonicity/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/monotonicity/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/monotonicity/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/monotonicity/Marabou.queries/monotonic-query1.txt.golden
+++ b/vehicle/tests/golden/compile/monotonicity/Marabou.queries/monotonic-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 -y0 +y1 <= 0.0
 +x0 -x1 <= 0.0

--- a/vehicle/tests/golden/compile/monotonicity/Marabou.queries/monotonic-query1.txt.golden
+++ b/vehicle/tests/golden/compile/monotonicity/Marabou.queries/monotonic-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 -y0 +y1 <= 0.0
 +x0 -x1 <= 0.0

--- a/vehicle/tests/golden/compile/quantifierInIf/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/quantifierInIf/Marabou.queries/p-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/quantifierInIf/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/quantifierInIf/Marabou.queries/p-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/reachability/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/reachability/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/reachability/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/reachability/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/reachability/Marabou.queries/reachable-query1.txt.golden
+++ b/vehicle/tests/golden/compile/reachability/Marabou.queries/reachable-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 = 0.0

--- a/vehicle/tests/golden/compile/reachability/Marabou.queries/reachable-query1.txt.golden
+++ b/vehicle/tests/golden/compile/reachability/Marabou.queries/reachable-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 = 0.0

--- a/vehicle/tests/golden/compile/simple-arithmetic/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-arithmetic/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-arithmetic/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-arithmetic/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-arithmetic/Marabou.queries/.vcl-plan.golden
+++ b/vehicle/tests/golden/compile/simple-arithmetic/Marabou.queries/.vcl-plan.golden
@@ -51,7 +51,7 @@
     "specificationSummary": {
       "name": "specification",
       "filePath": "spec.vcl",
-      "fileHash": -2059453136677417345
+      "fileHash": -760293435080544488
     },
     "parameterSummaries": {},
     "networkSummaries": [

--- a/vehicle/tests/golden/compile/simple-arithmetic/Marabou.queries/property-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-arithmetic/Marabou.queries/property-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.5
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-arithmetic/Marabou.queries/property-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-arithmetic/Marabou.queries/property-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.5
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-constantInput/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-constantInput/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-constantInput/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-constantInput/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-constantInput/Marabou.queries/spec-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-constantInput/Marabou.queries/spec-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x1 = 0.0
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-constantInput/Marabou.queries/spec-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-constantInput/Marabou.queries/spec-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x1 = 0.0
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-constantNetworkInput/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-constantNetworkInput/Marabou.queries/p-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 y0 = 0.0

--- a/vehicle/tests/golden/compile/simple-constantNetworkInput/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-constantNetworkInput/Marabou.queries/p-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 y0 = 0.0

--- a/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!0-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!0-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 x1 = 0.0
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!0-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!0-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 x1 = 0.0
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!1-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 x1 = 0.0
 y1 >= 0.0

--- a/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-foreach/Marabou.queries/index!1-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 x1 = 0.0
 y1 >= 0.0

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar1-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.0
 x0 >= 3.0

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar1-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.0
 x0 >= 3.0

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar2-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.0
 x0 >= 3.0

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVar2-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.0
 x0 >= 3.0

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVars-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVars-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 2.0
 x0 >= 2.5

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVars-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/underConstrainedVars-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 2.0
 x0 >= 2.5

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/unusedVar-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/unusedVar-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/unusedVar-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Marabou.queries/unusedVar-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test1-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 = 0.0
 x0 >= 2.0

--- a/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test1-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 = 0.0
 x0 >= 2.0

--- a/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test2-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 = 0.0
 -2.0x0 +x1 <= -1.0
 3.0x0 -2.0x1 <= 0.0

--- a/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/Marabou.queries/test2-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 = 0.0
 -2.0x0 +x1 <= -1.0
 3.0x0 -2.0x1 <= 0.0

--- a/vehicle/tests/golden/compile/simple-generalisedVariables/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-generalisedVariables/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-generalisedVariables/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-generalisedVariables/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-if/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-if/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-if/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-if/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.0
 x0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.0
 x0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query2.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.0
 x0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop1-query2.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.0
 x0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.0
 x0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.0
 x0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query2.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.2
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop2-query2.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.2
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 0.0
 x0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 0.0
 x0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query2.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.0
 x0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-if/Marabou.queries/prop3-query2.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.0
 x0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-index/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-index/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-index/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-index/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-let/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-let/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-let/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-let/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-pruneDecls/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-pruneDecls/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-pruneDecls/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-pruneDecls/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-pruneDecls/Marabou.queries/p2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-pruneDecls/Marabou.queries/p2-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-pruneDecls/Marabou.queries/p2-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-pruneDecls/Marabou.queries/p2-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-quantifier/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/expandedExpr-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/expandedExpr-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +x0 -y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/expandedExpr-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/expandedExpr-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +x0 -y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query2.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 y0 >= 5.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/parallel-query2.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 y0 >= 5.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/sequential-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/sequential-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 +y0 -y1 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/sequential-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifier/Marabou.queries/sequential-query1.txt.golden
@@ -2,5 +2,5 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 +y0 -y1 <= 0.0

--- a/vehicle/tests/golden/compile/simple-quantifierIn/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-quantifierIn/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-quantifierIn/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-quantifierIn/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-quantifierIn/Marabou.queries/forallInForall-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifierIn/Marabou.queries/forallInForall-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.5
 x1 = 1.0

--- a/vehicle/tests/golden/compile/simple-quantifierIn/Marabou.queries/forallInForall-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-quantifierIn/Marabou.queries/forallInForall-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.5
 x1 = 1.0

--- a/vehicle/tests/golden/compile/simple-tensor/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-tensor/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query2.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query3.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query3.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query3.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query4.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query4.txt.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Marabou.queries/p-query4.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 x1 = 0.0
 x2 = 0.0

--- a/vehicle/tests/golden/compile/simple-triviallyTrue/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-triviallyTrue/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-triviallyTrue/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-triviallyTrue/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-untypedDecls/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-untypedDecls/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-untypedDecls/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-untypedDecls/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-vector/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-vector/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-vector/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/simple-vector/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/simple-vector/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-vector/Marabou.queries/p-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 = 0.0
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-vector/Marabou.queries/p-query1.txt.golden
+++ b/vehicle/tests/golden/compile/simple-vector/Marabou.queries/p-query1.txt.golden
@@ -2,6 +2,6 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 = 0.0
 y0 >= 0.0

--- a/vehicle/tests/golden/compile/windController/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/windController/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.3.0-dev
+--  - Vehicle version: 0.3.0+dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/windController/Agda.agda.golden
+++ b/vehicle/tests/golden/compile/windController/Agda.agda.golden
@@ -2,7 +2,7 @@
 -- and should not be modified manually!
 -- Metadata:
 --  - Agda version: 2.6.2
---  - Vehicle version: 0.2.0
+--  - Vehicle version: 0.3.0-dev
 
 {-# OPTIONS --allow-exec #-}
 

--- a/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query1.txt.golden
+++ b/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 >= -3.25
 x0 <= 3.25
 x1 >= -3.25

--- a/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query1.txt.golden
+++ b/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query1.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 >= -3.25
 x0 <= 3.25
 x1 >= -3.25

--- a/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query2.txt.golden
+++ b/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.2.0
+//  - Vehicle version: 0.3.0-dev
 x0 >= -3.25
 x0 <= 3.25
 x1 >= -3.25

--- a/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query2.txt.golden
+++ b/vehicle/tests/golden/compile/windController/Marabou.queries/safe-query2.txt.golden
@@ -2,7 +2,7 @@
 // and should not be modified manually!
 // Metadata:
 //  - Marabou query format version: unknown
-//  - Vehicle version: 0.3.0-dev
+//  - Vehicle version: 0.3.0+dev
 x0 >= -3.25
 x0 <= 3.25
 x1 >= -3.25

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -1,21 +1,19 @@
-cabal-version: 3.4
-name:          vehicle
-version:       0.2.0
+cabal-version:      3.4
+name:               vehicle
+version:            0.3.0
 description:
   Please see the README on GitHub at <https://github.com/vehicle-lang/vehicle#readme>
 
-homepage:      https://github.com/vehicle-lang/vehicle#readme
-bug-reports:   https://github.com/vehicle-lang/vehicle/issues
-author:        Matthew Daggitt and Wen Kokke
-maintainer:    wenkokke@users.noreply.github.com
-copyright:     © Matthew Daggitt and Wen Kokke
-license:       BSD-3-Clause
-license-file:  LICENSE
-build-type:    Simple
-tested-with:   GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
-
-extra-source-files:
-  lib/std.vcl
+homepage:           https://github.com/vehicle-lang/vehicle#readme
+bug-reports:        https://github.com/vehicle-lang/vehicle/issues
+author:             Matthew Daggitt and Wen Kokke
+maintainer:         wenkokke@users.noreply.github.com
+copyright:          © Matthew Daggitt and Wen Kokke
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
+extra-source-files: lib/std.vcl
 
 source-repository head
   type:     git
@@ -28,6 +26,11 @@ flag ghc-debug
 
 flag nothunks
   description: Add NoThunks instrumentation
+  manual:      True
+  default:     False
+
+flag release-build
+  description: Marks this as an official release build
   manual:      True
   default:     False
 
@@ -77,6 +80,9 @@ common common-library
   if flag(nothunks)
     build-depends: nothunks >=0.1.3 && <0.2
     cpp-options:   -Dnothunks
+
+  if flag(release-build)
+    cpp-options: -DreleaseBuild
 
 common common-executable
   import:      common-language
@@ -207,6 +213,7 @@ library
     Vehicle.Prelude.Misc
     Vehicle.Prelude.Prettyprinter
     Vehicle.Prelude.Supply
+    Vehicle.Prelude.Version
     Vehicle.Verify.Verifier
     Vehicle.Verify.Verifier.Marabou
 
@@ -226,6 +233,7 @@ library
     , directory              >=1.3.6    && <1.4
     , file-embed             >=0.0.15.0 && <0.1
     , filepath               >=1.4      && <2
+    , gitrev                 >=1.3      && <2
     , hashable               >=1.3      && <2
     , linkedhashmap          >=0.4      && <1
     , mnist-idx              >=0.1.3.1  && <0.2


### PR DESCRIPTION
As discussed added a build flag `release-build` to the cabal file which can be used to turn off the addition of additional information to the version.