### PR TITLE
Preparations for implementing @noinline in NBE

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
@@ -66,6 +66,7 @@ instance NoThunks Builtin
 
 -- Vehicle.Syntax.AST.Decl
 instance NoThunks expr => NoThunks (GenericDecl expr)
+instance NoThunks ParameterSort
 instance NoThunks DefAbstractSort
 instance NoThunks Annotation
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Name.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Name.hs
@@ -75,3 +75,6 @@ class HasName a name | a -> name where
 
 instance HasName Identifier Name where
   nameOf (Identifier mod name) = name
+
+instance HasName Name Name where
+  nameOf = id

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -51,8 +51,9 @@ instance Delaborate V.InputDecl [B.Decl] where
             V.PostulateDef -> delabAnn postulateAnn []
             V.NetworkDef -> delabAnn networkAnn []
             V.DatasetDef -> delabAnn datasetAnn []
-            V.ParameterDef -> delabAnn parameterAnn []
-            V.InferableParameterDef -> delabAnn parameterAnn [mkDeclAnnOption InferableOption True]
+            V.ParameterDef sort -> case sort of
+              V.NonInferable -> delabAnn parameterAnn []
+              V.Inferable -> delabAnn parameterAnn [mkDeclAnnOption InferableOption True]
 
       return [defAnn, defFun]
     V.DefFunction _ n anns t e -> do
@@ -97,6 +98,7 @@ instance Delaborate V.InputBinder B.BasicBinder where
 instance Delaborate V.Annotation B.Decl where
   delabM = \case
     V.AnnProperty -> return $ delabAnn propertyAnn []
+    V.AnnNoInline -> return $ delabAnn noInlineAnn []
 
 -- | Used for things not in the user-syntax.
 cheatDelab :: Text -> B.Expr

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/Internal.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE InstanceSigs #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 module Vehicle.Syntax.BNFC.Delaborate.Internal
@@ -51,8 +52,9 @@ instance Delaborate V.DefAbstractSort (B.NameToken -> B.Expr -> B.Decl) where
     V.PostulateDef -> B.DeclPost
     V.NetworkDef -> B.DeclNetw
     V.DatasetDef -> B.DeclData
-    V.ParameterDef -> B.DeclParam
-    V.InferableParameterDef -> B.DeclImplParam
+    V.ParameterDef sort -> case sort of
+      V.NonInferable -> B.DeclParam
+      V.Inferable -> B.DeclImplParam
 
 instance Delaborate V.InputExpr B.Expr where
   delabM expr = case expr of
@@ -69,6 +71,7 @@ instance Delaborate V.InputExpr B.Expr where
     V.App _ fun args -> delabApp <$> delabM fun <*> traverse delabM (reverse (NonEmpty.toList args))
 
 instance Delaborate V.InputArg B.Arg where
+  delabM :: (MonadDelab m) => V.InputArg -> m B.Arg
   delabM (V.Arg _ v r e) = case (v, r) of
     (V.Explicit {}, V.Relevant) -> B.RelevantExplicitArg <$> delabM e
     (V.Implicit {}, V.Relevant) -> B.RelevantImplicitArg <$> delabM e

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/Internal.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/Internal.hs
@@ -45,8 +45,8 @@ instance Elab B.Decl V.InputDecl where
   elab = \case
     B.DeclNetw n t -> elabDefAbstract n t V.NetworkDef
     B.DeclData n t -> elabDefAbstract n t V.DatasetDef
-    B.DeclParam n t -> elabDefAbstract n t V.ParameterDef
-    B.DeclImplParam n t -> elabDefAbstract n t V.InferableParameterDef
+    B.DeclParam n t -> elabDefAbstract n t (V.ParameterDef V.NonInferable)
+    B.DeclImplParam n t -> elabDefAbstract n t (V.ParameterDef V.Inferable)
     B.DeclPost n t -> elabDefAbstract n t V.PostulateDef
     B.DefFun n t e -> V.DefFunction <$> mkProvenance n <*> elab n <*> pure mempty <*> elab t <*> elab e
 

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Utils.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Utils.hs
@@ -33,6 +33,8 @@ parameterAnn = B.Parameter $ mkToken B.TokParameter "@parameter"
 
 propertyAnn = B.Property $ mkToken B.TokProperty "@property"
 
+noInlineAnn = B.Property $ mkToken B.TokProperty "@noinline"
+
 postulateAnn = B.Dataset $ mkToken B.TokDataset "@postulate"
 
 tokArrow = mkToken B.TokArrow "->"

--- a/vehicle-syntax/src/Vehicle/Syntax/External.cf
+++ b/vehicle-syntax/src/Vehicle/Syntax/External.cf
@@ -15,6 +15,7 @@ position token TokDataset   {"@dataset"};
 position token TokParameter {"@parameter"};
 position token TokProperty  {"@property"};
 position token TokPostulate {"@postulate"};
+position token TokNoInline  {"@noinline"};
 
 position token TokArrow     {"->"};
 position token TokForallT   {"forallT"};
@@ -216,6 +217,7 @@ Dataset.   DeclAnnName ::= TokDataset;
 Parameter. DeclAnnName ::= TokParameter;
 Property.  DeclAnnName ::= TokProperty;
 Postulate. DeclAnnName ::= TokPostulate;
+NoInline.  DeclAnnName ::= TokNoInline;
 
 -- * Annotation options
 

--- a/vehicle/lib/std.vcl
+++ b/vehicle/lib/std.vcl
@@ -30,12 +30,15 @@ foreachVector {A} {n} f = map f (indices n)
 zipWith : (A -> B -> C) -> Vector A n -> Vector B n -> Vector C n
 zipWith f xs ys = foreach i . f (xs ! i) (ys ! i)
 
+@noinline
 addVector : {{HasAdd A B C}} -> Vector A n -> Vector B n -> Vector C n
 addVector = zipWith (\x y -> x + y)
 
+@noinline
 subVector : {{HasSub A B C}} -> Vector A n -> Vector B n -> Vector C n
 subVector = zipWith (\x y -> x - y)
 
+@noinline
 equalsVector : {{HasEq A B}} -> Vector A n -> Vector B n -> Bool
 equalsVector xs ys = bigAnd (zipWith (\x y -> x == y) xs ys)
 

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -111,7 +111,7 @@ instance MeaningfulError CompileError where
                     <+> pretty NetworkDef <> ","
                     <+> pretty DatasetDef
                     <+> "or"
-                    <+> pretty ParameterDef <> "."
+                    <+> pretty (ParameterDef NonInferable) <> "."
             }
       MultiplyAnnotatedAbstractDef p name ann1 ann2 ->
         UError $
@@ -134,6 +134,16 @@ instance MeaningfulError CompileError where
               UserError
                 { provenance = p,
                   problem = "missing definition for property" <+> quotePretty name <> ".",
+                  fix = Just $ "add a definition for" <+> quotePretty name <+> "."
+                }
+          AnnNoInline ->
+            UError $
+              UserError
+                { provenance = p,
+                  problem =
+                    "the annotation"
+                      <+> pretty AnnNoInline
+                        <> "must be attached to a declaration with a definition.",
                   fix = Just $ "add a definition for" <+> quotePretty name <+> "."
                 }
       NonAbstractDefWithAbstractAnnotation p name resource ->
@@ -875,7 +885,7 @@ instance MeaningfulError CompileError where
         UserError
           { provenance = p,
             problem =
-              unsupportedAnnotationTypeDescription (pretty ParameterDef) ident datasetType
+              unsupportedAnnotationTypeDescription (pretty (ParameterDef NonInferable)) ident datasetType
                 <+> "as the dimension size"
                   <> line
                   <> indent 2 (prettyFriendly (WithContext variableDim emptyDBCtx))
@@ -986,7 +996,7 @@ instance MeaningfulError CompileError where
         UserError
           { provenance = p,
             problem =
-              unsupportedAnnotationTypeDescription (pretty ParameterDef) ident expectedType <> "."
+              unsupportedAnnotationTypeDescription (pretty (ParameterDef NonInferable)) ident expectedType <> "."
                 <+> "Only the following types are allowed for"
                 <+> pretty Parameter
                   <> "s:"
@@ -1022,7 +1032,7 @@ instance MeaningfulError CompileError where
         UserError
           { provenance = p,
             problem =
-              unsupportedAnnotationTypeDescription (pretty ParameterDef) ident parameterType
+              unsupportedAnnotationTypeDescription (pretty (ParameterDef NonInferable)) ident parameterType
                 <> "as the size of the"
                 <+> pretty Index
                 <+> "type is not a known constant.",
@@ -1087,7 +1097,7 @@ instance MeaningfulError CompileError where
         UserError
           { provenance = p,
             problem =
-              unsupportedAnnotationTypeDescription (pretty InferableParameterDef) ident expectedType
+              unsupportedAnnotationTypeDescription (pretty (ParameterDef Inferable)) ident expectedType
                 <> "."
                 <+> "Inferable parameters must be of type 'Nat'.",
             fix =

--- a/vehicle/src/Vehicle/Compile/ExpandResources.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources.hs
@@ -4,6 +4,7 @@ module Vehicle.Compile.ExpandResources
   )
 where
 
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State

--- a/vehicle/src/Vehicle/Compile/ExpandResources.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources.hs
@@ -1,5 +1,6 @@
 module Vehicle.Compile.ExpandResources
   ( expandResources,
+    splitResourceCtx,
   )
 where
 
@@ -7,53 +8,52 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.Foldable (traverse_)
-import Data.Map (Map)
-import Data.Map qualified as Map (insert, lookup)
-import Data.Traversable (for)
+import Data.Map qualified as Map
 import Vehicle.Compile.Error
 import Vehicle.Compile.ExpandResources.Core
 import Vehicle.Compile.ExpandResources.Dataset
 import Vehicle.Compile.ExpandResources.Network
 import Vehicle.Compile.ExpandResources.Parameter
-import Vehicle.Compile.Normalise.NBE (runNormT, whnf)
-import Vehicle.Compile.Normalise.Quote (unnormalise)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Resource
+import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
-import Vehicle.Expr.Normalised
+import Vehicle.Expr.Normalised (pattern VNatLiteral)
 
--- | Expands datasets and parameters, and attempts to infer the values of
--- inferable parameters. Also checks the resulting types of networks.
+-- | Calculates the context for external resources, reading them from disk and
+-- inferring the values of inferable parameters.
 expandResources ::
   (MonadIO m, MonadCompile m) =>
   Resources ->
   StandardGluedProg ->
-  m (NetworkContext, StandardGluedProg)
-expandResources resources@Resources {..} prog =
+  m ResourceContext
+expandResources resources prog =
   logCompilerPass MinDetail "expansion of external resources" $ do
-    resourcesCtx@ResourceContext {..} <-
-      execStateT (runReaderT (readResourcesInProg prog) resources) emptyResourceCtx
+    (intermediateResourcesCtx, inferableParameterCtx) <-
+      execStateT (runReaderT (readResourcesInProg prog) resources) (emptyResourceCtx, mempty)
 
-    finalProg <-
-      evalStateT (runReaderT (insertResourcesInProg prog) resourcesCtx) mempty
+    checkForUnusedResources resources intermediateResourcesCtx
 
-    warnIfUnusedResources Parameter parameters parameterContext
-    warnIfUnusedResources Dataset datasets datasetContext
-    warnIfUnusedResources Network networks networkContext
+    fillInInferableParameters intermediateResourcesCtx inferableParameterCtx
 
-    return (networkContext, finalProg)
+splitResourceCtx :: ResourceContext -> (NetworkContext, StandardNormDeclCtx)
+splitResourceCtx ResourceContext {..} = do
+  let mkEntry expr =
+        NormDeclCtxEntry
+          { declExpr = expr,
+            declAnns = []
+          }
+  let declCtx = fmap mkEntry parameterContext <> fmap mkEntry datasetContext
+  (networkContext, declCtx)
 
---------------------------------------------------------------------------------
--- First pass
-
--- | The first pass of expanding resources goes through the program finding all
--- the resources, comparing the data against the type in the spec, and making
--- note of the values for implicit parameters.
 type MonadReadResources m =
   ( MonadIO m,
     MonadExpandResources m
   )
 
+-- | Goes through the program finding all
+-- the resources, comparing the data against the type in the spec, and making
+-- note of the values for implicit parameters.
 readResourcesInProg :: (MonadReadResources m) => StandardGluedProg -> m ()
 readResourcesInProg (Main ds) = traverse_ readResourcesInDecl ds
 
@@ -62,99 +62,43 @@ readResourcesInDecl decl = case decl of
   DefFunction {} -> return ()
   DefAbstract p ident defType declType ->
     case defType of
-      InferableParameterDef ->
-        modify (noteInferableParameter ident)
-      ParameterDef -> do
-        parameterValues <- asks parameters
-        normParameterExpr <- parseParameterValue parameterValues (ident, p) declType
-        let parameterExpr = mkTyped normParameterExpr
-        modify (addParameter ident parameterExpr)
+      ParameterDef sort -> case sort of
+        Inferable ->
+          noteInferableParameter p ident
+        NonInferable -> do
+          parameterValues <- asks parameters
+          parameterExpr <- parseParameterValue parameterValues (ident, p) declType
+          addParameter ident parameterExpr
       DatasetDef -> do
         datasetLocations <- asks datasets
-        normDatasetExpr <- parseDataset datasetLocations (ident, p) declType
-        let datasetExpr = mkTyped normDatasetExpr
-        modify (addDataset ident datasetExpr)
+        datasetExpr <- parseDataset datasetLocations (ident, p) declType
+        addDataset ident datasetExpr
       NetworkDef -> do
         networkLocations <- asks networks
         networkDetails <- checkNetwork networkLocations (ident, p) declType
-        modify (addNetworkType ident networkDetails)
+        addNetworkType ident networkDetails
       PostulateDef -> return ()
 
-mkTyped :: StandardNormExpr -> StandardGluedExpr
-mkTyped expr = Glued (unnormalise 0 expr) expr
+checkForUnusedResources ::
+  (MonadLogger m) =>
+  Resources ->
+  ResourceContext ->
+  m ()
+checkForUnusedResources Resources {..} ResourceContext {..} = do
+  warnIfUnusedResources Parameter parameters parameterContext
+  warnIfUnusedResources Dataset datasets datasetContext
+  warnIfUnusedResources Network networks networkContext
 
---------------------------------------------------------------------------------
--- Second pass
-
--- | The second pass of expanding resources goes through the program finding all
--- substituting in the resources and making sure to normalise the program with
--- the new values now inserted.
-type MonadInsertResources m =
-  ( MonadReader ResourceContext m,
-    MonadState (DeclCtx StandardGluedExpr) m,
-    MonadCompile m
-  )
-
-insertResourcesInProg :: (MonadInsertResources m) => StandardGluedProg -> m StandardGluedProg
-insertResourcesInProg (Main ds) = Main <$> insertDecls ds
-
-insertDecls :: (MonadInsertResources m) => [StandardGluedDecl] -> m [StandardGluedDecl]
-insertDecls [] = return []
-insertDecls (d : ds) = do
-  norm <- normDecl d
-  maybeDecl <- insertDecl norm
-  case maybeDecl of
-    Nothing -> insertDecls ds
-    Just decl -> do
-      case bodyOf decl of
-        Nothing -> return ()
-        Just body -> modify (Map.insert (identifierOf decl) body)
-      ds' <- insertDecls ds
-      return $ decl : ds'
-
-insertDecl ::
-  (MonadInsertResources m) =>
-  StandardGluedDecl ->
-  m (Maybe StandardGluedDecl)
-insertDecl d = case d of
-  DefFunction {} -> return (Just d)
-  DefAbstract p ident defType declType -> case defType of
-    InferableParameterDef -> do
-      implicitParams <- asks inferableParameterContext
-      paramValue <- lookupValue ident implicitParams
-      case paramValue of
-        Nothing -> throwError $ InferableParameterUninferrable (ident, p)
-        Just (_, _, v) -> do
-          let normParameterExpr = VNatLiteral v
-          let parameterExpr = mkTyped normParameterExpr
-          modify (Map.insert ident parameterExpr)
-          return $ Just $ DefFunction p ident [] declType parameterExpr
-    ParameterDef -> do
-      parameters <- asks parameterContext
-      parameterExpr <- lookupValue ident parameters
-      modify (Map.insert ident parameterExpr)
-      return $ Just $ DefFunction p ident [] declType parameterExpr
-    DatasetDef -> do
-      datasets <- asks datasetContext
-      datasetExpr <- lookupValue ident datasets
-      modify (Map.insert ident datasetExpr)
-      return $ Just $ DefFunction p ident [] declType datasetExpr
-    NetworkDef ->
-      return Nothing
-    PostulateDef ->
-      return $ Just d
-
-lookupValue :: (MonadCompile m) => Identifier -> Map Name a -> m a
-lookupValue ident ctx = case Map.lookup (nameOf ident) ctx of
-  Nothing ->
-    compilerDeveloperError $
-      "Somehow missed resource" <+> quotePretty ident <+> "on the first pass"
-  Just value -> return value
-
-normDecl :: (MonadInsertResources m) => StandardGluedDecl -> m StandardGluedDecl
-normDecl decl = do
-  ctx <- gets (fmap normalised)
-  for decl $ \(Glued unnorm norm) -> do
-    -- Ugh, horrible. We really need to be able to renormalise.
-    norm' <- runNormT ctx mempty (whnf mempty (unnormalise 0 norm))
-    return $ Glued unnorm norm'
+fillInInferableParameters :: (MonadCompile m) => ResourceContext -> InferableParameterContext -> m ResourceContext
+fillInInferableParameters ResourceContext {..} inferableCtx = do
+  newParameterCtx <- foldM insertInferableParameter parameterContext (Map.assocs inferableCtx)
+  return $ ResourceContext {parameterContext = newParameterCtx, ..}
+  where
+    insertInferableParameter ::
+      (MonadCompile m) =>
+      ParameterContext ->
+      (Identifier, Either Provenance InferableParameterEntry) ->
+      m ParameterContext
+    insertInferableParameter ctx (param, maybeValue) = case maybeValue of
+      Left p -> throwError $ InferableParameterUninferrable (param, p)
+      Right (_, _, v) -> return $ Map.insert param (VNatLiteral v) ctx

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Network.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Network.hs
@@ -4,7 +4,6 @@ module Vehicle.Compile.ExpandResources.Network
 where
 
 import Control.Monad.Except (MonadError (..))
-import Control.Monad.State (gets)
 import Data.Map qualified as Map
 import Vehicle.Compile.Error
 import Vehicle.Compile.ExpandResources.Core
@@ -73,11 +72,11 @@ getNetworkType decl networkType = case normalised networkType of
     getTensorDimension io dim = case dim of
       VNatLiteral n -> return n
       VFreeVar varIdent _ -> do
-        implicitParameters <- gets inferableParameterContext
-        case Map.lookup (nameOf varIdent) implicitParameters of
+        implicitParameters <- getInferableParameterContext
+        case Map.lookup varIdent implicitParameters of
           Nothing -> throwError $ NetworkTypeHasVariableSizeTensor decl networkType dim io
-          Just Nothing -> throwError $ NetworkTypeHasImplicitSizeTensor decl networkType varIdent io
-          Just (Just (_, _, d)) -> return d
+          Just Left {} -> throwError $ NetworkTypeHasImplicitSizeTensor decl networkType varIdent io
+          Just (Right (_, _, d)) -> return d
       dims -> throwError $ NetworkTypeHasVariableSizeTensor decl networkType dims io
 
     getElementType :: StandardNormType -> m NetworkBaseType

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
@@ -4,7 +4,6 @@ module Vehicle.Compile.ExpandResources.Parameter
 where
 
 import Control.Monad.Except
-import Control.Monad.State
 import Data.Map qualified as Map
 import Data.Text (pack)
 import Data.Text.Read (rational)
@@ -26,7 +25,7 @@ parseParameterValue ::
   StandardGluedType ->
   m StandardNormExpr
 parseParameterValue parameterValues decl@(ident, _) parameterType = do
-  implicitParams <- gets inferableParameterContext
+  implicitParams <- getInferableParameterContext
 
   parser <- case normalised parameterType of
     VBoolType {} -> return parseBool
@@ -38,7 +37,7 @@ parseParameterValue parameterValues decl@(ident, _) parameterType = do
     VIndexType (VNatLiteral n) ->
       return (parseIndex n)
     VIndexType (VFreeVar varIdent _)
-      | Map.member (nameOf varIdent) implicitParams ->
+      | Map.member varIdent implicitParams ->
           throwError $
             ParameterTypeInferableParameterIndex decl varIdent
     VIndexType {} ->

--- a/vehicle/src/Vehicle/Compile/Resource.hs
+++ b/vehicle/src/Vehicle/Compile/Resource.hs
@@ -2,6 +2,7 @@ module Vehicle.Compile.Resource where
 
 import Data.Map (Map)
 import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Subsystem.Standard.Core
 
 --------------------------------------------------------------------------------
 -- Networks
@@ -40,4 +41,17 @@ instance Pretty NetworkBaseType where
   pretty = \case
     NetworkRatType -> pretty Rat
 
+--------------------------------------------------------------------------------
+-- Context
+
+type ParameterContext = Map Identifier StandardNormExpr
+
+type DatasetContext = Map Identifier StandardNormExpr
+
 type NetworkContext = Map Name (FilePath, NetworkType)
+
+data ResourceContext = ResourceContext
+  { parameterContext :: ParameterContext,
+    datasetContext :: DatasetContext,
+    networkContext :: NetworkContext
+  }

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -190,8 +190,7 @@ restrictAbstractDefType resource decl@(ident, _) defType = do
   let resourceName = pretty resource <+> squotes (pretty ident)
   logCompilerPass MidDetail ("checking suitability of the type of" <+> resourceName) $ do
     case resource of
-      ParameterDef -> restrictParameterType decl defType
-      InferableParameterDef -> restrictInferableParameterType decl defType
+      ParameterDef sort -> restrictParameterType sort decl defType
       DatasetDef -> restrictDatasetType decl defType
       NetworkDef -> restrictNetworkType decl defType
       PostulateDef -> return $ unnormalised defType
@@ -383,4 +382,4 @@ createDeclCtx imports =
     getEntry :: GluedDecl types -> (Identifier, TypingDeclCtxEntry types)
     getEntry d = do
       let ident = identifierOf d
-      (ident, toDeclCtxEntry d)
+      (ident, mkTypingDeclCtxEntry d)

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -159,12 +159,7 @@ class (PrintableBuiltin types) => TypableBuiltin types where
 
   restrictParameterType ::
     (MonadTypeChecker types m) =>
-    DeclProvenance ->
-    GluedType types ->
-    m (CheckedType types)
-
-  restrictInferableParameterType ::
-    (MonadTypeChecker types m) =>
+    ParameterSort ->
     DeclProvenance ->
     GluedType types ->
     m (CheckedType types)
@@ -433,7 +428,8 @@ getDeclType :: (MonadTypeChecker types m) => Provenance -> Identifier -> m (Chec
 getDeclType p ident = do
   ctx <- getDeclContext
   case Map.lookup ident ctx of
-    Just (checkedType, _) -> return checkedType
+    Just TypingDeclCtxEntry {..} ->
+      return declType
     -- This should have been caught during scope checking
     Nothing ->
       compilerDeveloperError $

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
@@ -17,14 +17,12 @@ import Control.Monad.State
   )
 import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Trans.Class (lift)
-import Data.Map qualified as Map
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad.Class
 import Vehicle.Expr.DeBruijn (DBType)
-import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
 -- Implementation
@@ -64,13 +62,13 @@ mapTypeCheckerT f m = TypeCheckerT (mapReaderT (mapStateT f) (unTypeCheckerT m))
 -- Instances that TypeCheckerT satisfies
 
 instance (PrintableBuiltin types, MonadCompile m) => MonadNorm types (TypeCheckerT types m) where
-  getDeclSubstitution = TypeCheckerT $ asks $ Map.mapMaybe (fmap normalised . snd)
+  getDeclSubstitution = TypeCheckerT $ asks typingDeclCtxToNormDeclCtx
 
   getMetaSubstitution = TypeCheckerT (gets currentSubstitution)
 
 instance (PrintableBuiltin types, MonadCompile m) => MonadTypeChecker types (TypeCheckerT types m) where
   getDeclContext = TypeCheckerT ask
-  addDeclContext d s = TypeCheckerT $ local (addToDeclCtx d) (unTypeCheckerT s)
+  addDeclContext d s = TypeCheckerT $ local (addToTypingDeclCtx d) (unTypeCheckerT s)
   getMetaState = TypeCheckerT get
   modifyMetaCtx f = TypeCheckerT $ modify f
   getFreshName typ = TypeCheckerT $ getFreshNameInternal typ

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity.hs
@@ -25,8 +25,7 @@ instance TypableBuiltin LinearityType where
   typeBuiltin = typeLinearityBuiltin
   restrictNetworkType = checkNetworkType
   restrictDatasetType = assertConstantLinearity
-  restrictParameterType = assertConstantLinearity
-  restrictInferableParameterType = assertConstantLinearity
+  restrictParameterType = const assertConstantLinearity
   restrictPropertyType _ _ = return ()
   handleTypingError = handleLinearityTypingError
   typeClassRelevancy = const $ return Relevant

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity.hs
@@ -25,8 +25,7 @@ instance TypableBuiltin PolarityType where
   typeBuiltin = typePolarityBuiltin
   restrictNetworkType = checkNetworkType
   restrictDatasetType = assertUnquantifiedPolarity
-  restrictParameterType = assertUnquantifiedPolarity
-  restrictInferableParameterType = assertUnquantifiedPolarity
+  restrictParameterType = const assertUnquantifiedPolarity
   restrictPropertyType _ _ = return ()
   handleTypingError = handlePolarityTypingError
   typeClassRelevancy = const $ return Relevant

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
@@ -27,7 +27,6 @@ instance TypableBuiltin StandardBuiltinType where
   restrictNetworkType = restrictStandardNetworkType
   restrictDatasetType = restrictStandardDatasetType
   restrictParameterType = restrictStandardParameterType
-  restrictInferableParameterType = restrictStandardInferableParameterType
   restrictPropertyType = restrictStandardPropertyType
   handleTypingError = handleStandardTypingError
   typeClassRelevancy = relevanceOfTypeClass

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/AnnotationRestrictions.hs
@@ -1,6 +1,5 @@
 module Vehicle.Compile.Type.Subsystem.Standard.AnnotationRestrictions
   ( restrictStandardParameterType,
-    restrictStandardInferableParameterType,
     restrictStandardDatasetType,
     restrictStandardNetworkType,
     restrictStandardPropertyType,
@@ -36,10 +35,20 @@ restrictStandardPropertyType decl parameterType = go (normalised parameterType)
 
 restrictStandardParameterType ::
   (MonadTypeChecker StandardBuiltinType m) =>
+  ParameterSort ->
   DeclProvenance ->
   StandardGluedType ->
   m StandardType
-restrictStandardParameterType decl parameterType = do
+restrictStandardParameterType sort = case sort of
+  NonInferable -> restrictStandardNonInferableParameterType
+  Inferable -> restrictStandardInferableParameterType
+
+restrictStandardNonInferableParameterType ::
+  (MonadTypeChecker StandardBuiltinType m) =>
+  DeclProvenance ->
+  StandardGluedType ->
+  m StandardType
+restrictStandardNonInferableParameterType decl parameterType = do
   case normalised parameterType of
     VIndexType {} -> return ()
     VNatType {} -> return ()
@@ -55,9 +64,10 @@ restrictStandardInferableParameterType ::
   DeclProvenance ->
   StandardGluedType ->
   m StandardType
-restrictStandardInferableParameterType decl parameterType = case normalised parameterType of
-  VNatType {} -> return (unnormalised parameterType)
-  _ -> throwError $ InferableParameterTypeUnsupported decl parameterType
+restrictStandardInferableParameterType decl parameterType =
+  case normalised parameterType of
+    VNatType {} -> return (unnormalised parameterType)
+    _ -> throwError $ InferableParameterTypeUnsupported decl parameterType
 
 --------------------------------------------------------------------------------
 -- Datasets

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
@@ -90,6 +90,8 @@ type StandardExplicitSpine = ExplicitSpine StandardBuiltinType
 
 type StandardEnv = Env StandardBuiltinType
 
+type StandardNormDeclCtx = NormDeclCtx StandardBuiltinType
+
 -----------------------------------------------------------------------------
 -- Glued expressions
 

--- a/vehicle/src/Vehicle/Resource.hs
+++ b/vehicle/src/Vehicle/Resource.hs
@@ -180,10 +180,10 @@ reparseResourceType = foldr (\info -> Map.insert (name info) (filePath info)) me
 -- Others
 
 warnIfUnusedResources ::
-  (MonadLogger m) =>
+  (MonadLogger m, HasName ident Name) =>
   ExternalResource ->
   Map Name a ->
-  Map Name b ->
+  Map ident b ->
   m ()
 warnIfUnusedResources resourceType given found = do
   when (null found) $
@@ -191,7 +191,7 @@ warnIfUnusedResources resourceType given found = do
       "No" <+> pretty resourceType <> "s found in program"
 
   let givenNames = Map.keysSet given
-  let foundNames = Map.keysSet found
+  let foundNames = Set.map nameOf $ Map.keysSet found
   let unusedParams = givenNames `Set.difference` foundNames
   when (Set.size unusedParams > 0) $
     logWarning $

--- a/vehicle/tests/golden/error/inferableParameter/unsupportedType/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/inferableParameter/unsupportedType/TypeCheck.err.golden
@@ -1,4 +1,4 @@
-Error at Line 2, Columns 1-2: The type of @inferable parameter 'n':
+Error at Line 2, Columns 1-2: The type of @parameter 'n':
   Rat
 is not supported. Inferable parameters must be of type 'Nat'.
 Fix: either change the type of 'n' or make the parameter non-inferable and provide the value manually.


### PR DESCRIPTION
Turns out implementing @noinline requires some medium size changes to how we handle external resource inlining. This PR adds the `@noinline` syntax to the front-end makes those changes in preparation for the actual implementation.

 In particular before, we were sneakily renormalising the entire expressions in the `expandResources` pass. This has been made much more explicit by actually forcing the `compileQueries` code to do the normalisation itself. This also makes it clear that we never actually use the glued expression representation outside of type-checking itself....