### PR TITLE
Prune type aliases

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -21,15 +21,6 @@ module Vehicle.Syntax.AST.Expr
     UniverseLevel (..),
     Telescope,
 
-    -- * Input expressions
-    InputBinding,
-    InputVar,
-    InputArg,
-    InputBinder,
-    InputExpr,
-    InputDecl,
-    InputProg,
-
     -- * Utilities
     isTypeSynonym,
     mkHole,
@@ -186,24 +177,7 @@ instance HasProvenance (Expr binder var builtin) where
     Lam p _ _ -> p
 
 --------------------------------------------------------------------------------
--- Type of input expressions, before being analysed by the compiler
-
-type InputBinding = ()
-
-type InputVar = Name
-
-type InputArg = Arg InputBinding InputVar Builtin
-
-type InputBinder = Binder InputBinding InputVar Builtin
-
-type InputExpr = Expr InputBinding InputVar Builtin
-
-type InputDecl = Decl InputBinding InputVar Builtin
-
-type InputProg = Prog InputBinding InputVar Builtin
-
---------------------------------------------------------------------------------
--- Other AST datatypes specialised to the Expr type
+-- The AST datatypes specialised to the Expr type
 
 type Type = Expr
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -19,6 +19,7 @@ module Vehicle.Syntax.AST.Expr
     Prog,
     Type,
     UniverseLevel (..),
+    Telescope,
 
     -- * Input expressions
     InputBinding,
@@ -213,6 +214,8 @@ type Arg binder var builtin = GenericArg (Expr binder var builtin)
 type Decl binder var builtin = GenericDecl (Expr binder var builtin)
 
 type Prog binder var builtin = GenericProg (Expr binder var builtin)
+
+type Telescope binder var builtin = [Binder binder var builtin]
 
 --------------------------------------------------------------------------------
 -- Utilities

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -39,10 +39,10 @@ type MonadDelab m = Monad m
 class Delaborate t bnfc | t -> bnfc, bnfc -> t where
   delabM :: (MonadDelab m) => t -> m bnfc
 
-instance Delaborate V.InputProg B.Prog where
+instance Delaborate (V.Prog () V.Name V.Builtin) B.Prog where
   delabM (V.Main decls) = B.Main . concat <$> traverse delabM decls
 
-instance Delaborate V.InputDecl [B.Decl] where
+instance Delaborate (V.Decl () V.Name V.Builtin) [B.Decl] where
   delabM = \case
     V.DefAbstract _ n a t -> do
       defFun <- B.DefFunType (delabIdentifier n) tokElemOf <$> delabM t
@@ -61,7 +61,7 @@ instance Delaborate V.InputDecl [B.Decl] where
       funDecls <- delabFun n t e
       return $ annDecls <> funDecls
 
-instance Delaborate V.InputExpr B.Expr where
+instance Delaborate (V.Expr () V.Name V.Builtin) B.Expr where
   delabM expr = case expr of
     V.Universe _ u -> return $ delabUniverse u
     V.FreeVar _ n -> return $ B.Var (delabSymbol (V.nameOf n))
@@ -78,7 +78,7 @@ instance Delaborate V.InputExpr B.Expr where
       delabApp fun' (NonEmpty.toList args)
     V.Builtin _ op -> delabBuiltin op []
 
-instance Delaborate V.InputArg B.Arg where
+instance Delaborate (V.Arg () V.Name V.Builtin) B.Arg where
   delabM arg = do
     e' <- delabM (V.argExpr arg)
     return $ case V.visibilityOf arg of
@@ -86,7 +86,7 @@ instance Delaborate V.InputArg B.Arg where
       V.Implicit {} -> B.ImplicitArg e'
       V.Instance {} -> B.InstanceArg e'
 
-instance Delaborate V.InputBinder B.BasicBinder where
+instance Delaborate (V.Binder () V.Name V.Builtin) B.BasicBinder where
   delabM binder = do
     let n' = delabSymbol $ fromMaybe "_" (V.nameOf binder)
     t' <- delabM (V.binderType binder)
@@ -104,7 +104,7 @@ instance Delaborate V.Annotation B.Decl where
 cheatDelab :: Text -> B.Expr
 cheatDelab n = B.Var (delabSymbol n)
 
-delabNameBinder :: (MonadDelab m) => V.InputBinder -> m B.NameBinder
+delabNameBinder :: (MonadDelab m) => V.Binder () V.Name V.Builtin -> m B.NameBinder
 delabNameBinder b = case V.binderNamingForm b of
   V.OnlyType {} ->
     developerError $
@@ -117,7 +117,7 @@ delabNameBinder b = case V.binderNamingForm b of
     V.Implicit {} -> B.ImplicitNameBinder (delabSymbol name)
     V.Instance {} -> B.InstanceNameBinder (delabSymbol name)
 
-delabTypeBinder :: (MonadDelab m) => V.InputBinder -> m B.TypeBinder
+delabTypeBinder :: (MonadDelab m) => V.Binder () V.Name V.Builtin -> m B.TypeBinder
 delabTypeBinder b = case V.binderNamingForm b of
   V.OnlyName {} ->
     developerError $
@@ -130,7 +130,7 @@ delabTypeBinder b = case V.binderNamingForm b of
     V.Implicit {} -> B.ImplicitTypeBinder <$> delabM (V.binderType b)
     V.Instance {} -> B.InstanceTypeBinder <$> delabM (V.binderType b)
 
-delabLetBinding :: (MonadDelab m) => (V.InputBinder, V.InputExpr) -> m B.LetDecl
+delabLetBinding :: (MonadDelab m) => (V.Binder () V.Name V.Builtin, V.Expr () V.Name V.Builtin) -> m B.LetDecl
 delabLetBinding (binder, bound) = B.LDecl <$> delabNameBinder binder <*> delabM bound
 
 delabBoolLit :: Bool -> B.Boolean
@@ -148,7 +148,7 @@ delabSymbol = mkToken B.Name
 delabIdentifier :: V.Identifier -> B.Name
 delabIdentifier (V.Identifier _ n) = mkToken B.Name n
 
-delabApp :: (MonadDelab m) => B.Expr -> [V.InputArg] -> m B.Expr
+delabApp :: (MonadDelab m) => B.Expr -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabApp fun allArgs = go fun <$> traverse delabM (reverse allArgs)
   where
     go fn [] = fn
@@ -158,7 +158,7 @@ delabUniverse :: V.UniverseLevel -> B.Expr
 delabUniverse = \case
   V.UniverseLevel l -> tokType l
 
-delabBuiltin :: (MonadDelab m) => V.Builtin -> [V.InputArg] -> m B.Expr
+delabBuiltin :: (MonadDelab m) => V.Builtin -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabBuiltin fun args = case fun of
   V.Constructor c -> delabConstructor c args
   V.TypeClassOp tc -> delabTypeClassOp tc args
@@ -166,7 +166,7 @@ delabBuiltin fun args = case fun of
   V.BuiltinFunction f -> delabBuiltinFunction f args
   V.BuiltinType t -> delabBuiltinType t args
 
-delabBuiltinFunction :: (MonadDelab m) => V.BuiltinFunction -> [V.InputArg] -> m B.Expr
+delabBuiltinFunction :: (MonadDelab m) => V.BuiltinFunction -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabBuiltinFunction fun args = case fun of
   V.And -> delabInfixOp2 B.And tokAnd args
   V.Or -> delabInfixOp2 B.Or tokOr args
@@ -189,7 +189,7 @@ delabBuiltinFunction fun args = case fun of
   V.At -> delabInfixOp2 B.At tokAt args
   V.Indices -> delabApp (B.Indices tokIndices) args
 
-delabBuiltinType :: (MonadDelab m) => V.BuiltinType -> [V.InputArg] -> m B.Expr
+delabBuiltinType :: (MonadDelab m) => V.BuiltinType -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabBuiltinType fun args = case fun of
   V.Unit -> delabApp (B.Unit tokUnit) args
   V.Bool -> delabApp (B.Bool tokBool) args
@@ -200,7 +200,7 @@ delabBuiltinType fun args = case fun of
   V.Vector -> delabApp (B.Vector tokVector) args
   V.Index -> delabApp (B.Index tokIndex) args
 
-delabTypeClass :: (MonadDelab m) => V.TypeClass -> [V.InputArg] -> m B.Expr
+delabTypeClass :: (MonadDelab m) => V.TypeClass -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabTypeClass tc args = case tc of
   V.HasEq eq -> case eq of
     V.Eq -> delabApp (B.HasEq tokHasEq) args
@@ -212,7 +212,7 @@ delabTypeClass tc args = case tc of
   V.HasFold -> delabApp (B.HasFold tokHasFold) args
   _ -> delabApp (B.Var (delabSymbol (layoutAsText $ pretty tc))) args
 
-delabConstructor :: (MonadDelab m) => V.BuiltinConstructor -> [V.InputArg] -> m B.Expr
+delabConstructor :: (MonadDelab m) => V.BuiltinConstructor -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabConstructor fun args = case fun of
   V.Cons -> delabInfixOp2 B.Cons tokCons args
   V.Nil -> delabApp (B.Nil tokNil) args
@@ -228,7 +228,7 @@ delabConstructor fun args = case fun of
   V.LRat r -> return $ B.Literal $ B.RatLiteral $ delabRatLit r
   V.LVec _ -> B.VecLiteral tokSeqOpen <$> traverse (delabM . argExpr) args <*> pure tokSeqClose
 
-delabTypeClassOp :: (MonadDelab m) => V.TypeClassOp -> [V.InputArg] -> m B.Expr
+delabTypeClassOp :: (MonadDelab m) => V.TypeClassOp -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabTypeClassOp op args = case op of
   V.FromNatTC {} -> delabApp (cheatDelab $ layoutAsText $ pretty op) args
   V.FromRatTC {} -> delabApp (cheatDelab $ layoutAsText $ pretty op) args
@@ -250,22 +250,22 @@ delabTypeClassOp op args = case op of
   V.FoldTC -> delabApp (B.Fold tokFold) args
   V.QuantifierTC q -> delabQuantifier q args
 
-delabOp1 :: (MonadDelab m, IsToken token) => (token -> B.Expr -> B.Expr) -> token -> [V.InputArg] -> m B.Expr
+delabOp1 :: (MonadDelab m, IsToken token) => (token -> B.Expr -> B.Expr) -> token -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabOp1 op tk [arg]
   | V.isExplicit arg = op tk <$> delabM (argExpr arg)
 delabOp1 _ tk args = delabApp (cheatDelab $ tkSymbol tk) args
 
-delabOp2 :: (MonadDelab m, IsToken token) => (token -> B.Expr -> B.Expr -> B.Expr) -> token -> [V.InputArg] -> m B.Expr
+delabOp2 :: (MonadDelab m, IsToken token) => (token -> B.Expr -> B.Expr -> B.Expr) -> token -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabOp2 op tk args@[arg1, arg2]
   | all V.isExplicit args = op tk <$> delabM (argExpr arg1) <*> delabM (argExpr arg2)
 delabOp2 op tk args = delabApp (cheatDelab $ tkSymbol tk) args
 
-delabOp3 :: (MonadDelab m, IsToken token) => (token -> B.Expr -> B.Expr -> B.Expr -> B.Expr) -> token -> [V.InputArg] -> m B.Expr
+delabOp3 :: (MonadDelab m, IsToken token) => (token -> B.Expr -> B.Expr -> B.Expr -> B.Expr) -> token -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabOp3 op tk args@[arg1, arg2, arg3]
   | all V.isExplicit args = op tk <$> delabM (argExpr arg1) <*> delabM (argExpr arg2) <*> delabM (argExpr arg3)
 delabOp3 op tk args = delabApp (cheatDelab $ tkSymbol tk) args
 
-delabInfixOp2 :: (MonadDelab m, IsToken token) => (B.Expr -> token -> B.Expr -> B.Expr) -> token -> [V.InputArg] -> m B.Expr
+delabInfixOp2 :: (MonadDelab m, IsToken token) => (B.Expr -> token -> B.Expr -> B.Expr) -> token -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabInfixOp2 op tk args@[arg1, arg2]
   | all V.isExplicit args = op <$> delabM (argExpr arg1) <*> pure tk <*> delabM (argExpr arg2)
 delabInfixOp2 op tk args = delabApp (cheatDelab $ tkSymbol tk) args
@@ -279,7 +279,7 @@ delabPartialSection expectedArgs actualArgs mkOp = do
   let missingBinders = fmap B.ExplicitNameBinder missingVarNames
   B.Lam tokLambda missingBinders tokArrow (mkOp (actualArgs <> missingVars))
 
-delabIf :: (MonadDelab m) => [V.InputArg] -> m B.Expr
+delabIf :: (MonadDelab m) => [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabIf args@[arg1, arg2, arg3]
   | all V.isExplicit args = do
       e1 <- delabM (argExpr arg1)
@@ -301,7 +301,7 @@ argsError s n args =
       <+> squotes (pretty (External.printTree args))
 
 -- | Collapses pi expressions into either a function or a sequence of forall bindings
-delabPi :: (MonadDelab m) => V.InputBinder -> V.InputExpr -> m B.Expr
+delabPi :: (MonadDelab m) => V.Binder () V.Name V.Builtin -> V.Expr () V.Name V.Builtin -> m B.Expr
 delabPi binder body = case V.binderNamingForm binder of
   V.OnlyType -> do
     binder' <- delabTypeBinder binder
@@ -314,7 +314,7 @@ delabPi binder body = case V.binderNamingForm binder of
     return $ B.ForallT tokForallT binders' tokDot body'
 
 -- | Collapses let expressions into a sequence of let declarations
-delabLet :: (MonadDelab m) => V.InputExpr -> V.InputBinder -> V.InputExpr -> m B.Expr
+delabLet :: (MonadDelab m) => V.Expr () V.Name V.Builtin -> V.Binder () V.Name V.Builtin -> V.Expr () V.Name V.Builtin -> m B.Expr
 delabLet bound binder body = do
   let (boundExprs, foldedBody) = foldLetBinders body
   binders' <- traverse delabLetBinding boundExprs
@@ -322,14 +322,14 @@ delabLet bound binder body = do
   return $ B.Let tokLet binders' body'
 
 -- | Collapses consecutative lambda expressions into a sequence of binders
-delabLam :: (MonadDelab m) => V.InputBinder -> V.InputExpr -> m B.Expr
+delabLam :: (MonadDelab m) => V.Binder () V.Name V.Builtin -> V.Expr () V.Name V.Builtin -> m B.Expr
 delabLam binder body = do
   let (foldedBinders, foldedBody) = foldBinders (FoldableBinder LamFold binder) body
   binders' <- traverse delabNameBinder (binder : foldedBinders)
   body' <- delabM foldedBody
   return $ B.Lam tokLambda binders' tokArrow body'
 
-delabFun :: (MonadDelab m) => V.Identifier -> V.InputExpr -> V.InputExpr -> m [B.Decl]
+delabFun :: (MonadDelab m) => V.Identifier -> V.Expr () V.Name V.Builtin -> V.Expr () V.Name V.Builtin -> m [B.Decl]
 delabFun name typ expr = do
   let n' = delabIdentifier name
   let (binders, body) = foldBinders FunFold expr
@@ -342,7 +342,7 @@ delabFun name typ expr = do
       defExpr <- B.DefFunExpr n' <$> traverse delabNameBinder binders <*> delabM body
       return [defType, defExpr]
 
-delabQuantifier :: (MonadDelab m) => V.Quantifier -> [V.InputArg] -> m B.Expr
+delabQuantifier :: (MonadDelab m) => V.Quantifier -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabQuantifier q args = case reverse args of
   V.ExplicitArg _ (V.Lam _ binder body) : _ -> do
     let (foldedBinders, foldedBody) = foldBinders (FoldableBinder (QuantFold q) binder) body
@@ -354,7 +354,7 @@ delabQuantifier q args = case reverse args of
     return $ mkTk binders' tokDot body'
   _ -> return $ cheatDelab (layoutAsText $ pretty q)
 
-delabQuantifierIn :: (MonadDelab m) => V.Quantifier -> [V.InputArg] -> m B.Expr
+delabQuantifierIn :: (MonadDelab m) => V.Quantifier -> [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabQuantifierIn q args = case reverse args of
   V.ExplicitArg _ cont : V.ExplicitArg _ (V.Lam _ binder body) : _ -> do
     binder' <- delabNameBinder binder
@@ -368,7 +368,7 @@ delabQuantifierIn q args = case reverse args of
     let sym = case q of V.Forall -> tkSymbol tokForall; V.Exists -> tkSymbol tokExists
     argsError sym 2 <$> traverse delabM args
 
-delabForeach :: (MonadDelab m) => [V.InputArg] -> m B.Expr
+delabForeach :: (MonadDelab m) => [V.Arg () V.Name V.Builtin] -> m B.Expr
 delabForeach args = case reverse args of
   V.ExplicitArg _ (V.Lam _ binder body) : _ -> do
     binder' <- delabNameBinder binder

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -110,7 +110,7 @@ delabNameBinder b = case V.binderNamingForm b of
     developerError $
       "Should not be delaborating the `OnlyType` binder named"
         <+> pretty (show (V.binderRepresentation b))
-        <+> "to a `NamedBinder`"
+        <+> "to a `Binder () Name`"
   V.NameAndType name -> B.BasicNameBinder <$> delabM b
   V.OnlyName name -> return $ case V.visibilityOf b of
     V.Explicit -> B.ExplicitNameBinder (delabSymbol name)

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
@@ -247,7 +247,7 @@ elaborateDecl ::
   (MonadError ParseError m) =>
   V.Module ->
   PartiallyParsedDecl ->
-  m V.InputDecl
+  m (V.Decl () V.Name V.Builtin)
 elaborateDecl mod decl = flip runReaderT mod $ case decl of
   V.DefAbstract p n r t -> V.DefAbstract p n r <$> elabDeclType t
   V.DefFunction p n b t e -> V.DefFunction p n b <$> elabDeclType t <*> elabDeclBody e
@@ -255,13 +255,13 @@ elaborateDecl mod decl = flip runReaderT mod $ case decl of
 elabDeclType ::
   (MonadElab m) =>
   UnparsedExpr ->
-  m V.InputExpr
+  m (V.Expr () V.Name V.Builtin)
 elabDeclType (UnparsedExpr expr) = elabExpr expr
 
 elabDeclBody ::
   (MonadElab m) =>
   UnparsedExpr ->
-  m V.InputExpr
+  m (V.Expr () V.Name V.Builtin)
 elabDeclBody (UnparsedExpr expr) = case expr of
   B.Lam tk binders _ body -> do
     binders' <- traverse (elabNameBinder True) binders
@@ -274,10 +274,10 @@ elaborateExpr ::
   (MonadError ParseError m) =>
   V.Module ->
   UnparsedExpr ->
-  m V.InputExpr
+  m (V.Expr () V.Name V.Builtin)
 elaborateExpr mod (UnparsedExpr expr) = runReaderT (elabExpr expr) mod
 
-elabExpr :: (MonadElab m) => B.Expr -> m V.InputExpr
+elabExpr :: (MonadElab m) => B.Expr -> m (V.Expr () V.Name V.Builtin)
 elabExpr = \case
   B.Type t -> V.Universe <$> mkProvenance t <*> pure (V.UniverseLevel 0)
   B.Var n -> V.BoundVar <$> mkProvenance n <*> pure (tkSymbol n)
@@ -335,7 +335,7 @@ elabExpr = \case
   B.HasMap tk -> builtinTypeClass V.HasMap tk []
   B.HasFold tk -> builtinTypeClass V.HasFold tk []
 
-elabArg :: (MonadElab m) => B.Arg -> m V.InputArg
+elabArg :: (MonadElab m) => B.Arg -> m (V.Arg () V.Name V.Builtin)
 elabArg = \case
   B.ExplicitArg e -> mkArg V.Explicit <$> elabExpr e
   B.ImplicitArg e -> mkArg (V.Implicit False) <$> elabExpr e
@@ -346,30 +346,30 @@ elabName n = do
   mod <- ask
   return $ V.Identifier mod $ tkSymbol n
 
-elabBasicBinder :: (MonadElab m) => Bool -> B.BasicBinder -> m V.InputBinder
+elabBasicBinder :: (MonadElab m) => Bool -> B.BasicBinder -> m (V.Binder () V.Name V.Builtin)
 elabBasicBinder folded = \case
   B.ExplicitBinder n _tk typ -> mkBinder folded V.Explicit . These n =<< elabExpr typ
   B.ImplicitBinder n _tk typ -> mkBinder folded (V.Implicit False) . These n =<< elabExpr typ
   B.InstanceBinder n _tk typ -> mkBinder folded (V.Instance False) . These n =<< elabExpr typ
 
-elabNameBinder :: (MonadElab m) => Bool -> B.NameBinder -> m V.InputBinder
+elabNameBinder :: (MonadElab m) => Bool -> B.NameBinder -> m (V.Binder () V.Name V.Builtin)
 elabNameBinder folded = \case
   B.ExplicitNameBinder n -> mkBinder folded V.Explicit (This n)
   B.ImplicitNameBinder n -> mkBinder folded (V.Implicit False) (This n)
   B.InstanceNameBinder n -> mkBinder folded (V.Instance False) (This n)
   B.BasicNameBinder b -> elabBasicBinder folded b
 
-elabTypeBinder :: (MonadElab m) => Bool -> B.TypeBinder -> m V.InputBinder
+elabTypeBinder :: (MonadElab m) => Bool -> B.TypeBinder -> m (V.Binder () V.Name V.Builtin)
 elabTypeBinder folded = \case
   B.ExplicitTypeBinder t -> mkBinder folded V.Explicit . That =<< elabExpr t
   B.ImplicitTypeBinder t -> mkBinder folded (V.Implicit False) . That =<< elabExpr t
   B.InstanceTypeBinder t -> mkBinder folded (V.Instance False) . That =<< elabExpr t
   B.BasicTypeBinder b -> elabBasicBinder folded b
 
-mkArg :: V.Visibility -> V.InputExpr -> V.InputArg
+mkArg :: V.Visibility -> V.Expr () V.Name V.Builtin -> V.Arg () V.Name V.Builtin
 mkArg v e = V.Arg (V.expandByArgVisibility v (V.provenanceOf e)) v V.Relevant e
 
-mkBinder :: (MonadElab m) => V.BinderFoldingForm -> V.Visibility -> These B.Name V.InputExpr -> m V.InputBinder
+mkBinder :: (MonadElab m) => V.BinderFoldingForm -> V.Visibility -> These B.Name (V.Expr () V.Name V.Builtin) -> m (V.Binder () V.Name V.Builtin)
 mkBinder folded v nameTyp = do
   (exprProv, form, typ) <- case nameTyp of
     This nameTk -> do
@@ -393,10 +393,10 @@ mkBinder folded v nameTyp = do
   let displayForm = V.BinderDisplayForm form folded
   return $ V.Binder prov displayForm v V.Relevant () typ
 
-elabLetDecl :: (MonadElab m) => B.LetDecl -> m (V.InputBinder, V.InputExpr)
+elabLetDecl :: (MonadElab m) => B.LetDecl -> m (V.Binder () V.Name V.Builtin, V.Expr () V.Name V.Builtin)
 elabLetDecl (B.LDecl b e) = bitraverse (elabNameBinder False) elabExpr (b, e)
 
-elabLiteral :: (MonadElab m) => B.Lit -> m V.InputExpr
+elabLiteral :: (MonadElab m) => B.Lit -> m (V.Expr () V.Name V.Builtin)
 elabLiteral = \case
   B.UnitLiteral -> return $ V.Builtin mempty $ V.Constructor V.LUnit
   B.BoolLiteral t -> do
@@ -443,30 +443,30 @@ op2 mk t e1 e2 = do
   let p = V.fillInProvenance (tProv :| [V.provenanceOf ce1, V.provenanceOf ce2])
   return $ mk p ce1 ce2
 
-builtin :: (MonadElab m, IsToken token) => V.Builtin -> token -> [B.Expr] -> m V.InputExpr
+builtin :: (MonadElab m, IsToken token) => V.Builtin -> token -> [B.Expr] -> m (V.Expr () V.Name V.Builtin)
 builtin b t args = do
   tProv <- mkProvenance t
   app (V.Builtin tProv b) <$> traverse elabExpr args
 
-constructor :: (MonadElab m, IsToken token) => V.BuiltinConstructor -> token -> [B.Expr] -> m V.InputExpr
+constructor :: (MonadElab m, IsToken token) => V.BuiltinConstructor -> token -> [B.Expr] -> m (V.Expr () V.Name V.Builtin)
 constructor b = builtin (V.Constructor b)
 
-builtinType :: (MonadElab m, IsToken token) => V.BuiltinType -> token -> [B.Expr] -> m V.InputExpr
+builtinType :: (MonadElab m, IsToken token) => V.BuiltinType -> token -> [B.Expr] -> m (V.Expr () V.Name V.Builtin)
 builtinType b = builtin (V.BuiltinType b)
 
-builtinTypeClass :: (MonadElab m, IsToken token) => V.TypeClass -> token -> [B.Expr] -> m V.InputExpr
+builtinTypeClass :: (MonadElab m, IsToken token) => V.TypeClass -> token -> [B.Expr] -> m (V.Expr () V.Name V.Builtin)
 builtinTypeClass b = builtin (V.TypeClass b)
 
-builtinFunction :: (MonadElab m, IsToken token) => V.BuiltinFunction -> token -> [B.Expr] -> m V.InputExpr
+builtinFunction :: (MonadElab m, IsToken token) => V.BuiltinFunction -> token -> [B.Expr] -> m (V.Expr () V.Name V.Builtin)
 builtinFunction b = builtin (V.BuiltinFunction b)
 
-app :: V.InputExpr -> [V.InputExpr] -> V.InputExpr
+app :: V.Expr () V.Name V.Builtin -> [V.Expr () V.Name V.Builtin] -> V.Expr () V.Name V.Builtin
 app fun argExprs = V.normAppList p' fun args
   where
     p' = V.fillInProvenance (V.provenanceOf fun :| map V.provenanceOf args)
     args = fmap (mkArg V.Explicit) argExprs
 
-elabVecLiteral :: (MonadElab m, IsToken token) => token -> [B.Expr] -> m V.InputExpr
+elabVecLiteral :: (MonadElab m, IsToken token) => token -> [B.Expr] -> m (V.Expr () V.Name V.Builtin)
 elabVecLiteral tk xs = do
   let n = length xs
   p <- mkProvenance tk
@@ -474,14 +474,14 @@ elabVecLiteral tk xs = do
   let lit = app (V.Builtin p $ V.Constructor $ V.LVec n) xs'
   return $ app (V.Builtin p (V.TypeClassOp V.FromVecTC)) [lit]
 
-elabApp :: (MonadElab m) => B.Expr -> B.Arg -> m V.InputExpr
+elabApp :: (MonadElab m) => B.Expr -> B.Arg -> m (V.Expr () V.Name V.Builtin)
 elabApp fun arg = do
   fun' <- elabExpr fun
   arg' <- elabArg arg
   let p = V.fillInProvenance (V.provenanceOf fun' :| [V.provenanceOf arg'])
   return $ V.normAppList p fun' [arg']
 
-elabOrder :: (MonadElab m, IsToken token) => V.OrderOp -> token -> B.Expr -> B.Expr -> m V.InputExpr
+elabOrder :: (MonadElab m, IsToken token) => V.OrderOp -> token -> B.Expr -> B.Expr -> m (V.Expr () V.Name V.Builtin)
 elabOrder order tk e1 e2 = do
   let Tk tkDetails@(tkPos, _) = toToken tk
   let chainedOrder = case e1 of
@@ -504,14 +504,14 @@ elabOrder order tk e1 e2 = do
           V.Gt -> B.Gt e (B.TokGt tkDetails) e2
 
 -- | Unfolds a list of binders into a consecutative forall expressions
-elabForallT :: (MonadElab m) => B.TokForallT -> [B.NameBinder] -> B.Expr -> m V.InputExpr
+elabForallT :: (MonadElab m) => B.TokForallT -> [B.NameBinder] -> B.Expr -> m (V.Expr () V.Name V.Builtin)
 elabForallT tk binders body = do
   p <- mkProvenance tk
   binders' <- elabNamedBinders tk binders
   body' <- elabExpr body
   return $ foldr (V.Pi p) body' binders'
 
-elabLam :: (MonadElab m) => B.TokLambda -> [B.NameBinder] -> B.Expr -> m V.InputExpr
+elabLam :: (MonadElab m) => B.TokLambda -> [B.NameBinder] -> B.Expr -> m (V.Expr () V.Name V.Builtin)
 elabLam tk binders body = do
   p <- mkProvenance tk
   binders' <- elabNamedBinders tk binders
@@ -524,7 +524,7 @@ elabQuantifier ::
   V.Quantifier ->
   [B.NameBinder] ->
   B.Expr ->
-  m V.InputExpr
+  m (V.Expr () V.Name V.Builtin)
 elabQuantifier tk q binders body = do
   p <- mkProvenance tk
   let builtin = V.Builtin p $ V.TypeClassOp $ V.QuantifierTC q
@@ -549,7 +549,7 @@ elabQuantifierIn ::
   B.NameBinder ->
   B.Expr ->
   B.Expr ->
-  m V.InputExpr
+  m (V.Expr () V.Name V.Builtin)
 elabQuantifierIn tk q binder container body = do
   p <- mkProvenance tk
   let builtin = V.FreeVar p $ case q of
@@ -574,7 +574,7 @@ elabForeach ::
   token ->
   B.NameBinder ->
   B.Expr ->
-  m V.InputExpr
+  m (V.Expr () V.Name V.Builtin)
 elabForeach tk binder body = do
   p <- mkProvenance tk
   let builtin = V.FreeVar p (V.Identifier V.StdLib "foreachVector")
@@ -590,17 +590,17 @@ elabForeach tk binder body = do
       [ mkArg V.Explicit (V.Lam p' binder' body')
       ]
 
-elabLet :: (MonadElab m) => B.TokLet -> [B.LetDecl] -> B.Expr -> m V.InputExpr
+elabLet :: (MonadElab m) => B.TokLet -> [B.LetDecl] -> B.Expr -> m (V.Expr () V.Name V.Builtin)
 elabLet tk decls body = do
   p <- mkProvenance tk
   decls' <- traverse elabLetDecl decls
   body' <- elabExpr body
   return $ foldr (insertLet p) body' decls'
   where
-    insertLet :: V.Provenance -> (V.InputBinder, V.InputExpr) -> V.InputExpr -> V.InputExpr
+    insertLet :: V.Provenance -> (V.Binder () V.Name V.Builtin, V.Expr () V.Name V.Builtin) -> V.Expr () V.Name V.Builtin -> V.Expr () V.Name V.Builtin
     insertLet p (binder, bound) = V.Let p bound binder
 
-elabNamedBinders :: (MonadElab m, IsToken token) => token -> [B.NameBinder] -> m (NonEmpty V.InputBinder)
+elabNamedBinders :: (MonadElab m, IsToken token) => token -> [B.NameBinder] -> m (NonEmpty (V.Binder () V.Name V.Builtin))
 elabNamedBinders tk binders = case binders of
   [] -> do
     p <- mkProvenance tk

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/Internal.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/Internal.hs
@@ -38,10 +38,10 @@ import Vehicle.Syntax.Prelude (developerError, readNat, readRat)
 class Elab vf vc where
   elab :: (MonadElab m) => vf -> m vc
 
-instance Elab B.Prog V.InputProg where
+instance Elab B.Prog (V.Prog () V.Name V.Builtin) where
   elab (B.Main ds) = V.Main <$> traverse elab ds
 
-instance Elab B.Decl V.InputDecl where
+instance Elab B.Decl (V.Decl () V.Name V.Builtin) where
   elab = \case
     B.DeclNetw n t -> elabDefAbstract n t V.NetworkDef
     B.DeclData n t -> elabDefAbstract n t V.DatasetDef
@@ -50,10 +50,10 @@ instance Elab B.Decl V.InputDecl where
     B.DeclPost n t -> elabDefAbstract n t V.PostulateDef
     B.DefFun n t e -> V.DefFunction <$> mkProvenance n <*> elab n <*> pure mempty <*> elab t <*> elab e
 
-elabDefAbstract :: (MonadElab m) => NameToken -> B.Expr -> V.DefAbstractSort -> m V.InputDecl
+elabDefAbstract :: (MonadElab m) => NameToken -> B.Expr -> V.DefAbstractSort -> m (V.Decl () V.Name V.Builtin)
 elabDefAbstract n t r = V.DefAbstract <$> mkProvenance n <*> elab n <*> pure r <*> elab t
 
-instance Elab B.Expr V.InputExpr where
+instance Elab B.Expr (V.Expr () V.Name V.Builtin) where
   elab = \case
     B.Type l -> convType l
     B.Hole name -> V.Hole <$> mkProvenance name <*> pure (tkSymbol name)
@@ -70,7 +70,7 @@ instance Elab B.Expr V.InputExpr where
       let p = fillInProvenance (provenanceOf fun' :| [provenanceOf arg'])
       return $ V.App p fun' (arg' :| [])
 
-instance Elab B.Binder V.InputBinder where
+instance Elab B.Binder (V.Binder () V.Name V.Builtin) where
   elab = \case
     B.RelevantExplicitBinder n e -> mkBinder n Explicit Relevant e
     B.RelevantImplicitBinder n e -> mkBinder n (Implicit False) Relevant e
@@ -79,13 +79,13 @@ instance Elab B.Binder V.InputBinder where
     B.IrrelevantImplicitBinder n e -> mkBinder n (Implicit False) Irrelevant e
     B.IrrelevantInstanceBinder n e -> mkBinder n (Instance False) Irrelevant e
     where
-      mkBinder :: (MonadElab m) => B.NameToken -> V.Visibility -> V.Relevance -> B.Expr -> m V.InputBinder
+      mkBinder :: (MonadElab m) => B.NameToken -> V.Visibility -> V.Relevance -> B.Expr -> m (V.Binder () V.Name V.Builtin)
       mkBinder n v r e = do
         let form = V.BinderDisplayForm (V.NameAndType (tkSymbol n)) False
         p <- mkProvenance n
         V.Binder p form v r () <$> elab e
 
-instance Elab B.Arg V.InputArg where
+instance Elab B.Arg (V.Arg () V.Name V.Builtin) where
   elab = \case
     B.RelevantExplicitArg e -> mkArg Explicit Relevant <$> elab e
     B.RelevantImplicitArg e -> mkArg (Implicit False) Relevant <$> elab e
@@ -94,7 +94,7 @@ instance Elab B.Arg V.InputArg where
     B.IrrelevantImplicitArg e -> mkArg (Implicit False) Irrelevant <$> elab e
     B.IrrelevantInstanceArg e -> mkArg (Instance False) Irrelevant <$> elab e
     where
-      mkArg :: V.Visibility -> V.Relevance -> V.InputExpr -> V.InputArg
+      mkArg :: V.Visibility -> V.Relevance -> V.Expr () V.Name V.Builtin -> V.Arg () V.Name V.Builtin
       mkArg v r e = V.Arg (expandByArgVisibility v (provenanceOf e)) v r e
 
 instance Elab B.Lit V.BuiltinConstructor where
@@ -141,7 +141,7 @@ op3 ::
   d
 op3 mk t1 t2 t3 = mk (provenanceOf t1 <> provenanceOf t2 <> provenanceOf t3) t1 t2 t3
 
-elabVec :: [V.InputExpr] -> V.InputExpr
+elabVec :: [V.Expr () V.Name V.Builtin] -> V.Expr () V.Name V.Builtin
 elabVec xs = do
   let vecConstructor = V.Builtin mempty (V.Constructor $ V.LVec (length xs))
   V.normAppList mempty vecConstructor (V.ExplicitArg mempty <$> xs)
@@ -149,7 +149,7 @@ elabVec xs = do
 -- | Elabs the type token into a Type expression.
 -- Doesn't run in the monad as if something goes wrong with this, we've got
 -- the grammar wrong.
-convType :: (MonadElab m) => TypeToken -> m V.InputExpr
+convType :: (MonadElab m) => TypeToken -> m (V.Expr () V.Name V.Builtin)
 convType tk = case Text.unpack (tkSymbol tk) of
   ('T' : 'y' : 'p' : 'e' : l) -> do
     p <- mkProvenance tk

--- a/vehicle-syntax/src/Vehicle/Syntax/Parse.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/Parse.hs
@@ -32,10 +32,10 @@ readAndParseProg :: (MonadError ParseError m) => Module -> Text -> m PartiallyPa
 readAndParseProg modul txt =
   castBNFCError (partiallyElabProg modul) (parseExternalProg txt)
 
-parseDecl :: (MonadError ParseError m) => Module -> PartiallyParsedDecl -> m InputDecl
+parseDecl :: (MonadError ParseError m) => Module -> PartiallyParsedDecl -> m (Decl () Name Builtin)
 parseDecl = elaborateDecl
 
-parseExpr :: (MonadError ParseError m) => Module -> UnparsedExpr -> m InputExpr
+parseExpr :: (MonadError ParseError m) => Module -> UnparsedExpr -> m (Expr () Name Builtin)
 parseExpr = elaborateExpr
 
 readExpr :: (MonadError ParseError m) => Text -> m UnparsedExpr

--- a/vehicle-syntax/src/Vehicle/Syntax/Print.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/Print.hs
@@ -30,23 +30,23 @@ class Printable a where
   printExternal :: a -> Doc b
   printExternal = pretty . bnfcPrintHack . printExternal'
 
-instance Printable InputArg where
+instance Printable (Arg () Name Builtin) where
   printInternal' = Internal.printTree . Internal.delab
   printExternal' = External.printTree . External.delab
 
-instance Printable InputBinder where
+instance Printable (Binder () Name Builtin) where
   printInternal' = Internal.printTree . Internal.delab
   printExternal' = External.printTree . External.delab
 
-instance Printable InputExpr where
+instance Printable (Expr () Name Builtin) where
   printInternal' = Internal.printTree . Internal.delab
   printExternal' = External.printTree . External.delab
 
-instance Printable InputDecl where
+instance Printable (Decl () Name Builtin) where
   printInternal' = Internal.printTree . Internal.delab
   printExternal' = External.printTree . External.delab
 
-instance Printable InputProg where
+instance Printable (Prog () Name Builtin) where
   printInternal' = Internal.printTree . Internal.delab
   printExternal' = External.printTree . External.delab
 

--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -92,15 +92,15 @@ type OutputBinding = ()
 
 type OutputVar = Name
 
-type OutputBinder = NamedBinder StandardBuiltin
+type OutputBinder = Binder () Name StandardBuiltin
 
-type OutputArg = NamedArg StandardBuiltin
+type OutputArg = Arg () Name StandardBuiltin
 
-type OutputExpr = NamedExpr StandardBuiltin
+type OutputExpr = Expr () Name StandardBuiltin
 
-type OutputDecl = NamedDecl StandardBuiltin
+type OutputDecl = Decl () Name StandardBuiltin
 
-type OutputProg = NamedProg StandardBuiltin
+type OutputProg = Prog () Name StandardBuiltin
 
 --------------------------------------------------------------------------------
 -- Modules

--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -397,7 +397,7 @@ compileExpr expr = do
   logExit result
   return result
 
-compileVar :: (MonadAgdaCompile m) => InputVar -> m Code
+compileVar :: (MonadAgdaCompile m) => Name -> m Code
 compileVar var = return $ case var of
   -- Standard library operators that we would like to compile
   "Tensor" -> annotateConstant [DataTensor] "Tensor"

--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -75,7 +75,7 @@ compileProgToAgda prog options = logCompilerPass MinDetail currentPhase $
 --------------------------------------------------------------------------------
 -- Debug functions
 
-logEntry :: (MonadAgdaCompile m) => OutputExpr -> m ()
+logEntry :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> m ()
 logEntry e = do
   incrCallDepth
   logDebug MaxDetail $ "compile-entry" <+> prettyExternal e
@@ -84,23 +84,6 @@ logExit :: (MonadAgdaCompile m) => Code -> m ()
 logExit e = do
   logDebug MaxDetail $ "compile-exit " <+> e
   decrCallDepth
-
---------------------------------------------------------------------------------
--- Type of annotations attached to the AST that are output by the compiler
-
-type OutputBinding = ()
-
-type OutputVar = Name
-
-type OutputBinder = Binder () Name StandardBuiltin
-
-type OutputArg = Arg () Name StandardBuiltin
-
-type OutputExpr = Expr () Name StandardBuiltin
-
-type OutputDecl = Decl () Name StandardBuiltin
-
-type OutputProg = Prog () Name StandardBuiltin
 
 --------------------------------------------------------------------------------
 -- Modules
@@ -352,10 +335,10 @@ setBoolLevel level = local (second (const level))
 --------------------------------------------------------------------------------
 -- Program Compilation
 
-compileProg :: (MonadAgdaCompile m) => OutputProg -> m Code
+compileProg :: (MonadAgdaCompile m) => Prog () Name StandardBuiltin -> m Code
 compileProg (Main ds) = vsep2 <$> traverse compileDecl ds
 
-compileDecl :: (MonadAgdaCompile m) => OutputDecl -> m Code
+compileDecl :: (MonadAgdaCompile m) => Decl () Name StandardBuiltin -> m Code
 compileDecl = \case
   DefAbstract _ n _ t ->
     compilePostulate (compileIdentifier n) <$> compileExpr t
@@ -368,7 +351,7 @@ compileDecl = \case
           let binders' = mapMaybe compileTopLevelBinder binders
           compileFunDef (compileIdentifier n) <$> compileExpr t <*> pure binders' <*> compileExpr body
 
-compileExpr :: (MonadAgdaCompile m) => OutputExpr -> m Code
+compileExpr :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> m Code
 compileExpr expr = do
   logEntry expr
   result <- case expr of
@@ -404,7 +387,7 @@ compileVar var = return $ case var of
   -- Other variables
   v -> annotateConstant [] (pretty v)
 
-compileApp :: (MonadAgdaCompile m) => OutputExpr -> NonEmpty OutputArg -> m Code
+compileApp :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> NonEmpty (Arg () Name StandardBuiltin) -> m Code
 compileApp fun args = do
   specialResult <- case fun of
     Builtin _ b -> Just <$> compileBuiltin b (NonEmpty.toList args)
@@ -420,7 +403,7 @@ compileApp fun args = do
       cArgs <- traverse compileExpr (filterOutNonExplicitArgs args)
       return $ annotateApp [] cFun cArgs
 
-compileStdLibFunction :: (MonadAgdaCompile m) => StdLibFunction -> NonEmpty OutputArg -> m (Maybe Code)
+compileStdLibFunction :: (MonadAgdaCompile m) => StdLibFunction -> NonEmpty (Arg () Name StandardBuiltin) -> m (Maybe Code)
 compileStdLibFunction fn args = case fn of
   StdTensor -> do
     let fun' = annotateConstant [DataTensor] "Tensor"
@@ -443,21 +426,21 @@ compileStdLibFunction fn args = case fn of
 
 compileLetBinder ::
   (MonadAgdaCompile m) =>
-  LetBinder OutputBinding OutputVar StandardBuiltin ->
+  LetBinder () Name StandardBuiltin ->
   m Code
 compileLetBinder (binder, expr) = do
   let binderName = pretty (getBinderName binder)
   cExpr <- compileExpr expr
   return $ binderName <+> "=" <+> cExpr
 
-compileLam :: (MonadAgdaCompile m) => OutputBinder -> OutputExpr -> m Code
+compileLam :: (MonadAgdaCompile m) => Binder () Name StandardBuiltin -> Expr () Name StandardBuiltin -> m Code
 compileLam binder expr = do
   let (binders, body) = foldBinders (FoldableBinder LamFold binder) expr
   cBinders <- traverse compileBinder (binder : binders)
   cBody <- compileExpr body
   return $ annotate (mempty, minPrecedence) ("λ" <+> hsep cBinders <+> arrow <+> cBody)
 
-compileArg :: (MonadAgdaCompile m) => OutputArg -> m Code
+compileArg :: (MonadAgdaCompile m) => Arg () Name StandardBuiltin -> m Code
 compileArg arg = argBrackets (visibilityOf arg) <$> compileExpr (argExpr arg)
 
 compileAnn :: Code -> Code -> Code
@@ -478,7 +461,7 @@ compileType (UniverseLevel l)
   | l == 0 = "Set"
   | otherwise = annotateConstant [] ("Set" <> pretty l)
 
-compileTopLevelBinder :: OutputBinder -> Maybe Code
+compileTopLevelBinder :: Binder () Name StandardBuiltin -> Maybe Code
 compileTopLevelBinder binder
   | visibilityOf binder /= Explicit = Nothing
   | otherwise = do
@@ -486,7 +469,7 @@ compileTopLevelBinder binder
       let addBrackets = binderBrackets True (visibilityOf binder)
       Just $ addBrackets binderName
 
-compileBinder :: (MonadAgdaCompile m) => OutputBinder -> m Code
+compileBinder :: (MonadAgdaCompile m) => Binder () Name StandardBuiltin -> m Code
 compileBinder binder = do
   binderType <- compileExpr (typeOf binder)
   (binderDoc, noExplicitBrackets) <- case binderNamingForm binder of
@@ -519,7 +502,7 @@ agdaDivRat = annotateInfixOp2 [DataRat] 7 id (Just ratQualifier) "/"
 agdaNatToFin :: [Code] -> Code
 agdaNatToFin = annotateInfixOp1 [DataFin] 10 Nothing "#"
 
-compileBuiltin :: (MonadAgdaCompile m) => StandardBuiltin -> [OutputArg] -> m Code
+compileBuiltin :: (MonadAgdaCompile m) => StandardBuiltin -> [Arg () Name StandardBuiltin] -> m Code
 compileBuiltin (CType (StandardTypeClassOp op)) allArgs
   | not (isTypeClassInAgda op) = do
       let result = nfTypeClassOp mempty op allArgs
@@ -610,7 +593,7 @@ nfTypeClassOp _p op args = do
         compilerDeveloperError $
           "Type class operation with no further arguments:" <+> pretty op
 
-compileTypeClass :: (MonadAgdaCompile m) => Code -> OutputExpr -> m Code
+compileTypeClass :: (MonadAgdaCompile m) => Code -> Expr () Name StandardBuiltin -> m Code
 compileTypeClass name arg = do
   arg' <- compileExpr arg
   return $ annotateApp [] name [arg']
@@ -618,8 +601,8 @@ compileTypeClass name arg = do
 compileTypeLevelQuantifier ::
   (MonadAgdaCompile m) =>
   Quantifier ->
-  NonEmpty OutputBinder ->
-  OutputExpr ->
+  NonEmpty (Binder () Name StandardBuiltin) ->
+  Expr () Name StandardBuiltin ->
   m Code
 compileTypeLevelQuantifier q binders body = do
   cBinders <- traverse compileBinder binders
@@ -629,7 +612,7 @@ compileTypeLevelQuantifier q binders body = do
     Exists -> return $ annotateConstant [DataProduct] "∃ λ"
   return $ quant <+> hsep cBinders <+> arrow <+> cBody
 
-compileQuantIn :: (MonadAgdaCompile m) => Quantifier -> OutputExpr -> OutputExpr -> OutputExpr -> m Code
+compileQuantIn :: (MonadAgdaCompile m) => Quantifier -> Expr () Name StandardBuiltin -> Expr () Name StandardBuiltin -> Expr () Name StandardBuiltin -> m Code
 compileQuantIn q tCont fn cont = do
   boolLevel <- getBoolLevel
 
@@ -663,7 +646,7 @@ compileRatLiteral r = agdaDivRat [num, denom]
     denom = compileNatLiteral (denominator r)
 
 -- | Compiling vector literals. No literals in Agda so have to go via cons.
-compileVecLiteral :: (MonadAgdaCompile m) => [OutputExpr] -> m Code
+compileVecLiteral :: (MonadAgdaCompile m) => [Expr () Name StandardBuiltin] -> m Code
 compileVecLiteral = \case
   [] -> return $ annotateConstant [DataVector] "[]ᵥ"
   (x : xs) -> do
@@ -785,7 +768,7 @@ isRatType :: Type binder var StandardBuiltin -> Bool
 isRatType RatType {} = True
 isRatType _ = False
 
-compileOrder :: (MonadAgdaCompile m) => OrderOp -> OutputExpr -> [Code] -> m Code
+compileOrder :: (MonadAgdaCompile m) => OrderOp -> Expr () Name StandardBuiltin -> [Code] -> m Code
 compileOrder originalOrder elemType originalArgs = do
   boolLevel <- getBoolLevel
 
@@ -816,10 +799,10 @@ compileOrder originalOrder elemType originalArgs = do
   let opDoc = orderDoc <> boolDecDoc
   return $ annotateInfixOp2 dependencies 4 opBraces (Just qualifier) opDoc args
 
-compileAt :: (MonadAgdaCompile m) => OutputExpr -> OutputExpr -> m Code
+compileAt :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> Expr () Name StandardBuiltin -> m Code
 compileAt xs i = annotateApp [] <$> compileExpr xs <*> traverse compileExpr [i]
 
-compileEquality :: (MonadAgdaCompile m) => OutputExpr -> [Code] -> m Code
+compileEquality :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> [Code] -> m Code
 compileEquality tElem args = do
   boolLevel <- getBoolLevel
   case boolLevel of
@@ -830,7 +813,7 @@ compileEquality tElem args = do
       instanceArgDependencies <- equalityDependencies tElem
       return $ annotateInfixOp2 ([RelNullary] <> instanceArgDependencies) 4 boolBraces Nothing "≟" args
 
-compileInequality :: (MonadAgdaCompile m) => OutputExpr -> [Code] -> m Code
+compileInequality :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> [Code] -> m Code
 compileInequality tElem args = do
   boolLevel <- getBoolLevel
   case boolLevel of
@@ -878,7 +861,7 @@ compileProperty propertyName propertyBody = do
                 )
 
 -- Calculates the dependencies needed for equality over the provided type
-equalityDependencies :: (MonadAgdaCompile m) => OutputExpr -> m [Dependency]
+equalityDependencies :: (MonadAgdaCompile m) => Expr () Name StandardBuiltin -> m [Dependency]
 equalityDependencies = \case
   NatType _ -> return [DataNatInstances]
   IntType _ -> return [DataIntegerInstances]
@@ -896,7 +879,7 @@ equalityDependencies = \case
   BoundVar p n -> throwError $ UnsupportedPolymorphicEquality Agda p n
   t -> unexpectedTypeError t (map pretty [Bool, Nat, Int, List, Vector] <> [pretty (identifierName TensorIdent)])
 
-unexpectedTypeError :: (MonadCompile m) => OutputExpr -> [Doc ()] -> m a
+unexpectedTypeError :: (MonadCompile m) => Expr () Name StandardBuiltin -> [Doc ()] -> m a
 unexpectedTypeError actualType expectedTypes =
   compilerDeveloperError $
     "Unexpected type found."
@@ -914,9 +897,9 @@ currentPhase = "compilation to Agda"
 -- user syntax.
 pattern ITensorType ::
   Provenance ->
-  OutputExpr ->
-  OutputExpr ->
-  OutputExpr
+  Expr () Name StandardBuiltin ->
+  Expr () Name StandardBuiltin ->
+  Expr () Name StandardBuiltin
 pattern ITensorType p tElem tDims <-
   App
     p

--- a/vehicle/src/Vehicle/Backend/LossFunction/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/LossFunction/Compile.hs
@@ -63,13 +63,13 @@ compile _resources logic typedProg = do
 currentPass :: Doc a
 currentPass = "compilation to loss functions"
 
-type InputProg = V.NamedProg V.StandardBuiltin
+type InputProg = V.Prog () V.Name V.StandardBuiltin
 
-type InputDecl = V.NamedDecl V.StandardBuiltin
+type InputDecl = V.Decl () V.Name V.StandardBuiltin
 
-type InputExpr = V.NamedExpr V.StandardBuiltin
+type InputExpr = V.Expr () V.Name V.StandardBuiltin
 
-type InputArg = V.NamedArg V.StandardBuiltin
+type InputArg = V.Arg () V.Name V.StandardBuiltin
 
 --------------------------------------------------------------------------------
 -- Main compilation pass
@@ -301,7 +301,7 @@ reformatLogicalOperators ::
   m InputProg
 reformatLogicalOperators logic = traverse (V.traverseBuiltinsM builtinUpdateFunction)
   where
-    builtinUpdateFunction :: V.BuiltinUpdate m V.NamedBinding V.NamedVar V.StandardBuiltin V.StandardBuiltin
+    builtinUpdateFunction :: V.BuiltinUpdate m () V.Name V.StandardBuiltin V.StandardBuiltin
     builtinUpdateFunction p1 p2 b args = case b of
       V.CFunction V.Not
         | isNothing (compileNot (implementationOf logic)) ->

--- a/vehicle/src/Vehicle/Backend/LossFunction/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/LossFunction/Compile.hs
@@ -63,14 +63,6 @@ compile _resources logic typedProg = do
 currentPass :: Doc a
 currentPass = "compilation to loss functions"
 
-type InputProg = V.Prog () V.Name V.StandardBuiltin
-
-type InputDecl = V.Decl () V.Name V.StandardBuiltin
-
-type InputExpr = V.Expr () V.Name V.StandardBuiltin
-
-type InputArg = V.Arg () V.Name V.StandardBuiltin
-
 --------------------------------------------------------------------------------
 -- Main compilation pass
 
@@ -78,7 +70,7 @@ type InputArg = V.Arg () V.Name V.StandardBuiltin
 compileProg ::
   (MonadCompile m) =>
   DifferentiableLogic ->
-  InputProg ->
+  V.Prog () V.Name V.StandardBuiltin ->
   m [LDecl]
 compileProg logic (V.Main ds) =
   logCompilerPass MinDetail "compilation to loss function" $
@@ -88,7 +80,7 @@ compileProg logic (V.Main ds) =
 compileDecl ::
   (MonadCompile m, MonadState (Set V.Name) m) =>
   DifferentiableLogic ->
-  InputDecl ->
+  V.Decl () V.Name V.StandardBuiltin ->
   m (Maybe LDecl)
 compileDecl logic = \case
   V.DefAbstract _ ident r _ -> do
@@ -107,11 +99,11 @@ type MonadCompileLoss m =
     MonadState (Set V.Name) m
   )
 
-compileArg :: (MonadCompileLoss m) => DifferentialLogicImplementation -> InputArg -> m LExpr
+compileArg :: (MonadCompileLoss m) => DifferentialLogicImplementation -> V.Arg () V.Name V.StandardBuiltin -> m LExpr
 compileArg t arg = compileExpr t (V.argExpr arg)
 
 -- | Compile a property or single expression
-compileExpr :: (MonadCompileLoss m) => DifferentialLogicImplementation -> InputExpr -> m LExpr
+compileExpr :: (MonadCompileLoss m) => DifferentialLogicImplementation -> V.Expr () V.Name V.StandardBuiltin -> m LExpr
 compileExpr t expr = showExit $ do
   e' <- showEntry expr
   case e' of
@@ -208,7 +200,7 @@ compileStdLibFunction ::
   (MonadCompileLoss m) =>
   StdLibFunction ->
   DifferentialLogicImplementation ->
-  NonEmpty InputArg ->
+  NonEmpty (V.Arg () V.Name V.StandardBuiltin) ->
   m LExpr
 compileStdLibFunction fn t args = case fn of
   StdEqualsBool -> compileEquality V.Eq t =<< compileExplicitArgs t args
@@ -274,7 +266,7 @@ compileQuant :: V.Quantifier -> Quantifier
 compileQuant V.Forall = All
 compileQuant V.Exists = Any
 
-compileExplicitArgs :: (MonadCompileLoss m) => DifferentialLogicImplementation -> NonEmpty InputArg -> m [LExpr]
+compileExplicitArgs :: (MonadCompileLoss m) => DifferentialLogicImplementation -> NonEmpty (V.Arg () V.Name V.StandardBuiltin) -> m [LExpr]
 compileExplicitArgs t args = do
   let explicitArgs = argExpr <$> NonEmpty.filter V.isExplicit args
   traverse (compileExpr t) explicitArgs
@@ -297,8 +289,8 @@ reformatLogicalOperators ::
   forall m.
   (MonadCompile m) =>
   DifferentiableLogic ->
-  InputProg ->
-  m InputProg
+  V.Prog () V.Name V.StandardBuiltin ->
+  m (V.Prog () V.Name V.StandardBuiltin)
 reformatLogicalOperators logic = traverse (V.traverseBuiltinsM builtinUpdateFunction)
   where
     builtinUpdateFunction :: V.BuiltinUpdate m () V.Name V.StandardBuiltin V.StandardBuiltin
@@ -314,7 +306,7 @@ reformatLogicalOperators logic = traverse (V.traverseBuiltinsM builtinUpdateFunc
             return (V.OrExpr p1 (flattenOrs (V.ExplicitArg p1 (V.OrExpr p1 (NonEmpty.fromList args)))))
       _ -> return $ V.normAppList p1 (V.Builtin p2 b) args
 
-    lowerNot :: V.Provenance -> InputExpr -> m InputExpr
+    lowerNot :: V.Provenance -> V.Expr () V.Name V.StandardBuiltin -> m (V.Expr () V.Name V.StandardBuiltin)
     lowerNot notProv arg = case arg of
       -- Base cases
       V.BoolLiteral p b -> return $ V.BoolLiteral p (not b)
@@ -339,12 +331,12 @@ reformatLogicalOperators logic = traverse (V.traverseBuiltinsM builtinUpdateFunc
       -- Errors
       e -> throwError $ UnsupportedNegatedOperation logic notProv e
 
-    flattenAnds :: InputArg -> NonEmpty InputArg
+    flattenAnds :: V.Arg () V.Name V.StandardBuiltin -> NonEmpty (V.Arg () V.Name V.StandardBuiltin)
     flattenAnds arg = case argExpr arg of
       V.AndExpr _ [e1, e2] -> flattenAnds e1 <> flattenAnds e2
       _ -> [arg]
 
-    flattenOrs :: InputArg -> NonEmpty InputArg
+    flattenOrs :: V.Arg () V.Name V.StandardBuiltin -> NonEmpty (V.Arg () V.Name V.StandardBuiltin)
     flattenOrs arg = case argExpr arg of
       V.OrExpr _ [e1, e2] -> flattenOrs e1 <> flattenOrs e2
       _ -> [arg]
@@ -352,7 +344,7 @@ reformatLogicalOperators logic = traverse (V.traverseBuiltinsM builtinUpdateFunc
 -----------------------------------------------------------------------
 -- Debugging options
 
-showEntry :: (MonadCompile m) => InputExpr -> m InputExpr
+showEntry :: (MonadCompile m) => V.Expr () V.Name V.StandardBuiltin -> m (V.Expr () V.Name V.StandardBuiltin)
 showEntry e = do
   logDebug MinDetail ("loss-entry " <> prettyFriendly e)
   incrCallDepth

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -33,13 +33,13 @@ runNaiveCoDBDescope e1 =
 class DescopeNamed a b | a -> b where
   descopeNamed :: a -> b
 
-instance DescopeNamed (DBProg builtin) (Prog InputBinding InputVar builtin) where
+instance DescopeNamed (Prog () Ix builtin) (Prog InputBinding InputVar builtin) where
   descopeNamed = fmap (runWithNoCtx descopeNamed)
 
-instance DescopeNamed (DBDecl builtin) (Decl InputBinding InputVar builtin) where
+instance DescopeNamed (Decl () Ix builtin) (Decl InputBinding InputVar builtin) where
   descopeNamed = fmap (runWithNoCtx descopeNamed)
 
-instance DescopeNamed (Contextualised (DBExpr builtin) BoundDBCtx) (Expr InputBinding InputVar builtin) where
+instance DescopeNamed (Contextualised (Expr () Ix builtin) BoundDBCtx) (Expr InputBinding InputVar builtin) where
   descopeNamed = performDescoping descopeDBIndexVar
 
 instance
@@ -62,10 +62,10 @@ instance
 class DescopeNaive a b | a -> b where
   descopeNaive :: a -> b
 
-instance DescopeNaive (DBProg builtin) (Prog InputBinding InputVar builtin) where
+instance DescopeNaive (Prog () Ix builtin) (Prog InputBinding InputVar builtin) where
   descopeNaive = fmap descopeNaive
 
-instance DescopeNaive (DBDecl builtin) (Decl InputBinding InputVar builtin) where
+instance DescopeNaive (Decl () Ix builtin) (Decl InputBinding InputVar builtin) where
   descopeNaive = fmap descopeNaive
 
 instance DescopeNaive (Expr DBBinding Ix builtin) (Expr InputBinding InputVar builtin) where

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -8,7 +8,7 @@ import Control.Monad.Reader (MonadReader (..), Reader, runReader)
 import Vehicle.Compile.Prelude
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalisable
-import Vehicle.Expr.Normalised (NormBinder, Spine, Value (..))
+import Vehicle.Expr.Normalised (Spine, VBinder, Value (..))
 
 --------------------------------------------------------------------------------
 -- Public interface
@@ -187,7 +187,7 @@ descopeSpine f = fmap (fmap (descopeNormExpr f))
 
 descopeNormBinder ::
   (Provenance -> Lv -> Name) ->
-  NormBinder types ->
+  VBinder types ->
   Binder () Name (NormalisableBuiltin types)
 descopeNormBinder f = fmap (descopeNormExpr f)
 

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -68,7 +68,7 @@ instance DescopeNaive (Prog () Ix builtin) (Prog InputBinding InputVar builtin) 
 instance DescopeNaive (Decl () Ix builtin) (Decl InputBinding InputVar builtin) where
   descopeNaive = fmap descopeNaive
 
-instance DescopeNaive (Expr DBBinding Ix builtin) (Expr InputBinding InputVar builtin) where
+instance DescopeNaive (Expr () Ix builtin) (Expr InputBinding InputVar builtin) where
   descopeNaive = runWithNoCtx (performDescoping descopeDBIndexVarNaive)
 
 instance
@@ -101,7 +101,7 @@ addBinderToCtx binder (Ctx ctx) = Ctx (nameOf binder : ctx)
 performDescoping ::
   (Show var) =>
   (Provenance -> var -> Reader Ctx Name) ->
-  Contextualised (Expr DBBinding var builtin) BoundDBCtx ->
+  Contextualised (Expr () var builtin) BoundDBCtx ->
   Expr InputBinding InputVar builtin
 performDescoping convertVar (WithContext e ctx) =
   runReader (descopeExpr convertVar e) (Ctx ctx)
@@ -111,7 +111,7 @@ type MonadDescope m = MonadReader Ctx m
 descopeExpr ::
   (MonadDescope m, Show var) =>
   (Provenance -> var -> m Name) ->
-  Expr DBBinding var builtin ->
+  Expr () var builtin ->
   m (Expr InputBinding InputVar builtin)
 descopeExpr f e = showScopeExit $ case showScopeEntry e of
   Universe p l -> return $ Universe p l
@@ -139,14 +139,14 @@ descopeExpr f e = showScopeExit $ case showScopeEntry e of
 descopeBinder ::
   (MonadReader Ctx f, Show var) =>
   (Provenance -> var -> f Name) ->
-  Binder DBBinding var builtin ->
+  Binder () var builtin ->
   f (Binder InputBinding InputVar builtin)
 descopeBinder f = traverse (descopeExpr f)
 
 descopeArg ::
   (MonadReader Ctx f, Show var) =>
   (Provenance -> var -> f Name) ->
-  Arg DBBinding var builtin ->
+  Arg () var builtin ->
   f (Arg InputBinding InputVar builtin)
 descopeArg f = traverse (descopeExpr f)
 
@@ -214,7 +214,7 @@ descopeCoDBVarNaive _ = \case
 --------------------------------------------------------------------------------
 -- Logging and errors
 
-showScopeEntry :: (Show var) => Expr DBBinding var builtin -> Expr DBBinding var builtin
+showScopeEntry :: (Show var) => Expr () var builtin -> Expr () var builtin
 showScopeEntry e =
   e
 

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -8,7 +8,7 @@ import Control.Monad.Reader (MonadReader (..), Reader, runReader)
 import Vehicle.Compile.Prelude
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalisable
-import Vehicle.Expr.Normalised (NormBinder, NormExpr (..), Spine)
+import Vehicle.Expr.Normalised (NormBinder, Spine, Value (..))
 
 --------------------------------------------------------------------------------
 -- Public interface
@@ -83,7 +83,7 @@ instance
   where
   descopeNaive = fmap descopeNaive
 
-instance DescopeNaive (NormExpr types) (Expr () Name (NormalisableBuiltin types)) where
+instance DescopeNaive (Value types) (Expr () Name (NormalisableBuiltin types)) where
   descopeNaive = descopeNormExpr descopeDBLevelVarNaive
 
 --------------------------------------------------------------------------------
@@ -151,10 +151,10 @@ descopeArg ::
 descopeArg f = traverse (descopeExpr f)
 
 -- | This function is not meant to do anything sensible and is merely
--- used for printing `NormExpr`s in a readable form.
+-- used for printing `Value`s in a readable form.
 descopeNormExpr ::
   (Provenance -> Lv -> Name) ->
-  NormExpr types ->
+  Value types ->
   Expr () Name (NormalisableBuiltin types)
 descopeNormExpr f e = case e of
   VUniverse u -> Universe p u

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -113,7 +113,7 @@ data CompileError
   | UnsupportedVariableType QueryFormatID Identifier Provenance Name StandardNormType StandardNormType [Builtin]
   | UnsupportedAlternatingQuantifiers QueryFormatID DeclProvenance Quantifier Provenance PolarityProvenance
   | UnsupportedNonLinearConstraint QueryFormatID DeclProvenance Provenance LinearityProvenance LinearityProvenance
-  | UnsupportedNegatedOperation DifferentiableLogic Provenance (NamedExpr StandardBuiltin)
+  | UnsupportedNegatedOperation DifferentiableLogic Provenance (Expr () Name StandardBuiltin)
   deriving (Show)
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -7,10 +7,10 @@ import Data.List.NonEmpty (NonEmpty)
 import Prettyprinter (list)
 import Vehicle.Backend.Prelude
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Linearity.Core
 import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
+import Vehicle.Expr.Normalisable (NormalisableArg)
 import Vehicle.Syntax.Parse (ParseError)
 import Vehicle.Verify.Core (QueryFormatID)
 
@@ -51,7 +51,7 @@ data CompileError
       StandardType -- The expected type.
   | MissingExplicitArg
       BoundDBCtx -- The context at the time of the failure
-      (UncheckedArg StandardBuiltinType) -- The non-explicit argument
+      (NormalisableArg StandardBuiltinType) -- The non-explicit argument
       StandardType -- Expected type of the argument
   | UnsolvedConstraints (NonEmpty (WithContext StandardConstraint))
   | UnsolvedMetas (NonEmpty (MetaID, Provenance))

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -1454,7 +1454,7 @@ prettyOrdinal object argNo argTotal
       9 -> "ninth"
       _ -> developerError "Cannot convert ordinal"
 
-prettyTypeClassConstraintOriginExpr :: StandardConstraintContext -> TypeCheckedExpr -> [UncheckedArg StandardBuiltinType] -> Doc a
+prettyTypeClassConstraintOriginExpr :: StandardConstraintContext -> TypeCheckedExpr -> [NormalisableArg StandardBuiltinType] -> Doc a
 prettyTypeClassConstraintOriginExpr ctx fun args = case fun of
   Builtin _ b
     -- Need to check whether the function was introduced as part of desugaring

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -141,7 +141,7 @@ eval env expr = do
   showExit env result
   return result
 
-evalBinder :: (MonadNorm types m) => Env types -> NormalisableBinder types -> m (NormBinder types)
+evalBinder :: (MonadNorm types m) => Env types -> NormalisableBinder types -> m (VBinder types)
 evalBinder env = traverse (eval env)
 
 evalApp :: (MonadNorm types m) => Value types -> Spine types -> m (Value types)

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -49,7 +49,7 @@ whnf ::
   (MonadNorm types m) =>
   Env types ->
   NormalisableExpr types ->
-  m (NormExpr types)
+  m (Value types)
 whnf = eval
 
 -----------------------------------------------------------------------------
@@ -105,7 +105,7 @@ instance (MonadCompile m, PrintableBuiltin types) => MonadNorm types (NormT type
 -- Evaluation
 
 -- TODO change to return a tuple of NF and WHNF?
-eval :: (MonadNorm types m) => Env types -> NormalisableExpr types -> m (NormExpr types)
+eval :: (MonadNorm types m) => Env types -> NormalisableExpr types -> m (Value types)
 eval env expr = do
   showEntry env expr
   result <- case expr of
@@ -144,7 +144,7 @@ eval env expr = do
 evalBinder :: (MonadNorm types m) => Env types -> NormalisableBinder types -> m (NormBinder types)
 evalBinder env = traverse (eval env)
 
-evalApp :: (MonadNorm types m) => NormExpr types -> Spine types -> m (NormExpr types)
+evalApp :: (MonadNorm types m) => Value types -> Spine types -> m (Value types)
 evalApp fun [] = return fun
 evalApp fun (arg : args) = do
   showApp fun (arg : args)
@@ -170,7 +170,7 @@ evalApp fun (arg : args) = do
     VUniverse {} -> unexpectedExprError currentPass "VUniverse"
     VPi {} -> unexpectedExprError currentPass "VPi"
 
-lookupIn :: (MonadCompile m) => Provenance -> Ix -> Env types -> m (NormExpr types)
+lookupIn :: (MonadCompile m) => Provenance -> Ix -> Env types -> m (Value types)
 lookupIn p i env = case lookupVar env i of
   Just (_, value) -> return value
   Nothing ->
@@ -185,7 +185,7 @@ lookupIn p i env = case lookupVar env i of
 -----------------------------------------------------------------------------
 -- Reevaluation
 
-reeval :: (MonadNorm types m) => NormExpr types -> m (NormExpr types)
+reeval :: (MonadNorm types m) => Value types -> m (Value types)
 reeval expr = case expr of
   VUniverse {} -> return expr
   VLam {} -> return expr
@@ -203,7 +203,7 @@ reevalSpine = traverse (traverse reeval)
 
 -- | Recursively forces the evaluation of any meta-variables at the head
 -- of the expresson.
-forceHead :: (MonadNorm types m) => ConstraintContext types -> NormExpr types -> m (NormExpr types, MetaSet)
+forceHead :: (MonadNorm types m) => ConstraintContext types -> Value types -> m (Value types, MetaSet)
 forceHead ctx expr = do
   (maybeForcedExpr, blockingMetas) <- forceExpr expr
   forcedExpr <- case maybeForcedExpr of
@@ -216,16 +216,16 @@ forceHead ctx expr = do
 
 -- | Recursively forces the evaluation of any meta-variables that are blocking
 -- evaluation.
-forceExpr :: forall types m. (MonadNorm types m) => NormExpr types -> m (Maybe (NormExpr types), MetaSet)
+forceExpr :: forall types m. (MonadNorm types m) => Value types -> m (Maybe (Value types), MetaSet)
 forceExpr = go
   where
-    go :: NormExpr types -> m (Maybe (NormExpr types), MetaSet)
+    go :: Value types -> m (Maybe (Value types), MetaSet)
     go = \case
       VMeta m spine -> goMeta m spine
       VBuiltin b spine -> forceBuiltin b spine
       _ -> return (Nothing, mempty)
 
-    goMeta :: MetaID -> Spine types -> m (Maybe (NormExpr types), MetaSet)
+    goMeta :: MetaID -> Spine types -> m (Maybe (Value types), MetaSet)
     goMeta m spine = do
       metaSubst <- getMetaSubstitution
       case MetaMap.lookup m metaSubst of
@@ -236,7 +236,7 @@ forceExpr = go
           return (forcedExpr, blockingMetas)
         Nothing -> return (Nothing, MetaSet.singleton m)
 
-forceArg :: (MonadNorm types m) => NormExpr types -> m (NormExpr types, Bool, MetaSet)
+forceArg :: (MonadNorm types m) => Value types -> m (Value types, Bool, MetaSet)
 forceArg expr = do
   (maybeResult, blockingMetas) <- forceExpr expr
   let result = fromMaybe expr maybeResult
@@ -247,7 +247,7 @@ forceBuiltin ::
   (MonadNorm types m) =>
   NormalisableBuiltin types ->
   ExplicitSpine types ->
-  m (Maybe (NormExpr types), MetaSet)
+  m (Maybe (Value types), MetaSet)
 forceBuiltin b spine = case b of
   CConstructor {} -> return (Nothing, mempty)
   CType {} -> return (Nothing, mempty)
@@ -270,13 +270,13 @@ evalBuiltin ::
   (MonadNorm types m) =>
   NormalisableBuiltin types ->
   ExplicitSpine types ->
-  m (NormExpr types)
+  m (Value types)
 evalBuiltin b args = case b of
   CConstructor {} -> return $ VBuiltin b args
   CType {} -> return $ VBuiltin b args
   CFunction f -> evalBuiltinFunction f args
 
-evalBuiltinFunction :: (MonadNorm types m) => BuiltinFunction -> ExplicitSpine types -> m (NormExpr types)
+evalBuiltinFunction :: (MonadNorm types m) => BuiltinFunction -> ExplicitSpine types -> m (Value types)
 evalBuiltinFunction b args
   | isDerived b = evalDerivedBuiltin b args
   | otherwise = do
@@ -314,7 +314,7 @@ evalDerivedBuiltin ::
   (MonadNorm types m) =>
   BuiltinFunction ->
   ExplicitSpine types ->
-  m (NormExpr types)
+  m (Value types)
 evalDerivedBuiltin b args = case b of
   Implies -> evalImplies args
   _ -> compilerDeveloperError $ "Invalid derived types" <+> quotePretty b
@@ -322,9 +322,9 @@ evalDerivedBuiltin b args = case b of
 -----------------------------------------------------------------------------
 -- Indvidual builtins
 
-type EvalBuiltin types m = ExplicitSpine types -> Maybe (m (NormExpr types))
+type EvalBuiltin types m = ExplicitSpine types -> Maybe (m (Value types))
 
-type EvalSimpleBuiltin types = ExplicitSpine types -> Maybe (NormExpr types)
+type EvalSimpleBuiltin types = ExplicitSpine types -> Maybe (Value types)
 
 evalNot :: EvalSimpleBuiltin types
 evalNot e = case e of
@@ -565,7 +565,7 @@ evalIndices = \case
 -----------------------------------------------------------------------------
 -- Derived
 
-type EvalDerived types m = ExplicitSpine types -> m (NormExpr types)
+type EvalDerived types m = ExplicitSpine types -> m (Value types)
 
 -- TODO define in terms of language
 
@@ -588,14 +588,14 @@ showEntry _env _expr = do
   -- logDebug MaxDetail $ "nbe-entry" <+> prettyFriendly (WithContext expr (fmap fst env)) <+> "   { env=" <+> prettyVerbose env <+> "}"
   incrCallDepth
 
-showExit :: (MonadNorm types m) => Env types -> NormExpr types -> m ()
+showExit :: (MonadNorm types m) => Env types -> Value types -> m ()
 showExit _env _result = do
   decrCallDepth
   -- logDebug MaxDetail $ "nbe-exit" <+> prettyVerbose result
   -- logDebug MaxDetail $ "nbe-exit" <+> prettyFriendly (WithContext result (fmap fst env))
   return ()
 
-showApp :: (MonadNorm types m) => NormExpr types -> Spine types -> m ()
+showApp :: (MonadNorm types m) => Value types -> Spine types -> m ()
 showApp _fun _spine =
   return ()
 

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -170,7 +170,7 @@ evalApp fun (arg : args) = do
     VUniverse {} -> unexpectedExprError currentPass "VUniverse"
     VPi {} -> unexpectedExprError currentPass "VPi"
 
-lookupIn :: (MonadCompile m) => Provenance -> DBIndex -> Env types -> m (NormExpr types)
+lookupIn :: (MonadCompile m) => Provenance -> Ix -> Env types -> m (NormExpr types)
 lookupIn p i env = case lookupVar env i of
   Just (_, value) -> return value
   Nothing ->

--- a/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
@@ -20,7 +20,7 @@ unnormalise level e = runCompileMonadSilently "unquoting" (quote mempty level e)
 class Quote a b where
   quote :: (MonadCompile m) => Provenance -> Lv -> a -> m b
 
-instance Quote (NormExpr types) (NormalisableExpr types) where
+instance Quote (Value types) (NormalisableExpr types) where
   quote p level = \case
     VUniverse u -> return $ Universe p u
     VMeta m spine -> quoteApp level p (Meta p m) spine

--- a/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
@@ -42,10 +42,10 @@ instance Quote (Value types) (NormalisableExpr types) where
       -- quotedBody <- quote (level + 1) normBody
       return $ Lam mempty quotedBinder quotedBody
 
-instance Quote (NormBinder types) (NormalisableBinder types) where
+instance Quote (VBinder types) (NormalisableBinder types) where
   quote p level = traverse (quote p level)
 
-instance Quote (NormArg types) (NormalisableArg types) where
+instance Quote (VArg types) (NormalisableArg types) where
   quote p level = traverse (quote p level)
 
 quoteApp :: (MonadCompile m) => Lv -> Provenance -> NormalisableExpr types -> Spine types -> m (NormalisableExpr types)

--- a/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
@@ -9,7 +9,7 @@ import Vehicle.Expr.Normalised
 -- | Converts from a normalised representation to an unnormalised representation.
 -- Do not call except for logging and debug purposes, very expensive with nested
 -- lambdas.
-unnormalise :: forall a b. (Quote a b) => DBLevel -> a -> b
+unnormalise :: forall a b. (Quote a b) => Lv -> a -> b
 unnormalise level e = runCompileMonadSilently "unquoting" (quote mempty level e)
 
 -----------------------------------------------------------------------------
@@ -18,7 +18,7 @@ unnormalise level e = runCompileMonadSilently "unquoting" (quote mempty level e)
 -- i.e. converting back to unnormalised expressions
 
 class Quote a b where
-  quote :: (MonadCompile m) => Provenance -> DBLevel -> a -> m b
+  quote :: (MonadCompile m) => Provenance -> Lv -> a -> m b
 
 instance Quote (NormExpr types) (NormalisableExpr types) where
   quote p level = \case
@@ -48,7 +48,7 @@ instance Quote (NormBinder types) (NormalisableBinder types) where
 instance Quote (NormArg types) (NormalisableArg types) where
   quote p level = traverse (quote p level)
 
-quoteApp :: (MonadCompile m) => DBLevel -> Provenance -> NormalisableExpr types -> Spine types -> m (NormalisableExpr types)
+quoteApp :: (MonadCompile m) => Lv -> Provenance -> NormalisableExpr types -> Spine types -> m (NormalisableExpr types)
 quoteApp l p fn spine = normAppList p fn <$> traverse (quote p l) spine
 
 envSubst :: BoundCtx (NormalisableExpr types) -> Substitution (NormalisableExpr types)

--- a/vehicle/src/Vehicle/Compile/Prelude.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude.hs
@@ -15,20 +15,6 @@ import Vehicle.Syntax.AST as X
 --------------------------------------------------------------------------------
 -- Type synonyms
 
-type NamedBinding = ()
-
-type NamedVar = Name
-
-type NamedArg builtin = Arg NamedBinding NamedVar builtin
-
-type NamedBinder builtin = Binder NamedBinding NamedVar builtin
-
-type NamedExpr builtin = Expr NamedBinding NamedVar builtin
-
-type NamedDecl builtin = Decl NamedBinding NamedVar builtin
-
-type NamedProg builtin = Prog NamedBinding NamedVar builtin
-
 type DeclProvenance = (Identifier, Provenance)
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Prelude/Contexts.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Contexts.hs
@@ -34,7 +34,7 @@ addToBoundCtx v = local (v :)
 getBoundCtx :: (MonadReader (BoundCtx b) m) => m (BoundCtx b)
 getBoundCtx = ask
 
-lookupVar :: BoundCtx b -> DBIndex -> Maybe b
+lookupVar :: BoundCtx b -> Ix -> Maybe b
 lookupVar ctx i = ctx !!? coerce i
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
@@ -3,7 +3,6 @@ module Vehicle.Compile.Prelude.Utils where
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Data.Maybe (mapMaybe)
-import Vehicle.Expr.DeBruijn
 import Vehicle.Prelude
 import Vehicle.Syntax.AST
 
@@ -52,7 +51,7 @@ getMetaID e = case exprHead e of
   Meta _ m -> Just m
   _ -> Nothing
 
-getBinderName :: GenericBinder DBBinding expr -> Name
+getBinderName :: GenericBinder () expr -> Name
 getBinderName binder = case binderNamingForm binder of
   NameAndType name -> name
   OnlyName name -> name

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -111,11 +111,11 @@ data Strategy
 -- and the type of the expression.
 type family StrategyFor (tags :: Tags) a :: Strategy where
   -- To convert any named representation to the target language, simply convert it.
-  StrategyFor ('As lang) InputProg = 'PrintAs lang
-  StrategyFor ('As lang) InputDecl = 'PrintAs lang
-  StrategyFor ('As lang) InputExpr = 'PrintAs lang
-  StrategyFor ('As lang) InputArg = 'PrintAs lang
-  StrategyFor ('As lang) InputBinder = 'PrintAs lang
+  StrategyFor ('As lang) (Prog () Name Builtin) = 'PrintAs lang
+  StrategyFor ('As lang) (Decl () Name Builtin) = 'PrintAs lang
+  StrategyFor ('As lang) (Expr () Name Builtin) = 'PrintAs lang
+  StrategyFor ('As lang) (Arg () Name Builtin) = 'PrintAs lang
+  StrategyFor ('As lang) (Binder () Name Builtin) = 'PrintAs lang
   -- To print a DB expr in an unnamed representation, simply naively descope.
   StrategyFor ('Unnamed tags) (Prog () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedProg builtin))
   StrategyFor ('Unnamed tags) (Decl () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedDecl builtin))
@@ -127,11 +127,11 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor ('Unnamed tags) (NormArg types) = 'DescopeNaively (StrategyFor tags (NamedArg (NormalisableBuiltin types)))
   StrategyFor ('Unnamed tags) (NormBinder types) = 'DescopeNaively (StrategyFor tags (NamedBinder (NormalisableBuiltin types)))
   -- To standardise builtins
-  StrategyFor ('StandardiseBuiltin tags) (NamedProg builtin) = 'ConvertBuiltins (StrategyFor tags InputProg)
-  StrategyFor ('StandardiseBuiltin tags) (NamedDecl builtin) = 'ConvertBuiltins (StrategyFor tags InputDecl)
-  StrategyFor ('StandardiseBuiltin tags) (NamedExpr builtin) = 'ConvertBuiltins (StrategyFor tags InputExpr)
-  StrategyFor ('StandardiseBuiltin tags) (NamedArg builtin) = 'ConvertBuiltins (StrategyFor tags InputArg)
-  StrategyFor ('StandardiseBuiltin tags) (NamedBinder builtin) = 'ConvertBuiltins (StrategyFor tags InputBinder)
+  StrategyFor ('StandardiseBuiltin tags) (NamedProg builtin) = 'ConvertBuiltins (StrategyFor tags (Prog () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (NamedDecl builtin) = 'ConvertBuiltins (StrategyFor tags (Decl () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (NamedExpr builtin) = 'ConvertBuiltins (StrategyFor tags (Expr () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (NamedArg builtin) = 'ConvertBuiltins (StrategyFor tags (Arg () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (NamedBinder builtin) = 'ConvertBuiltins (StrategyFor tags (Binder () Name Builtin))
   -- To convert an expression using a named representation to a named representation is a no-op.
   StrategyFor ('Named tags) (NamedProg builtin) = StrategyFor tags (NamedProg builtin)
   StrategyFor ('Named tags) (NamedDecl builtin) = StrategyFor tags (NamedDecl builtin)
@@ -141,11 +141,11 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   -- To convert a closed expression using a DB representation but whose missing names have been supplied
   -- to a named representation, perform the Checked to named conversion. For expressions, args, binders
   -- we need to have the context in scope.
-  StrategyFor ('Named tags) (Prog () Ix builtin) = 'DescopeWithNames (StrategyFor tags InputProg)
-  StrategyFor ('Named tags) (Decl () Ix builtin) = 'DescopeWithNames (StrategyFor tags InputDecl)
-  StrategyFor ('Named tags) (Contextualised (Expr () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputExpr)
-  StrategyFor ('Named tags) (Contextualised (Arg () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputArg)
-  StrategyFor ('Named tags) (Contextualised (Binder () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputBinder)
+  StrategyFor ('Named tags) (Prog () Ix builtin) = 'DescopeWithNames (StrategyFor tags (Prog () Name Builtin))
+  StrategyFor ('Named tags) (Decl () Ix builtin) = 'DescopeWithNames (StrategyFor tags (Decl () Name Builtin))
+  StrategyFor ('Named tags) (Contextualised (Expr () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags (Expr () Name Builtin))
+  StrategyFor ('Named tags) (Contextualised (Arg () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags (Arg () Name Builtin))
+  StrategyFor ('Named tags) (Contextualised (Binder () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags (Binder () Name Builtin))
   -- To convert a named normalised expr, first denormalise to a checked expr.
   StrategyFor ('Named tags) (Contextualised (NormExpr types) BoundDBCtx) = 'Denormalise (StrategyFor ('Named tags) (Contextualised (Expr () Ix (NormalisableBuiltin types)) BoundDBCtx))
   -- Things that we just pretty print.
@@ -204,86 +204,86 @@ prettyWith = prettyUsing @(StrategyFor tags a) @a @b
 --------------------------------------------------------------------------------
 -- Printing to internal language
 
-instance PrettyUsing ('PrintAs 'Internal) InputProg where
+instance PrettyUsing ('PrintAs 'Internal) (Prog () Name Builtin) where
   prettyUsing = printInternal
 
-instance PrettyUsing ('PrintAs 'Internal) InputDecl where
+instance PrettyUsing ('PrintAs 'Internal) (Decl () Name Builtin) where
   prettyUsing = printInternal
 
-instance PrettyUsing ('PrintAs 'Internal) InputExpr where
+instance PrettyUsing ('PrintAs 'Internal) (Expr () Name Builtin) where
   prettyUsing = printInternal
 
-instance PrettyUsing ('PrintAs 'Internal) InputArg where
+instance PrettyUsing ('PrintAs 'Internal) (Arg () Name Builtin) where
   prettyUsing = printInternal
 
-instance PrettyUsing ('PrintAs 'Internal) InputBinder where
+instance PrettyUsing ('PrintAs 'Internal) (Binder () Name Builtin) where
   prettyUsing = printInternal
 
 --------------------------------------------------------------------------------
 -- Printing to external language
 
-instance PrettyUsing ('PrintAs 'External) InputProg where
+instance PrettyUsing ('PrintAs 'External) (Prog () Name Builtin) where
   prettyUsing = printExternal
 
-instance PrettyUsing ('PrintAs 'External) InputDecl where
+instance PrettyUsing ('PrintAs 'External) (Decl () Name Builtin) where
   prettyUsing = printExternal
 
-instance PrettyUsing ('PrintAs 'External) InputExpr where
+instance PrettyUsing ('PrintAs 'External) (Expr () Name Builtin) where
   prettyUsing = printExternal
 
-instance PrettyUsing ('PrintAs 'External) InputArg where
+instance PrettyUsing ('PrintAs 'External) (Arg () Name Builtin) where
   prettyUsing = printExternal
 
-instance PrettyUsing ('PrintAs 'External) InputBinder where
+instance PrettyUsing ('PrintAs 'External) (Binder () Name Builtin) where
   prettyUsing = printExternal
 
 --------------------------------------------------------------------------------
 -- Converting the basic builtins
 
-instance (PrettyUsing rest InputProg) => PrettyUsing ('ConvertBuiltins rest) InputProg where
+instance (PrettyUsing rest (Prog () Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Prog () Name Builtin) where
   prettyUsing = prettyUsing @rest
 
-instance (PrettyUsing rest InputDecl) => PrettyUsing ('ConvertBuiltins rest) InputDecl where
+instance (PrettyUsing rest (Decl () Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Decl () Name Builtin) where
   prettyUsing = prettyUsing @rest
 
-instance (PrettyUsing rest InputExpr) => PrettyUsing ('ConvertBuiltins rest) InputExpr where
+instance (PrettyUsing rest (Expr () Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Expr () Name Builtin) where
   prettyUsing = prettyUsing @rest
 
-instance (PrettyUsing rest InputArg) => PrettyUsing ('ConvertBuiltins rest) InputArg where
+instance (PrettyUsing rest (Arg () Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Arg () Name Builtin) where
   prettyUsing = prettyUsing @rest
 
-instance (PrettyUsing rest InputBinder) => PrettyUsing ('ConvertBuiltins rest) InputBinder where
+instance (PrettyUsing rest (Binder () Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Binder () Name Builtin) where
   prettyUsing = prettyUsing @rest
 
 --------------------------------------------------------------------------------
 -- Converting builtins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest InputProg) =>
+  (PrintableBuiltin types, PrettyUsing rest (Prog () Name Builtin)) =>
   PrettyUsing ('ConvertBuiltins rest) (NamedProg (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest InputDecl) =>
+  (PrintableBuiltin types, PrettyUsing rest (Decl () Name Builtin)) =>
   PrettyUsing ('ConvertBuiltins rest) (NamedDecl (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest InputExpr) =>
+  (PrintableBuiltin types, PrettyUsing rest (Expr () Name Builtin)) =>
   PrettyUsing ('ConvertBuiltins rest) (NamedExpr (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest InputArg) =>
+  (PrintableBuiltin types, PrettyUsing rest (Arg () Name Builtin)) =>
   PrettyUsing ('ConvertBuiltins rest) (NamedArg (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest InputBinder) =>
+  (PrintableBuiltin types, PrettyUsing rest (Binder () Name Builtin)) =>
   PrettyUsing ('ConvertBuiltins rest) (NamedBinder (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -117,11 +117,11 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor ('As lang) InputArg = 'PrintAs lang
   StrategyFor ('As lang) InputBinder = 'PrintAs lang
   -- To print a DB expr in an unnamed representation, simply naively descope.
-  StrategyFor ('Unnamed tags) (DBProg builtin) = 'DescopeNaively (StrategyFor tags (NamedProg builtin))
-  StrategyFor ('Unnamed tags) (DBDecl builtin) = 'DescopeNaively (StrategyFor tags (NamedDecl builtin))
-  StrategyFor ('Unnamed tags) (DBExpr builtin) = 'DescopeNaively (StrategyFor tags (NamedExpr builtin))
-  StrategyFor ('Unnamed tags) (DBArg builtin) = 'DescopeNaively (StrategyFor tags (NamedArg builtin))
-  StrategyFor ('Unnamed tags) (DBBinder builtin) = 'DescopeNaively (StrategyFor tags (NamedBinder builtin))
+  StrategyFor ('Unnamed tags) (Prog () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedProg builtin))
+  StrategyFor ('Unnamed tags) (Decl () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedDecl builtin))
+  StrategyFor ('Unnamed tags) (Expr () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedExpr builtin))
+  StrategyFor ('Unnamed tags) (Arg () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedArg builtin))
+  StrategyFor ('Unnamed tags) (Binder () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedBinder builtin))
   -- To print a normalised expr in an unnamed representation, simply naively descope.
   StrategyFor ('Unnamed tags) (NormExpr types) = 'DescopeNaively (StrategyFor tags (NamedExpr (NormalisableBuiltin types)))
   StrategyFor ('Unnamed tags) (NormArg types) = 'DescopeNaively (StrategyFor tags (NamedArg (NormalisableBuiltin types)))
@@ -141,13 +141,13 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   -- To convert a closed expression using a DB representation but whose missing names have been supplied
   -- to a named representation, perform the Checked to named conversion. For expressions, args, binders
   -- we need to have the context in scope.
-  StrategyFor ('Named tags) (DBProg builtin) = 'DescopeWithNames (StrategyFor tags InputProg)
-  StrategyFor ('Named tags) (DBDecl builtin) = 'DescopeWithNames (StrategyFor tags InputDecl)
-  StrategyFor ('Named tags) (Contextualised (DBExpr builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputExpr)
-  StrategyFor ('Named tags) (Contextualised (DBArg builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputArg)
-  StrategyFor ('Named tags) (Contextualised (DBBinder builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputBinder)
+  StrategyFor ('Named tags) (Prog () Ix builtin) = 'DescopeWithNames (StrategyFor tags InputProg)
+  StrategyFor ('Named tags) (Decl () Ix builtin) = 'DescopeWithNames (StrategyFor tags InputDecl)
+  StrategyFor ('Named tags) (Contextualised (Expr () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputExpr)
+  StrategyFor ('Named tags) (Contextualised (Arg () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputArg)
+  StrategyFor ('Named tags) (Contextualised (Binder () Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags InputBinder)
   -- To convert a named normalised expr, first denormalise to a checked expr.
-  StrategyFor ('Named tags) (Contextualised (NormExpr types) BoundDBCtx) = 'Denormalise (StrategyFor ('Named tags) (Contextualised (DBExpr (NormalisableBuiltin types)) BoundDBCtx))
+  StrategyFor ('Named tags) (Contextualised (NormExpr types) BoundDBCtx) = 'Denormalise (StrategyFor ('Named tags) (Contextualised (Expr () Ix (NormalisableBuiltin types)) BoundDBCtx))
   -- Things that we just pretty print.
   StrategyFor tags Int = 'Pretty
   StrategyFor tags Text = 'Pretty
@@ -304,19 +304,19 @@ convertExprBuiltins = traverseBuiltins $ \p1 p2 b args -> do
 --------------------------------------------------------------------------------
 -- Convert closed terms from DeBruijn representation to named representation naively
 
-instance (PrettyUsing rest (NamedProg builtin)) => PrettyUsing ('DescopeNaively rest) (DBProg builtin) where
+instance (PrettyUsing rest (NamedProg builtin)) => PrettyUsing ('DescopeNaively rest) (Prog () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedDecl builtin)) => PrettyUsing ('DescopeNaively rest) (DBDecl builtin) where
+instance (PrettyUsing rest (NamedDecl builtin)) => PrettyUsing ('DescopeNaively rest) (Decl () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedExpr builtin)) => PrettyUsing ('DescopeNaively rest) (DBExpr builtin) where
+instance (PrettyUsing rest (NamedExpr builtin)) => PrettyUsing ('DescopeNaively rest) (Expr () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedArg builtin)) => PrettyUsing ('DescopeNaively rest) (DBArg builtin) where
+instance (PrettyUsing rest (NamedArg builtin)) => PrettyUsing ('DescopeNaively rest) (Arg () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedBinder builtin)) => PrettyUsing ('DescopeNaively rest) (DBBinder builtin) where
+instance (PrettyUsing rest (NamedBinder builtin)) => PrettyUsing ('DescopeNaively rest) (Binder () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
 instance (PrettyUsing rest (NamedExpr (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (NormExpr types) where
@@ -331,27 +331,27 @@ instance (PrettyUsing rest (NamedBinder (NormalisableBuiltin types))) => PrettyU
 --------------------------------------------------------------------------------
 -- Convert open terms from DeBruijn representation to named representation
 
-instance (PrettyUsing rest (NamedProg builtin)) => PrettyUsing ('DescopeWithNames rest) (DBProg builtin) where
+instance (PrettyUsing rest (NamedProg builtin)) => PrettyUsing ('DescopeWithNames rest) (Prog () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNamed
 
-instance (PrettyUsing rest (NamedDecl builtin)) => PrettyUsing ('DescopeWithNames rest) (DBDecl builtin) where
+instance (PrettyUsing rest (NamedDecl builtin)) => PrettyUsing ('DescopeWithNames rest) (Decl () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNamed
 
 instance
   (PrettyUsing rest (NamedExpr builtin)) =>
-  PrettyUsing ('DescopeWithNames rest) (Contextualised (DBExpr builtin) BoundDBCtx)
+  PrettyUsing ('DescopeWithNames rest) (Contextualised (Expr () Ix builtin) BoundDBCtx)
   where
   prettyUsing = prettyUsing @rest . descopeNamed
 
 instance
   (PrettyUsing rest (NamedArg builtin)) =>
-  PrettyUsing ('DescopeWithNames rest) (Contextualised (DBArg builtin) BoundDBCtx)
+  PrettyUsing ('DescopeWithNames rest) (Contextualised (Arg () Ix builtin) BoundDBCtx)
   where
   prettyUsing = prettyUsing @rest . descopeNamed
 
 instance
   (PrettyUsing rest (NamedBinder builtin)) =>
-  PrettyUsing ('DescopeWithNames rest) (Contextualised (DBBinder builtin) BoundDBCtx)
+  PrettyUsing ('DescopeWithNames rest) (Contextualised (Binder () Ix builtin) BoundDBCtx)
   where
   prettyUsing = prettyUsing @rest . descopeNamed
 
@@ -416,18 +416,18 @@ instance (Pretty a) => PrettyUsing 'Pretty a where
 -- Instances for normalised types
 
 instance
-  (PrettyUsing rest (Contextualised (DBExpr (NormalisableBuiltin types)) BoundDBCtx)) =>
+  (PrettyUsing rest (Contextualised (Expr () Ix (NormalisableBuiltin types)) BoundDBCtx)) =>
   PrettyUsing ('Denormalise rest) (Contextualised (NormExpr types) BoundDBCtx)
   where
   prettyUsing (WithContext e ctx) = do
-    let e' = unnormalise @(NormExpr types) @(DBExpr (NormalisableBuiltin types)) (Lv $ length ctx) e
+    let e' = unnormalise @(NormExpr types) @(Expr () Ix (NormalisableBuiltin types)) (Lv $ length ctx) e
     prettyUsing @rest (WithContext e' ctx)
 
-instance (PrettyUsing rest (DBExpr (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (NormExpr types) where
-  prettyUsing e = prettyUsing @rest (unnormalise @(NormExpr types) @(DBExpr (NormalisableBuiltin types)) 0 e)
+instance (PrettyUsing rest (Expr () Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (NormExpr types) where
+  prettyUsing e = prettyUsing @rest (unnormalise @(NormExpr types) @(Expr () Ix (NormalisableBuiltin types)) 0 e)
 
-instance (PrettyUsing rest (DBArg (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (NormArg types) where
-  prettyUsing e = prettyUsing @rest (unnormalise @(NormArg types) @(DBArg (NormalisableBuiltin types)) 0 e)
+instance (PrettyUsing rest (Arg () Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (NormArg types) where
+  prettyUsing e = prettyUsing @rest (unnormalise @(NormArg types) @(Arg () Ix (NormalisableBuiltin types)) 0 e)
 
 --------------------------------------------------------------------------------
 -- Instances for constraints

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -117,27 +117,27 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor ('As lang) (Arg () Name Builtin) = 'PrintAs lang
   StrategyFor ('As lang) (Binder () Name Builtin) = 'PrintAs lang
   -- To print a DB expr in an unnamed representation, simply naively descope.
-  StrategyFor ('Unnamed tags) (Prog () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedProg builtin))
-  StrategyFor ('Unnamed tags) (Decl () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedDecl builtin))
-  StrategyFor ('Unnamed tags) (Expr () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedExpr builtin))
-  StrategyFor ('Unnamed tags) (Arg () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedArg builtin))
-  StrategyFor ('Unnamed tags) (Binder () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedBinder builtin))
+  StrategyFor ('Unnamed tags) (Prog () Ix builtin) = 'DescopeNaively (StrategyFor tags (Prog () Name builtin))
+  StrategyFor ('Unnamed tags) (Decl () Ix builtin) = 'DescopeNaively (StrategyFor tags (Decl () Name builtin))
+  StrategyFor ('Unnamed tags) (Expr () Ix builtin) = 'DescopeNaively (StrategyFor tags (Expr () Name builtin))
+  StrategyFor ('Unnamed tags) (Arg () Ix builtin) = 'DescopeNaively (StrategyFor tags (Arg () Name builtin))
+  StrategyFor ('Unnamed tags) (Binder () Ix builtin) = 'DescopeNaively (StrategyFor tags (Binder () Name builtin))
   -- To print a normalised expr in an unnamed representation, simply naively descope.
-  StrategyFor ('Unnamed tags) (Value types) = 'DescopeNaively (StrategyFor tags (NamedExpr (NormalisableBuiltin types)))
-  StrategyFor ('Unnamed tags) (VArg types) = 'DescopeNaively (StrategyFor tags (NamedArg (NormalisableBuiltin types)))
-  StrategyFor ('Unnamed tags) (VBinder types) = 'DescopeNaively (StrategyFor tags (NamedBinder (NormalisableBuiltin types)))
+  StrategyFor ('Unnamed tags) (Value types) = 'DescopeNaively (StrategyFor tags (Expr () Name (NormalisableBuiltin types)))
+  StrategyFor ('Unnamed tags) (VArg types) = 'DescopeNaively (StrategyFor tags (Arg () Name (NormalisableBuiltin types)))
+  StrategyFor ('Unnamed tags) (VBinder types) = 'DescopeNaively (StrategyFor tags (Binder () Name (NormalisableBuiltin types)))
   -- To standardise builtins
-  StrategyFor ('StandardiseBuiltin tags) (NamedProg builtin) = 'ConvertBuiltins (StrategyFor tags (Prog () Name Builtin))
-  StrategyFor ('StandardiseBuiltin tags) (NamedDecl builtin) = 'ConvertBuiltins (StrategyFor tags (Decl () Name Builtin))
-  StrategyFor ('StandardiseBuiltin tags) (NamedExpr builtin) = 'ConvertBuiltins (StrategyFor tags (Expr () Name Builtin))
-  StrategyFor ('StandardiseBuiltin tags) (NamedArg builtin) = 'ConvertBuiltins (StrategyFor tags (Arg () Name Builtin))
-  StrategyFor ('StandardiseBuiltin tags) (NamedBinder builtin) = 'ConvertBuiltins (StrategyFor tags (Binder () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (Prog () Name builtin) = 'ConvertBuiltins (StrategyFor tags (Prog () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (Decl () Name builtin) = 'ConvertBuiltins (StrategyFor tags (Decl () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (Expr () Name builtin) = 'ConvertBuiltins (StrategyFor tags (Expr () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (Arg () Name builtin) = 'ConvertBuiltins (StrategyFor tags (Arg () Name Builtin))
+  StrategyFor ('StandardiseBuiltin tags) (Binder () Name builtin) = 'ConvertBuiltins (StrategyFor tags (Binder () Name Builtin))
   -- To convert an expression using a named representation to a named representation is a no-op.
-  StrategyFor ('Named tags) (NamedProg builtin) = StrategyFor tags (NamedProg builtin)
-  StrategyFor ('Named tags) (NamedDecl builtin) = StrategyFor tags (NamedDecl builtin)
-  StrategyFor ('Named tags) (NamedExpr builtin) = StrategyFor tags (NamedExpr builtin)
-  StrategyFor ('Named tags) (NamedArg builtin) = StrategyFor tags (NamedArg builtin)
-  StrategyFor ('Named tags) (NamedBinder builtin) = StrategyFor tags (NamedBinder builtin)
+  StrategyFor ('Named tags) (Prog () Name builtin) = StrategyFor tags (Prog () Name builtin)
+  StrategyFor ('Named tags) (Decl () Name builtin) = StrategyFor tags (Decl () Name builtin)
+  StrategyFor ('Named tags) (Expr () Name builtin) = StrategyFor tags (Expr () Name builtin)
+  StrategyFor ('Named tags) (Arg () Name builtin) = StrategyFor tags (Arg () Name builtin)
+  StrategyFor ('Named tags) (Binder () Name builtin) = StrategyFor tags (Binder () Name builtin)
   -- To convert a closed expression using a DB representation but whose missing names have been supplied
   -- to a named representation, perform the Checked to named conversion. For expressions, args, binders
   -- we need to have the context in scope.
@@ -260,31 +260,31 @@ instance (PrettyUsing rest (Binder () Name Builtin)) => PrettyUsing ('ConvertBui
 
 instance
   (PrintableBuiltin types, PrettyUsing rest (Prog () Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (NamedProg (NormalisableBuiltin types))
+  PrettyUsing ('ConvertBuiltins rest) (Prog () Name (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
   (PrintableBuiltin types, PrettyUsing rest (Decl () Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (NamedDecl (NormalisableBuiltin types))
+  PrettyUsing ('ConvertBuiltins rest) (Decl () Name (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
   (PrintableBuiltin types, PrettyUsing rest (Expr () Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (NamedExpr (NormalisableBuiltin types))
+  PrettyUsing ('ConvertBuiltins rest) (Expr () Name (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . convertExprBuiltins
 
 instance
   (PrintableBuiltin types, PrettyUsing rest (Arg () Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (NamedArg (NormalisableBuiltin types))
+  PrettyUsing ('ConvertBuiltins rest) (Arg () Name (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
   (PrintableBuiltin types, PrettyUsing rest (Binder () Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (NamedBinder (NormalisableBuiltin types))
+  PrettyUsing ('ConvertBuiltins rest) (Binder () Name (NormalisableBuiltin types))
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
@@ -304,53 +304,53 @@ convertExprBuiltins = traverseBuiltins $ \p1 p2 b args -> do
 --------------------------------------------------------------------------------
 -- Convert closed terms from DeBruijn representation to named representation naively
 
-instance (PrettyUsing rest (NamedProg builtin)) => PrettyUsing ('DescopeNaively rest) (Prog () Ix builtin) where
+instance (PrettyUsing rest (Prog () Name builtin)) => PrettyUsing ('DescopeNaively rest) (Prog () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedDecl builtin)) => PrettyUsing ('DescopeNaively rest) (Decl () Ix builtin) where
+instance (PrettyUsing rest (Decl () Name builtin)) => PrettyUsing ('DescopeNaively rest) (Decl () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedExpr builtin)) => PrettyUsing ('DescopeNaively rest) (Expr () Ix builtin) where
+instance (PrettyUsing rest (Expr () Name builtin)) => PrettyUsing ('DescopeNaively rest) (Expr () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedArg builtin)) => PrettyUsing ('DescopeNaively rest) (Arg () Ix builtin) where
+instance (PrettyUsing rest (Arg () Name builtin)) => PrettyUsing ('DescopeNaively rest) (Arg () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedBinder builtin)) => PrettyUsing ('DescopeNaively rest) (Binder () Ix builtin) where
+instance (PrettyUsing rest (Binder () Name builtin)) => PrettyUsing ('DescopeNaively rest) (Binder () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedExpr (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (Value types) where
+instance (PrettyUsing rest (Expr () Name (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (Value types) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedArg (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VArg types) where
+instance (PrettyUsing rest (Arg () Name (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VArg types) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedBinder (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VBinder types) where
+instance (PrettyUsing rest (Binder () Name (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VBinder types) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
 --------------------------------------------------------------------------------
 -- Convert open terms from DeBruijn representation to named representation
 
-instance (PrettyUsing rest (NamedProg builtin)) => PrettyUsing ('DescopeWithNames rest) (Prog () Ix builtin) where
+instance (PrettyUsing rest (Prog () Name builtin)) => PrettyUsing ('DescopeWithNames rest) (Prog () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNamed
 
-instance (PrettyUsing rest (NamedDecl builtin)) => PrettyUsing ('DescopeWithNames rest) (Decl () Ix builtin) where
+instance (PrettyUsing rest (Decl () Name builtin)) => PrettyUsing ('DescopeWithNames rest) (Decl () Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNamed
 
 instance
-  (PrettyUsing rest (NamedExpr builtin)) =>
+  (PrettyUsing rest (Expr () Name builtin)) =>
   PrettyUsing ('DescopeWithNames rest) (Contextualised (Expr () Ix builtin) BoundDBCtx)
   where
   prettyUsing = prettyUsing @rest . descopeNamed
 
 instance
-  (PrettyUsing rest (NamedArg builtin)) =>
+  (PrettyUsing rest (Arg () Name builtin)) =>
   PrettyUsing ('DescopeWithNames rest) (Contextualised (Arg () Ix builtin) BoundDBCtx)
   where
   prettyUsing = prettyUsing @rest . descopeNamed
 
 instance
-  (PrettyUsing rest (NamedBinder builtin)) =>
+  (PrettyUsing rest (Binder () Name builtin)) =>
   PrettyUsing ('DescopeWithNames rest) (Contextualised (Binder () Ix builtin) BoundDBCtx)
   where
   prettyUsing = prettyUsing @rest . descopeNamed

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -124,8 +124,8 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor ('Unnamed tags) (Binder () Ix builtin) = 'DescopeNaively (StrategyFor tags (NamedBinder builtin))
   -- To print a normalised expr in an unnamed representation, simply naively descope.
   StrategyFor ('Unnamed tags) (Value types) = 'DescopeNaively (StrategyFor tags (NamedExpr (NormalisableBuiltin types)))
-  StrategyFor ('Unnamed tags) (NormArg types) = 'DescopeNaively (StrategyFor tags (NamedArg (NormalisableBuiltin types)))
-  StrategyFor ('Unnamed tags) (NormBinder types) = 'DescopeNaively (StrategyFor tags (NamedBinder (NormalisableBuiltin types)))
+  StrategyFor ('Unnamed tags) (VArg types) = 'DescopeNaively (StrategyFor tags (NamedArg (NormalisableBuiltin types)))
+  StrategyFor ('Unnamed tags) (VBinder types) = 'DescopeNaively (StrategyFor tags (NamedBinder (NormalisableBuiltin types)))
   -- To standardise builtins
   StrategyFor ('StandardiseBuiltin tags) (NamedProg builtin) = 'ConvertBuiltins (StrategyFor tags (Prog () Name Builtin))
   StrategyFor ('StandardiseBuiltin tags) (NamedDecl builtin) = 'ConvertBuiltins (StrategyFor tags (Decl () Name Builtin))
@@ -322,10 +322,10 @@ instance (PrettyUsing rest (NamedBinder builtin)) => PrettyUsing ('DescopeNaivel
 instance (PrettyUsing rest (NamedExpr (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (Value types) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedArg (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (NormArg types) where
+instance (PrettyUsing rest (NamedArg (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VArg types) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (NamedBinder (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (NormBinder types) where
+instance (PrettyUsing rest (NamedBinder (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VBinder types) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
 --------------------------------------------------------------------------------
@@ -426,8 +426,8 @@ instance
 instance (PrettyUsing rest (Expr () Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (Value types) where
   prettyUsing e = prettyUsing @rest (unnormalise @(Value types) @(Expr () Ix (NormalisableBuiltin types)) 0 e)
 
-instance (PrettyUsing rest (Arg () Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (NormArg types) where
-  prettyUsing e = prettyUsing @rest (unnormalise @(NormArg types) @(Arg () Ix (NormalisableBuiltin types)) 0 e)
+instance (PrettyUsing rest (Arg () Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (VArg types) where
+  prettyUsing e = prettyUsing @rest (unnormalise @(VArg types) @(Arg () Ix (NormalisableBuiltin types)) 0 e)
 
 --------------------------------------------------------------------------------
 -- Instances for constraints

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -420,7 +420,7 @@ instance
   PrettyUsing ('Denormalise rest) (Contextualised (NormExpr types) BoundDBCtx)
   where
   prettyUsing (WithContext e ctx) = do
-    let e' = unnormalise @(NormExpr types) @(DBExpr (NormalisableBuiltin types)) (DBLevel $ length ctx) e
+    let e' = unnormalise @(NormExpr types) @(DBExpr (NormalisableBuiltin types)) (Lv $ length ctx) e
     prettyUsing @rest (WithContext e' ctx)
 
 instance (PrettyUsing rest (DBExpr (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (NormExpr types) where

--- a/vehicle/src/Vehicle/Compile/Queries.hs
+++ b/vehicle/src/Vehicle/Compile/Queries.hs
@@ -26,7 +26,7 @@ import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
 import Vehicle.Expr.Boolean
-import Vehicle.Expr.DeBruijn (DBLevel (..))
+import Vehicle.Expr.DeBruijn (Lv (..))
 import Vehicle.Expr.Normalised
 import Vehicle.Verify.Core
 import Vehicle.Verify.Specification
@@ -328,7 +328,7 @@ compileQuantifierBodyToPropositionTree quantifiedVariables _ binder env body = d
 
   let variableName = getBinderName binder
   -- TODO avoid calculating this repeatedly?
-  let currentLevel = DBLevel $ sum (map (\(_, _, vars) -> length vars) quantifiedVariables)
+  let currentLevel = Lv $ sum (map (\(_, _, vars) -> length vars) quantifiedVariables)
   tensorDimensions <- calculateDimensionsOfQuantifiedVariable propertyState binder
   (envEntry, binderUserVars) <- calculateEnvEntry currentLevel variableName tensorDimensions
   let newEnv = extendEnv binder envEntry env
@@ -455,7 +455,7 @@ calculateDimensionsOfQuantifiedVariable propertyState binder = go (typeOf binder
 
 calculateEnvEntry ::
   (MonadCompile m) =>
-  DBLevel ->
+  Lv ->
   Name ->
   TensorDimensions ->
   m (StandardNormExpr, [UserVariable])
@@ -463,7 +463,7 @@ calculateEnvEntry startingLevel baseName baseDims = do
   runSupplyT (go baseName baseDims) [startingLevel ..]
   where
     go ::
-      (MonadSupply DBLevel m, MonadCompile m) =>
+      (MonadSupply Lv m, MonadCompile m) =>
       Name ->
       TensorDimensions ->
       m (StandardNormExpr, [UserVariable])

--- a/vehicle/src/Vehicle/Compile/Queries/LinearSatisfactionProblem.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearSatisfactionProblem.hs
@@ -59,7 +59,7 @@ generateCLSTProblem state inputEqualities conjuncts = flip runReaderT state $ do
     -- Create linear expression equating the magic variable `x_i`
     -- with the expression `e` in the relevant point = xs_i`
     exprSize <- getExprSize
-    let lhs = fromSparse $ Sparse exprSize (HashMap.singleton (unLevel i) 1) 0
+    let lhs = fromSparse $ Sparse exprSize (HashMap.singleton (unLv i) 1) 0
     rhs <- compileLinearExpr expr
     return $ constructAssertion (lhs, Equal, rhs)
 
@@ -252,8 +252,8 @@ compileLinearExpr expr = do
   exprSize <- getExprSize
   return $ fromSparse $ Sparse exprSize linearExpr constant
   where
-    singletonVar :: DBLevel -> Coefficient -> HashMap Int Coefficient
-    singletonVar v = HashMap.singleton (unLevel v)
+    singletonVar :: Lv -> Coefficient -> HashMap Int Coefficient
+    singletonVar v = HashMap.singleton (unLv v)
 
     go :: (MonadSMT m) => StandardNormExpr -> m (HashMap Int Coefficient, Coefficient)
     go e = case e of

--- a/vehicle/src/Vehicle/Compile/Queries/LinearityAndPolarityErrors.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearityAndPolarityErrors.hs
@@ -90,7 +90,7 @@ resolveInstanceArguments prog =
     logCompilerPassOutput $ prettyFriendly result
     return result
   where
-    builtinUpdateFunction :: BuiltinUpdate m DBBinding Ix StandardBuiltin StandardBuiltin
+    builtinUpdateFunction :: BuiltinUpdate m () Ix StandardBuiltin StandardBuiltin
     builtinUpdateFunction p1 p2 b args = case b of
       CType (StandardTypeClassOp {}) -> do
         let (inst, remainingArgs) = findInstanceArg args

--- a/vehicle/src/Vehicle/Compile/Queries/LinearityAndPolarityErrors.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearityAndPolarityErrors.hs
@@ -90,7 +90,7 @@ resolveInstanceArguments prog =
     logCompilerPassOutput $ prettyFriendly result
     return result
   where
-    builtinUpdateFunction :: BuiltinUpdate m DBBinding DBIndex StandardBuiltin StandardBuiltin
+    builtinUpdateFunction :: BuiltinUpdate m DBBinding Ix StandardBuiltin StandardBuiltin
     builtinUpdateFunction p1 p2 b args = case b of
       CType (StandardTypeClassOp {}) -> do
         let (inst, remainingArgs) = findInstanceArg args

--- a/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
@@ -32,7 +32,7 @@ import Vehicle.Expr.Normalised
 import Vehicle.Verify.Specification (MetaNetwork)
 
 -- Pairs of (input variable == expression)
--- TODO push back through this file once changing CheckedExpr to Value
+-- TODO push back through this file once changing NormalisableExpr to Value
 type InputEqualities = [(Lv, StandardNormExpr)]
 
 -- | Okay so this is a wild ride. The Marabou query format has special variable

--- a/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
@@ -32,7 +32,7 @@ import Vehicle.Expr.Normalised
 import Vehicle.Verify.Specification (MetaNetwork)
 
 -- Pairs of (input variable == expression)
--- TODO push back through this file once changing CheckedExpr to NormExpr
+-- TODO push back through this file once changing CheckedExpr to Value
 type InputEqualities = [(Lv, StandardNormExpr)]
 
 -- | Okay so this is a wild ride. The Marabou query format has special variable

--- a/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
@@ -33,7 +33,7 @@ import Vehicle.Verify.Specification (MetaNetwork)
 
 -- Pairs of (input variable == expression)
 -- TODO push back through this file once changing CheckedExpr to NormExpr
-type InputEqualities = [(DBLevel, StandardNormExpr)]
+type InputEqualities = [(Lv, StandardNormExpr)]
 
 -- | Okay so this is a wild ride. The Marabou query format has special variable
 -- names for input and output variables, namely x1 ... xN and y1 ... yM but
@@ -110,7 +110,7 @@ reevalute expr = runEmptyNormT @StandardBuiltinType (reeval expr)
 data IOVarState = IOVarState
   { applicationCache :: HashMap (Identifier, StandardNormExpr) StandardNormExpr,
     metaNetwork :: MetaNetwork,
-    inputEqualities :: [[(DBLevel, StandardNormExpr)]],
+    inputEqualities :: [[(Lv, StandardNormExpr)]],
     magicInputVarCount :: Int,
     magicOutputVarCount :: Int
   }
@@ -135,9 +135,9 @@ processNetworkApplication networkCtx boundCtx ident inputVector = do
         let outputType = baseType outputs
 
         let numberOfUserVariables = length boundCtx
-        let inputStartingDBLevel = DBLevel $ numberOfUserVariables + magicInputVarCount + magicOutputVarCount
-        let outputStartingDBLevel = inputStartingDBLevel + DBLevel inputSize
-        let outputEndingDBLevel = outputStartingDBLevel + DBLevel outputSize
+        let inputStartingDBLevel = Lv $ numberOfUserVariables + magicInputVarCount + magicOutputVarCount
+        let outputStartingDBLevel = inputStartingDBLevel + Lv inputSize
+        let outputEndingDBLevel = outputStartingDBLevel + Lv outputSize
         let inputVarIndices = [inputStartingDBLevel .. outputStartingDBLevel - 1]
         let outputVarIndices = [outputStartingDBLevel .. outputEndingDBLevel - 1]
 
@@ -165,9 +165,9 @@ processNetworkApplication networkCtx boundCtx ident inputVector = do
 createInputVarEqualities ::
   (MonadCompile m) =>
   TensorDimensions ->
-  [DBLevel] ->
+  [Lv] ->
   StandardNormExpr ->
-  m [(DBLevel, StandardNormExpr)]
+  m [(Lv, StandardNormExpr)]
 createInputVarEqualities [] [i] e = return [(i, e)]
 createInputVarEqualities (_dim : dims) inputVarIndices (VVecLiteral xs) = do
   let inputVarIndicesChunks = chunksOf (product dims) inputVarIndices
@@ -183,11 +183,11 @@ mkMagicVariableSeq ::
   (MonadCompile m) =>
   NetworkBaseType ->
   TensorDimensions ->
-  [DBLevel] ->
+  [Lv] ->
   m StandardNormExpr
 mkMagicVariableSeq tElem = go
   where
-    go :: (MonadCompile m) => TensorDimensions -> [DBLevel] -> m StandardNormExpr
+    go :: (MonadCompile m) => TensorDimensions -> [Lv] -> m StandardNormExpr
     go (_dim : dims) outputVarIndices = do
       let outputVarIndicesChunks = chunksOf (product dims) outputVarIndices
       elems <- traverse (go dims) outputVarIndicesChunks

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -225,7 +225,7 @@ logScopeEntry e = do
   incrCallDepth
   logDebug MaxDetail $ "scope-entry" <+> prettyVerbose e -- <+> "in" <+> pretty ctx
 
-logScopeExit :: MonadTraverse m => UncheckedExpr -> m ()
+logScopeExit :: MonadTraverse m => NormalisableExpr -> m ()
 logScopeExit e = do
   logDebug MaxDetail $ "scope-exit " <+> prettyVerbose e
   decrCallDepth

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -42,11 +42,11 @@ type UnscopedDecl = NamedDecl Builtin
 
 type UnscopedExpr = NamedExpr Builtin
 
-type ScopedProg = DBProg Builtin
+type ScopedProg = Prog () Ix Builtin
 
-type ScopedDecl = DBDecl Builtin
+type ScopedDecl = Decl () Ix Builtin
 
-type ScopedExpr = DBExpr Builtin
+type ScopedExpr = Expr () Ix Builtin
 
 --------------------------------------------------------------------------------
 -- Scope checking monad and context

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -36,11 +36,11 @@ scopeCheckClosedExpr e = runReaderT (scopeExpr e) (mempty, mempty)
 --------------------------------------------------------------------------------
 -- Type synonyms
 
-type UnscopedProg = NamedProg Builtin
+type UnscopedProg = Prog () Name Builtin
 
-type UnscopedDecl = NamedDecl Builtin
+type UnscopedDecl = Decl () Name Builtin
 
-type UnscopedExpr = NamedExpr Builtin
+type UnscopedExpr = Expr () Name Builtin
 
 type ScopedProg = Prog () Ix Builtin
 
@@ -193,13 +193,13 @@ type MonadTraverse m =
   )
 
 type VarUpdate m var1 var2 =
-  forall builtin. Provenance -> var1 -> m (Expr NamedBinding var2 builtin)
+  forall builtin. Provenance -> var1 -> m (Expr () var2 builtin)
 
 traverseVars ::
   (MonadTraverse m) =>
   VarUpdate m var1 var2 ->
-  Expr NamedBinding var1 builtin ->
-  m (Expr NamedBinding var2 builtin)
+  Expr () var1 builtin ->
+  m (Expr () var2 builtin)
 traverseVars f e = do
   result <- case e of
     BoundVar p v -> f p v
@@ -226,9 +226,9 @@ traverseVars f e = do
 traverseBinder ::
   (MonadTraverse m) =>
   VarUpdate m var1 var2 ->
-  Binder NamedBinding var1 builtin ->
-  (Binder NamedBinding var2 builtin -> m (Expr NamedBinding var2 builtin)) ->
-  m (Expr NamedBinding var2 builtin)
+  Binder () var1 builtin ->
+  (Binder () var2 builtin -> m (Expr () var2 builtin)) ->
+  m (Expr () var2 builtin)
 traverseBinder f binder update = do
   binder' <- traverse (traverseVars f) binder
   let updateCtx ctx = nameOf binder : ctx

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -173,12 +173,12 @@ scopeExpr :: (MonadScopeExpr m) => UnscopedExpr -> m ScopedExpr
 scopeExpr = traverseVars scopeVar
 
 -- | Find the index for a given name of a given sort.
-scopeVar :: (MonadScopeExpr m) => VarUpdate m Name DBIndex
+scopeVar :: (MonadScopeExpr m) => VarUpdate m Name Ix
 scopeVar p symbol = do
   (declCtx, boundCtx) <- ask
 
   case elemIndex (Just symbol) boundCtx of
-    Just i -> return $ BoundVar p $ DBIndex i
+    Just i -> return $ BoundVar p $ Ix i
     Nothing -> case Map.lookup symbol declCtx of
       Just ident -> return $ FreeVar p ident
       Nothing -> do

--- a/vehicle/src/Vehicle/Compile/Simplify.hs
+++ b/vehicle/src/Vehicle/Compile/Simplify.hs
@@ -17,15 +17,15 @@ class Simplify a where
   -- | Shortens vectors
   shortenVec :: a -> a
 
-instance Simplify InputProg where
+instance Simplify (Prog () Name Builtin) where
   uninsert = fmap uninsert
   shortenVec = fmap shortenVec
 
-instance Simplify InputDecl where
+instance Simplify (Decl () Name Builtin) where
   uninsert = fmap uninsert
   shortenVec = fmap shortenVec
 
-instance Simplify InputExpr where
+instance Simplify (Expr () Name Builtin) where
   uninsert expr = case expr of
     Universe {} -> expr
     Hole {} -> expr
@@ -60,15 +60,15 @@ instance Simplify InputExpr where
           n2 = Text.pack $ show $ length args - 2
       _ -> normAppList p1 (Builtin p2 b) args
 
-instance Simplify InputBinder where
+instance Simplify (Binder () Name Builtin) where
   uninsert = fmap uninsert
   shortenVec = fmap shortenVec
 
-instance Simplify InputArg where
+instance Simplify (Arg () Name Builtin) where
   uninsert = fmap uninsert
   shortenVec = fmap shortenVec
 
-simplifyArgs :: NonEmpty InputArg -> [InputArg]
+simplifyArgs :: NonEmpty (Arg () Name Builtin) -> [Arg () Name Builtin]
 simplifyArgs = fmap uninsert . NonEmpty.filter (not . wasInserted)
 
 wasInserted :: Arg binder var builtin -> Bool

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -93,7 +93,7 @@ convertExprFromStandardTypes ::
   m (UncheckedExpr types)
 convertExprFromStandardTypes = traverseBuiltinsM builtinUpdateFunction
   where
-    builtinUpdateFunction :: BuiltinUpdate m DBBinding Ix StandardBuiltin (NormalisableBuiltin types)
+    builtinUpdateFunction :: BuiltinUpdate m () Ix StandardBuiltin (NormalisableBuiltin types)
     builtinUpdateFunction p1 p2 b args = do
       case b of
         CConstructor c -> return $ normAppList p1 (Builtin p2 (CConstructor c)) args

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -93,7 +93,7 @@ convertExprFromStandardTypes ::
   m (UncheckedExpr types)
 convertExprFromStandardTypes = traverseBuiltinsM builtinUpdateFunction
   where
-    builtinUpdateFunction :: BuiltinUpdate m DBBinding DBIndex StandardBuiltin (NormalisableBuiltin types)
+    builtinUpdateFunction :: BuiltinUpdate m DBBinding Ix StandardBuiltin (NormalisableBuiltin types)
     builtinUpdateFunction p1 p2 b args = do
       case b of
         CConstructor c -> return $ normAppList p1 (Builtin p2 (CConstructor c)) args

--- a/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
@@ -161,11 +161,11 @@ inferExpr e = do
       ctx <- getBoundCtx
       case lookupVar ctx i of
         Just (_, checkedType) -> do
-          let liftedCheckedType = liftDBIndices (DBLevel $ unIndex i + 1) checkedType
+          let liftedCheckedType = liftDBIndices (Lv $ unIx i + 1) checkedType
           return (BoundVar p i, liftedCheckedType)
         Nothing ->
           compilerDeveloperError $
-            "DBIndex"
+            "Ix"
               <+> pretty i
               <+> "out of bounds when looking"
               <+> "up variable in context"

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -74,8 +74,8 @@ malformedConstraintError c =
 unify ::
   (MonadTypeChecker types m) =>
   ConstraintContext types ->
-  NormExpr types ->
-  NormExpr types ->
+  Value types ->
+  Value types ->
   m (WithContext (Constraint types))
 unify ctx e1 e2 = WithContext (UnificationConstraint $ Unify e1 e2) <$> copyContext ctx
 
@@ -83,8 +83,8 @@ unify ctx e1 e2 = WithContext (UnificationConstraint $ Unify e1 e2) <$> copyCont
 unifyWithPiType ::
   TCM types m =>
   ConstraintContext types ->
-  NormExpr types ->
-  m (WithContext (Constraint types), NormExpr types, NormExpr types)
+  Value types ->
+  m (WithContext (Constraint types), Value types, Value types)
 unifyWithPiType ctx expr = do
   let p = provenanceOf ctx
   let boundCtx = boundContext ctx
@@ -111,7 +111,7 @@ createTC c tc argExprs = do
   let newConstraint = TypeClassConstraint (Has meta tc (NonEmpty.toList argExprs))
   return (unnormalised metaExpr, WithContext newConstraint ctx)
 
-solveTypeClassMeta :: (TCM types m) => ConstraintContext types -> MetaID -> NormExpr types -> m ()
+solveTypeClassMeta :: (TCM types m) => ConstraintContext types -> MetaID -> Value types -> m ()
 solveTypeClassMeta ctx meta solution = do
   quotedSolution <- quote mempty (contextDBLevel ctx) solution
   solveMeta meta quotedSolution (boundContext ctx)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -99,7 +99,7 @@ createTC ::
   (TCM types m) =>
   ConstraintContext types ->
   types ->
-  NonEmpty (NormType types) ->
+  NonEmpty (VType types) ->
   m (CheckedExpr types, WithContext (Constraint types))
 createTC c tc argExprs = do
   let p = provenanceOf c

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -23,7 +23,7 @@ import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Compile.Type.Monad (MonadTypeChecker, TCM, copyContext, freshMetaIdAndExpr, solveMeta, trackSolvedMetas)
-import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
+import Vehicle.Expr.Normalisable (NormalisableBuiltin (..), NormalisableExpr)
 import Vehicle.Expr.Normalised
 
 -- | Attempts to solve as many constraints as possible. Takes in
@@ -100,7 +100,7 @@ createTC ::
   ConstraintContext types ->
   types ->
   NonEmpty (VType types) ->
-  m (CheckedExpr types, WithContext (Constraint types))
+  m (NormalisableExpr types, WithContext (Constraint types))
 createTC c tc argExprs = do
   let p = provenanceOf c
   ctx <- copyContext c

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -131,7 +131,7 @@ solveTrivially = do
 solveArg ::
   (MonadUnify types m) =>
   ConstraintContext types ->
-  (NormArg types, NormArg types) ->
+  (VArg types, VArg types) ->
   Maybe (m (UnificationResult types))
 solveArg ctx (arg1, arg2)
   | not (visibilityMatches arg1 arg2) = Just $ return HardFailure
@@ -164,16 +164,16 @@ solveExplicitSpine ctx args1 args2
 
 solveLam ::
   (MonadUnify types m) =>
-  (NormBinder types, Env builtin, CheckedExpr builtin) ->
-  (NormBinder types, Env builtin, CheckedExpr builtin) ->
+  (VBinder types, Env builtin, CheckedExpr builtin) ->
+  (VBinder types, Env builtin, CheckedExpr builtin) ->
   m (UnificationResult types)
 solveLam _l1 _l2 = compilerDeveloperError "unification of type-level lambdas not yet supported"
 
 solvePi ::
   (MonadUnify types m) =>
   ConstraintContext types ->
-  (NormBinder types, Value types) ->
-  (NormBinder types, Value types) ->
+  (VBinder types, Value types) ->
+  (VBinder types, Value types) ->
   m (UnificationResult types)
 solvePi ctx (binder1, body1) (binder2, body2) = do
   -- !!TODO!! Block until binders are solved

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -25,6 +25,7 @@ import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.DeBruijn
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
@@ -164,8 +165,8 @@ solveExplicitSpine ctx args1 args2
 
 solveLam ::
   (MonadUnify types m) =>
-  (VBinder types, Env builtin, CheckedExpr builtin) ->
-  (VBinder types, Env builtin, CheckedExpr builtin) ->
+  (VBinder types, Env builtin, NormalisableExpr builtin) ->
+  (VBinder types, Env builtin, NormalisableExpr builtin) ->
   m (UnificationResult types)
 solveLam _l1 _l2 = compilerDeveloperError "unification of type-level lambdas not yet supported"
 

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -86,7 +86,7 @@ unification ::
   (MonadUnify types m) =>
   ConstraintContext types ->
   MetaSet ->
-  (NormExpr types, NormExpr types) ->
+  (Value types, Value types) ->
   m (UnificationResult types)
 unification ctx reductionBlockingMetas = \case
   -----------------------
@@ -172,8 +172,8 @@ solveLam _l1 _l2 = compilerDeveloperError "unification of type-level lambdas not
 solvePi ::
   (MonadUnify types m) =>
   ConstraintContext types ->
-  (NormBinder types, NormExpr types) ->
-  (NormBinder types, NormExpr types) ->
+  (NormBinder types, Value types) ->
+  (NormBinder types, Value types) ->
   m (UnificationResult types)
 solvePi ctx (binder1, body1) (binder2, body2) = do
   -- !!TODO!! Block until binders are solved
@@ -191,7 +191,7 @@ solveFlexFlex ctx (meta1, spine1) (meta2, spine2) = do
     Nothing -> solveFlexRigid ctx (meta2, spine2) (VMeta meta1 spine1)
     Just renaming -> solveFlexRigidWithRenaming ctx (meta1, spine1) renaming (VMeta meta2 spine2)
 
-solveFlexRigid :: (MonadUnify types m) => ConstraintContext types -> (MetaID, Spine types) -> NormExpr types -> m (UnificationResult types)
+solveFlexRigid :: (MonadUnify types m) => ConstraintContext types -> (MetaID, Spine types) -> Value types -> m (UnificationResult types)
 solveFlexRigid ctx (metaID, spine) solution = do
   -- Check that 'spine' is a pattern and try to calculate a substitution
   -- that renames the variables in `solution` to ones available to `meta`
@@ -209,7 +209,7 @@ solveFlexRigidWithRenaming ::
   ConstraintContext types ->
   (MetaID, Spine types) ->
   Renaming ->
-  NormExpr types ->
+  Value types ->
   m (UnificationResult types)
 solveFlexRigidWithRenaming ctx meta@(metaID, _) renaming solution = do
   prunedSolution <-
@@ -227,15 +227,15 @@ pruneMetaDependencies ::
   (MonadUnify types m) =>
   ConstraintContext types ->
   (MetaID, Spine types) ->
-  NormExpr types ->
-  m (NormExpr types)
+  Value types ->
+  m (Value types)
 pruneMetaDependencies ctx (solvingMetaID, solvingMetaSpine) attemptedSolution = do
   go attemptedSolution
   where
     go ::
       (MonadUnify types m) =>
-      NormExpr types ->
-      m (NormExpr types)
+      Value types ->
+      m (Value types)
     go expr = case expr of
       VMeta m spine
         | m == solvingMetaID ->
@@ -273,7 +273,7 @@ createMetaWithRestrictedDependencies ::
   ConstraintContext types ->
   MetaID ->
   [Lv] ->
-  m (NormExpr types)
+  m (Value types)
 createMetaWithRestrictedDependencies ctx meta newDependencies = do
   p <- getMetaProvenance (Proxy @types) meta
   metaType <- getMetaType meta
@@ -300,7 +300,7 @@ createMetaWithRestrictedDependencies ctx meta newDependencies = do
 unify ::
   (MonadUnify types m) =>
   ConstraintContext types ->
-  (NormExpr types, NormExpr types) ->
+  (Value types, Value types) ->
   m (WithContext (UnificationConstraint types))
 unify ctx (e1, e2) = WithContext (Unify e1 e2) <$> copyContext ctx
 

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -15,26 +15,6 @@ import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
 
--- * Types pre type-checking
-
-type UncheckedBinding = ()
-
-type UncheckedVar = Ix
-
-type UncheckedBinder types = NormalisableBinder types
-
-type UncheckedArg types = NormalisableArg types
-
-type UncheckedExpr types = NormalisableExpr types
-
-type UncheckedType types = NormalisableExpr types
-
-type UncheckedDecl types = NormalisableDecl types
-
-type UncheckedProg types = NormalisableProg types
-
---------------------------------------------------------------------------------
-
 -- * Types post type-checking
 
 type CheckedBinding = ()
@@ -61,8 +41,8 @@ type Imports types = [GluedProg types]
 
 -- | Errors in bidirectional type-checking
 data TypingError types
-  = MissingExplicitArgument (TypingBoundCtx types) (CheckedBinder types) (UncheckedArg types)
-  | FunctionTypeMismatch (TypingBoundCtx types) (CheckedExpr types) [UncheckedArg types] (CheckedExpr types) [UncheckedArg types]
+  = MissingExplicitArgument (TypingBoundCtx types) (CheckedBinder types) (NormalisableArg types)
+  | FunctionTypeMismatch (TypingBoundCtx types) (CheckedExpr types) [NormalisableArg types] (CheckedExpr types) [NormalisableArg types]
   | FailedUnification (NonEmpty (WithContext (UnificationConstraint types)))
   | UnsolvableConstraints (NonEmpty (WithContext (Constraint types)))
 

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -19,7 +19,7 @@ import Vehicle.Expr.Normalised
 
 type UncheckedBinding = DBBinding
 
-type UncheckedVar = DBIndex
+type UncheckedVar = Ix
 
 type UncheckedBinder types = NormalisableBinder types
 
@@ -39,7 +39,7 @@ type UncheckedProg types = NormalisableProg types
 
 type CheckedBinding = DBBinding
 
-type CheckedVar = DBIndex
+type CheckedVar = Ix
 
 type CheckedBinder types = NormalisableBinder types
 
@@ -141,7 +141,7 @@ instance HasBoundCtx (TypingBoundCtx types) where
 
 typingBoundContextToEnv :: TypingBoundCtx types -> Env types
 typingBoundContextToEnv ctx = do
-  let levels = reverse (fmap DBLevel [0 .. length ctx - 1])
+  let levels = reverse (fmap Lv [0 .. length ctx - 1])
   zipWith (\level (n, _) -> (n, VBoundVar level [])) levels ctx
 
 --------------------------------------------------------------------------------
@@ -227,8 +227,8 @@ extendConstraintBoundCtx ConstraintContext {..} telescope =
       ..
     }
 
-contextDBLevel :: ConstraintContext types -> DBLevel
-contextDBLevel = DBLevel . length . boundContext
+contextDBLevel :: ConstraintContext types -> Lv
+contextDBLevel = Lv . length . boundContext
 
 --------------------------------------------------------------------------------
 -- Unification constraints

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -17,7 +17,7 @@ import Vehicle.Expr.Normalised
 
 -- * Types pre type-checking
 
-type UncheckedBinding = DBBinding
+type UncheckedBinding = ()
 
 type UncheckedVar = Ix
 
@@ -37,7 +37,7 @@ type UncheckedProg types = NormalisableProg types
 
 -- * Types post type-checking
 
-type CheckedBinding = DBBinding
+type CheckedBinding = ()
 
 type CheckedVar = Ix
 

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -99,7 +99,7 @@ addToTypingDeclCtx decl = Map.insert (identifierOf decl) (mkTypingDeclCtxEntry d
 -- Typing declaration context
 
 data NormDeclCtxEntry types = NormDeclCtxEntry
-  { declExpr :: NormExpr types,
+  { declExpr :: Value types,
     declAnns :: [Annotation]
   }
 
@@ -234,7 +234,7 @@ contextDBLevel = Lv . length . boundContext
 -- Unification constraints
 
 -- | A constraint representing that a pair of expressions should be equal
-data UnificationConstraint types = Unify (NormExpr types) (NormExpr types)
+data UnificationConstraint types = Unify (Value types) (Value types)
   deriving (Show)
 
 type instance
@@ -247,7 +247,7 @@ type instance
 data TypeClassConstraint types = Has MetaID types (ExplicitSpine types)
   deriving (Show)
 
-tcNormExpr :: TypeClassConstraint types -> NormExpr types
+tcNormExpr :: TypeClassConstraint types -> Value types
 tcNormExpr (Has _ tc spine) = VBuiltin (CType tc) spine
 
 type instance

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -124,7 +124,7 @@ quantifyOverMeta decl meta = do
         let binderDisplayForm = BinderDisplayForm (OnlyName binderName) True
         prependBinderAndSolveMeta meta binderDisplayForm (Implicit True) Relevant metaType decl
 
-isMeta :: DBExpr builtin -> Bool
+isMeta :: Expr () Ix builtin -> Bool
 isMeta Meta {} = True
 isMeta (App _ Meta {} _) = True
 isMeta _ = False

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -168,7 +168,7 @@ prependBinderAndSolveMeta meta f v r binderType decl = do
   -- We now solve the meta as the newly bound variable
   metaCtx <- getMetaCtx @types meta
   let p = provenanceOf prependedDecl
-  let solution = BoundVar p (DBIndex $ length metaCtx - 1)
+  let solution = BoundVar p (Ix $ length metaCtx - 1)
   solveMeta meta solution metaCtx
 
   logDebug MaxDetail $ "prepended-fresh-binder:" <+> prettyVerbose updatedDecl
@@ -201,7 +201,7 @@ removeContextsOfMetasIn binderType decl =
 addNewArgumentToMetaUses :: MetaID -> CheckedDecl types -> CheckedDecl types
 addNewArgumentToMetaUses meta = fmap (go (-1))
   where
-    go :: DBLevel -> CheckedExpr types -> CheckedExpr types
+    go :: Lv -> CheckedExpr types -> CheckedExpr types
     go d expr = case expr of
       Meta p m
         | m == meta -> App p (Meta p m) [newVar p]

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -18,6 +18,7 @@ import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.DeBruijn
+import Vehicle.Expr.Normalisable
 
 --------------------------------------------------------------------------------
 -- Type-class generalisation
@@ -27,8 +28,8 @@ import Vehicle.Expr.DeBruijn
 -- constraints as instance arguments to the declaration.
 generaliseOverUnsolvedConstraints ::
   (TCM types m) =>
-  CheckedDecl types ->
-  m (CheckedDecl types)
+  NormalisableDecl types ->
+  m (NormalisableDecl types)
 generaliseOverUnsolvedConstraints decl =
   logCompilerPass MidDetail "generalisation over unsolved type-class constraints" $ do
     unsolvedTypeClassConstraints <- traverse substMetas =<< getActiveTypeClassConstraints
@@ -42,9 +43,9 @@ generaliseOverUnsolvedConstraints decl =
 generaliseOverConstraint ::
   (TCM types m) =>
   [WithContext (Constraint types)] ->
-  (CheckedDecl types, [WithContext (TypeClassConstraint types)]) ->
+  (NormalisableDecl types, [WithContext (TypeClassConstraint types)]) ->
   WithContext (TypeClassConstraint types) ->
-  m (CheckedDecl types, [WithContext (TypeClassConstraint types)])
+  m (NormalisableDecl types, [WithContext (TypeClassConstraint types)])
 generaliseOverConstraint allConstraints (decl, rejected) c@(WithContext tc ctx) = do
   -- Find any unsolved meta variables that are transitively linked
   -- by constraints of the same type.
@@ -65,9 +66,9 @@ generaliseOverConstraint allConstraints (decl, rejected) c@(WithContext tc ctx) 
 
 prependConstraint ::
   (TCM types m) =>
-  CheckedDecl types ->
+  NormalisableDecl types ->
   WithContext (TypeClassConstraint types) ->
-  m (CheckedDecl types)
+  m (NormalisableDecl types)
 prependConstraint decl (WithContext constraint@(Has meta tc _) ctx) = do
   let p = originalProvenance ctx
   typeClass <- quote p 0 (tcNormExpr constraint)
@@ -86,8 +87,8 @@ prependConstraint decl (WithContext constraint@(Has meta tc _) ctx) = do
 generaliseOverUnsolvedMetaVariables ::
   forall types m.
   (TCM types m) =>
-  CheckedDecl types ->
-  m (CheckedDecl types)
+  NormalisableDecl types ->
+  m (NormalisableDecl types)
 generaliseOverUnsolvedMetaVariables decl = do
   let declType = typeOf decl
 
@@ -106,9 +107,9 @@ generaliseOverUnsolvedMetaVariables decl = do
 quantifyOverMeta ::
   forall types m.
   (TCM types m) =>
-  CheckedDecl types ->
+  NormalisableDecl types ->
   MetaID ->
-  m (CheckedDecl types)
+  m (NormalisableDecl types)
 quantifyOverMeta decl meta = do
   metaType <- substMetas =<< getMetaType meta
   if isMeta metaType
@@ -139,9 +140,9 @@ prependBinderAndSolveMeta ::
   BinderDisplayForm ->
   Visibility ->
   Relevance ->
-  CheckedType types ->
-  CheckedDecl types ->
-  m (CheckedDecl types)
+  NormalisableType types ->
+  NormalisableDecl types ->
+  m (NormalisableDecl types)
 prependBinderAndSolveMeta meta f v r binderType decl = do
   -- All the metas contained within the type of the binder about to be
   -- appended cannot have any dependencies on variables later on in the expression.
@@ -182,9 +183,9 @@ prependBinderAndSolveMeta meta f v r binderType decl = do
 removeContextsOfMetasIn ::
   forall types m.
   (TCM types m) =>
-  CheckedType types ->
-  CheckedDecl types ->
-  m (CheckedType types, CheckedDecl types)
+  NormalisableType types ->
+  NormalisableDecl types ->
+  m (NormalisableType types, NormalisableDecl types)
 removeContextsOfMetasIn binderType decl =
   logCompilerPass MaxDetail "removing dependencies from dependent metas" $ do
     metasInBinder <- metasIn binderType
@@ -198,10 +199,10 @@ removeContextsOfMetasIn binderType decl =
         logCompilerPassOutput (prettyVerbose substDecl)
         return (substBinderType, substDecl)
 
-addNewArgumentToMetaUses :: MetaID -> CheckedDecl types -> CheckedDecl types
+addNewArgumentToMetaUses :: MetaID -> NormalisableDecl types -> NormalisableDecl types
 addNewArgumentToMetaUses meta = fmap (go (-1))
   where
-    go :: Lv -> CheckedExpr types -> CheckedExpr types
+    go :: Lv -> NormalisableExpr types -> NormalisableExpr types
     go d expr = case expr of
       Meta p m
         | m == meta -> App p (Meta p m) [newVar p]

--- a/vehicle/src/Vehicle/Compile/Type/Irrelevance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Irrelevance.hs
@@ -64,7 +64,7 @@ instance RemoveIrrelevantCode m (CheckedExpr types) where
     showRemoveExit result
     return result
 
-instance (MonadNorm types m) => RemoveIrrelevantCode m (NormExpr types) where
+instance (MonadNorm types m) => RemoveIrrelevantCode m (Value types) where
   remove expr = case expr of
     VUniverse {} -> return expr
     VPi binder res

--- a/vehicle/src/Vehicle/Compile/Type/Irrelevance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Irrelevance.hs
@@ -8,7 +8,7 @@ import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Vehicle.Compile.Error (MonadCompile, compilerDeveloperError)
 import Vehicle.Compile.Normalise.NBE (MonadNorm)
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Type.Core
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 -- | Removes all irrelevant code from the program/expression.
@@ -36,7 +36,7 @@ instance (RemoveIrrelevantCode m expr) => RemoveIrrelevantCode m (GenericProg ex
 instance (RemoveIrrelevantCode m expr) => RemoveIrrelevantCode m (GenericDecl expr) where
   remove = traverse remove
 
-instance RemoveIrrelevantCode m (CheckedExpr types) where
+instance RemoveIrrelevantCode m (NormalisableExpr types) where
   remove expr = do
     showRemoveEntry expr
     result <- case expr of
@@ -109,12 +109,12 @@ removeArgs = traverse remove . filter isRelevant
 --------------------------------------------------------------------------------
 -- Debug functions
 
-showRemoveEntry :: (MonadRemove m) => CheckedExpr types -> m ()
+showRemoveEntry :: (MonadRemove m) => NormalisableExpr types -> m ()
 showRemoveEntry _e = do
   -- logDebug MaxDetail ("remove-entry" <+> prettyVerbose e)
   incrCallDepth
 
-showRemoveExit :: (MonadRemove m) => CheckedExpr types -> m ()
+showRemoveExit :: (MonadRemove m) => NormalisableExpr types -> m ()
 showRemoveExit _e = do
   decrCallDepth
 

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -14,7 +14,7 @@ import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Meta.Variable (MetaInfo (..))
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalisable
-import Vehicle.Expr.Normalised (GluedExpr (..), NormExpr (..))
+import Vehicle.Expr.Normalised (GluedExpr (..), Value (..))
 
 -- | Substitutes meta-variables through the provided object, returning the
 -- updated object and the set of meta-variables within the object for which
@@ -84,7 +84,7 @@ substApp p (fun@(Meta _ m), mArgs) = do
     substArgs e args = return $ normAppList p e args
 substApp p (fun, args) = normAppList p <$> subst fun <*> subst args
 
-instance (MonadNorm types m) => MetaSubstitutable m (NormExpr types) where
+instance (MonadNorm types m) => MetaSubstitutable m (Value types) where
   subst expr = case expr of
     VMeta m args -> do
       metaSubst <- getMetaSubstitution

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -90,7 +90,7 @@ getMetaDependencies = \case
   (ExplicitArg _ (BoundVar _ i)) : args -> i : getMetaDependencies args
   _ -> []
 
-getNormMetaDependencies :: [NormArg types] -> ([Lv], Spine types)
+getNormMetaDependencies :: [VArg types] -> ([Lv], Spine types)
 getNormMetaDependencies = \case
   (ExplicitArg _ (VBoundVar i [])) : args -> first (i :) $ getNormMetaDependencies args
   spine -> ([], spine)

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -29,7 +29,7 @@ import Vehicle.Expr.Normalised
 -- Meta information
 
 -- | The size of a meta-variable's context (i.e. how many bound variables it
--- can depend on.) In theory this should be identical to the current `DBLevel`
+-- can depend on.) In theory this should be identical to the current `Lv`
 -- but in practice, linearity/polarity/type-class insertion meta-variables
 -- have a context of zero size as they cannot depend on the context.
 type MetaCtxSize = Int
@@ -60,8 +60,8 @@ makeMetaExpr ::
 makeMetaExpr p metaID boundCtx = do
   -- Create bound variables for everything in the context
   let dependencyLevels = [0 .. (length boundCtx - 1)]
-  let unnormBoundEnv = [ExplicitArg p (BoundVar p $ DBIndex i) | i <- reverse dependencyLevels]
-  let normBoundEnv = [ExplicitArg p (VBoundVar (DBLevel i) []) | i <- dependencyLevels]
+  let unnormBoundEnv = [ExplicitArg p (BoundVar p $ Ix i) | i <- reverse dependencyLevels]
+  let normBoundEnv = [ExplicitArg p (VBoundVar (Lv i) []) | i <- dependencyLevels]
 
   -- Returns a meta applied to every bound variable in the context
   Glued
@@ -85,12 +85,12 @@ makeMetaType boundCtx p resultType = foldr entryToPi resultType (reverse boundCt
       let n = fromMaybe "_" name
       Pi p (Binder p (BinderDisplayForm (OnlyName n) True) Explicit Relevant () t)
 
-getMetaDependencies :: [CheckedArg types] -> [DBIndex]
+getMetaDependencies :: [CheckedArg types] -> [Ix]
 getMetaDependencies = \case
   (ExplicitArg _ (BoundVar _ i)) : args -> i : getMetaDependencies args
   _ -> []
 
-getNormMetaDependencies :: [NormArg types] -> ([DBLevel], Spine types)
+getNormMetaDependencies :: [NormArg types] -> ([Lv], Spine types)
 getNormMetaDependencies = \case
   (ExplicitArg _ (VBoundVar i [])) : args -> first (i :) $ getNormMetaDependencies args
   spine -> ([], spine)

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -118,7 +118,7 @@ instance HasMetas (CheckedExpr types) where
     Lam _ binder body -> do findMetas binder; findMetas body
     App _ fun args -> do findMetas fun; findMetas args
 
-instance HasMetas (NormExpr types) where
+instance HasMetas (Value types) where
   findMetas expr = case expr of
     VMeta m spine -> do
       tell (MetaSet.singleton m)

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -95,7 +95,7 @@ freshMetaIdAndExpr ::
   forall types m.
   (TCM types m) =>
   Provenance ->
-  CheckedType types ->
+  NormalisableType types ->
   TypingBoundCtx types ->
   m (MetaID, GluedExpr types)
 freshMetaIdAndExpr p t boundCtx = do
@@ -106,7 +106,7 @@ freshMetaExpr ::
   forall types m.
   (TCM types m) =>
   Provenance ->
-  CheckedType types ->
+  NormalisableType types ->
   TypingBoundCtx types ->
   m (GluedExpr types)
 freshMetaExpr p t boundCtx = snd <$> freshMetaIdAndExpr p t boundCtx
@@ -117,8 +117,8 @@ createFreshTypeClassConstraint ::
   forall types m.
   (TCM types m) =>
   TypingBoundCtx types ->
-  (CheckedExpr types, [CheckedArg types]) ->
-  CheckedType types ->
+  (NormalisableExpr types, [NormalisableArg types]) ->
+  NormalisableType types ->
   m (GluedExpr types)
 createFreshTypeClassConstraint boundCtx (fun, funArgs) tcExpr = do
   (tc, tcArgs) <- case tcExpr of
@@ -147,8 +147,8 @@ instantiateArgForNonExplicitBinder ::
   (TCM types m) =>
   TypingBoundCtx types ->
   Provenance ->
-  (CheckedExpr types, [CheckedArg types]) ->
-  CheckedBinder types ->
+  (NormalisableExpr types, [NormalisableArg types]) ->
+  NormalisableBinder types ->
   m (GluedArg types)
 instantiateArgForNonExplicitBinder boundCtx p origin binder = do
   let binderType = typeOf binder

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -135,8 +135,8 @@ class (PrintableBuiltin types) => TypableBuiltin types where
     (MonadTypeChecker types m) =>
     Provenance ->
     StandardBuiltinType ->
-    [UncheckedArg types] ->
-    m (UncheckedExpr types)
+    [NormalisableArg types] ->
+    m (NormalisableExpr types)
 
   -- | Can meta-variables be dependent on their context?
   useDependentMetas :: Proxy types -> Bool

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
@@ -22,7 +22,7 @@ import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad.Class
-import Vehicle.Expr.DeBruijn (DBType)
+import Vehicle.Expr.DeBruijn (Ix)
 
 --------------------------------------------------------------------------------
 -- Implementation
@@ -34,7 +34,7 @@ clearFreshNamesInternal :: (Monad m) => TypeCheckerTInternals builtin m ()
 clearFreshNamesInternal =
   modify (\TypeCheckerState {..} -> TypeCheckerState {freshNameState = 0, ..})
 
-getFreshNameInternal :: (Monad m) => DBType builtin -> TypeCheckerTInternals builtin2 m Name
+getFreshNameInternal :: (Monad m) => Type () Ix builtin -> TypeCheckerTInternals builtin2 m Name
 getFreshNameInternal _typ = do
   nameID <- gets freshNameState
   modify (\TypeCheckerState {..} -> TypeCheckerState {freshNameState = nameID + 1, ..})

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/InputOutputInsertion.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/InputOutputInsertion.hs
@@ -5,11 +5,10 @@ where
 
 import Control.Monad.State (MonadState (..), evalStateT, modify)
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta.Map (MetaMap (..))
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Monad (TCM, createFreshTypeClassConstraint, freshMetaExpr)
-import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 -------------------------------------------------------------------------------
@@ -22,8 +21,8 @@ import Vehicle.Expr.Normalised
 addFunctionAuxiliaryInputOutputConstraints ::
   (TCM types m) =>
   (FunctionPosition -> types) ->
-  CheckedDecl types ->
-  m (CheckedDecl types)
+  NormalisableDecl types ->
+  m (NormalisableDecl types)
 addFunctionAuxiliaryInputOutputConstraints mkConstraint = \case
   DefFunction p ident anns t e -> do
     logCompilerPass MaxDetail "insertion of input/output constraints" $ do
@@ -32,12 +31,12 @@ addFunctionAuxiliaryInputOutputConstraints mkConstraint = \case
   d -> return d
 
 decomposePiType ::
-  (TCM types m, MonadState (MetaMap (CheckedExpr types)) m) =>
+  (TCM types m, MonadState (MetaMap (NormalisableExpr types)) m) =>
   (FunctionPosition -> types) ->
   DeclProvenance ->
   Int ->
-  CheckedType types ->
-  m (CheckedType types)
+  NormalisableType types ->
+  m (NormalisableType types)
 decomposePiType mkConstraint declProv@(ident, p) inputNumber = \case
   Pi p' binder res
     | isExplicit binder -> do
@@ -55,11 +54,11 @@ decomposePiType mkConstraint declProv@(ident, p) inputNumber = \case
     addFunctionConstraint mkConstraint (p, position) outputType
 
 addFunctionConstraint ::
-  (TCM types m, MonadState (MetaMap (CheckedExpr types)) m) =>
+  (TCM types m, MonadState (MetaMap (NormalisableExpr types)) m) =>
   (FunctionPosition -> types) ->
   (Provenance, FunctionPosition) ->
-  CheckedExpr types ->
-  m (CheckedExpr types)
+  NormalisableExpr types ->
+  m (NormalisableExpr types)
 addFunctionConstraint mkConstraint (declProv, position) existingExpr = do
   let p = provenanceOf existingExpr
   newExpr <- case existingExpr of

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/AnnotationRestrictions.hs
@@ -18,7 +18,7 @@ checkNetworkType ::
   (MonadTypeChecker LinearityType m) =>
   DeclProvenance ->
   GluedType LinearityType ->
-  m (CheckedType LinearityType)
+  m (NormalisableType LinearityType)
 checkNetworkType (ident, p) networkType = case normalised networkType of
   -- \|Decomposes the Pi types in a network type signature, checking that the
   -- binders are explicit and their types are equal. Returns a function that
@@ -42,7 +42,7 @@ assertConstantLinearity ::
   (MonadTypeChecker LinearityType m) =>
   DeclProvenance ->
   GluedType LinearityType ->
-  m (CheckedType LinearityType)
+  m (NormalisableType LinearityType)
 assertConstantLinearity (_, p) t = do
   createFreshUnificationConstraint p mempty CheckingAuxiliary (LinearityExpr p Constant) (unnormalised t)
   return $ unnormalised t

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Core.hs
@@ -126,8 +126,8 @@ instance Pretty LinearityTypeClass where
 
 type LinearityBuiltin = NormalisableBuiltin LinearityType
 
--- NormExpr
-type LinearityNormExpr = NormExpr LinearityType
+-- Value
+type LinearityNormExpr = Value LinearityType
 
 type LinearityNormBinder = NormBinder LinearityType
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Core.hs
@@ -129,11 +129,11 @@ type LinearityBuiltin = NormalisableBuiltin LinearityType
 -- Value
 type LinearityNormExpr = Value LinearityType
 
-type LinearityNormBinder = NormBinder LinearityType
+type LinearityNormBinder = VBinder LinearityType
 
-type LinearityNormArg = NormArg LinearityType
+type LinearityNormArg = VArg LinearityType
 
-type LinearityNormType = NormType LinearityType
+type LinearityNormType = VType LinearityType
 
 type LinearitySpine = Spine LinearityType
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Type.hs
@@ -20,7 +20,7 @@ import Vehicle.Expr.Normalised
 import Prelude hiding (pi)
 
 -- | Return the type of the provided builtin.
-typeLinearityBuiltin :: Provenance -> NormalisableBuiltin LinearityType -> CheckedType LinearityType
+typeLinearityBuiltin :: Provenance -> NormalisableBuiltin LinearityType -> NormalisableType LinearityType
 typeLinearityBuiltin p b = fromDSL p $ case b of
   CConstructor c -> typeOfConstructor c
   CFunction f -> typeOfBuiltinFunction f

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Type.hs
@@ -154,8 +154,8 @@ convertToLinearityTypes ::
   (MonadTypeChecker LinearityType m) =>
   Provenance ->
   StandardBuiltinType ->
-  [UncheckedArg LinearityType] ->
-  m (UncheckedExpr LinearityType)
+  [NormalisableArg LinearityType] ->
+  m (NormalisableExpr LinearityType)
 convertToLinearityTypes p b args = case b of
   StandardBuiltinType s -> case s of
     Unit -> return $ Builtin p $ CType $ Linearity Constant

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/AnnotationRestrictions.hs
@@ -10,6 +10,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Polarity.Core
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 checkNetworkType ::
@@ -17,7 +18,7 @@ checkNetworkType ::
   (MonadTypeChecker PolarityType m) =>
   DeclProvenance ->
   GluedType PolarityType ->
-  m (CheckedType PolarityType)
+  m (NormalisableType PolarityType)
 checkNetworkType (_, p) networkType = case normalised networkType of
   -- \|Decomposes the Pi types in a network type signature, checking that the
   -- binders are explicit and their types are equal. Returns a function that
@@ -35,7 +36,7 @@ assertUnquantifiedPolarity ::
   (MonadTypeChecker PolarityType m) =>
   DeclProvenance ->
   GluedType PolarityType ->
-  m (CheckedType PolarityType)
+  m (NormalisableType PolarityType)
 assertUnquantifiedPolarity (_, p) t = do
   createFreshUnificationConstraint p mempty CheckingAuxiliary (PolarityExpr p Unquantified) (unnormalised t)
   return $ unnormalised t

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Core.hs
@@ -142,11 +142,11 @@ type PolarityConstraint = Constraint PolarityType
 -- Value
 type PolarityNormExpr = Value PolarityType
 
-type PolarityNormBinder = NormBinder PolarityType
+type PolarityNormBinder = VBinder PolarityType
 
-type PolarityNormArg = NormArg PolarityType
+type PolarityNormArg = VArg PolarityType
 
-type PolarityNormType = NormType PolarityType
+type PolarityNormType = VType PolarityType
 
 type PolaritySpine = Spine PolarityType
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Core.hs
@@ -139,8 +139,8 @@ type PolarityConstraintContext = ConstraintContext PolarityType
 
 type PolarityConstraint = Constraint PolarityType
 
--- NormExpr
-type PolarityNormExpr = NormExpr PolarityType
+-- Value
+type PolarityNormExpr = Value PolarityType
 
 type PolarityNormBinder = NormBinder PolarityType
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Type.hs
@@ -20,7 +20,7 @@ import Vehicle.Expr.Normalised
 import Prelude hiding (pi)
 
 -- | Return the type of the provided builtin.
-typePolarityBuiltin :: Provenance -> PolarityBuiltin -> CheckedType PolarityType
+typePolarityBuiltin :: Provenance -> PolarityBuiltin -> NormalisableType PolarityType
 typePolarityBuiltin p b = fromDSL p $ case b of
   CConstructor c -> typeOfConstructor c
   CFunction f -> typeOfBuiltinFunction f

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Type.hs
@@ -156,8 +156,8 @@ convertToPolarityTypes ::
   (MonadTypeChecker PolarityType m) =>
   Provenance ->
   StandardBuiltinType ->
-  [UncheckedArg PolarityType] ->
-  m (UncheckedExpr PolarityType)
+  [NormalisableArg PolarityType] ->
+  m (NormalisableExpr PolarityType)
 convertToPolarityTypes p b args = case b of
   StandardBuiltinType s -> case s of
     Unit -> return $ PolarityExpr p Unquantified

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/AnnotationRestrictions.hs
@@ -24,7 +24,7 @@ restrictStandardPropertyType ::
   m ()
 restrictStandardPropertyType decl parameterType = go (normalised parameterType)
   where
-    go :: NormType StandardBuiltinType -> m ()
+    go :: VType StandardBuiltinType -> m ()
     go = \case
       VBoolType {} -> return ()
       VVectorType tElem _ -> go tElem

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/InstanceSolver.hs
@@ -21,7 +21,7 @@ import Vehicle.Compile.Type.Subsystem.Standard.Constraint.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceBuiltins
 import Vehicle.Compile.Type.Subsystem.Standard.Constraint.TypeClassSolver (solveTypeClassConstraint)
 import Vehicle.Compile.Type.Subsystem.Standard.Core
-import Vehicle.Expr.DeBruijn (DBLevel (..), dbLevelToIndex, substDBInto)
+import Vehicle.Expr.DeBruijn (Lv (..), dbLevelToIndex, substDBInto)
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
@@ -121,7 +121,7 @@ findCandidatesInBoundCtx goal ctx = go ctx
             let candidate =
                   InstanceCandidate
                     { candidateExpr = t,
-                      candidateSolution = BoundVar mempty (dbLevelToIndex (DBLevel $ length ctx) (DBLevel $ length localCtx))
+                      candidateSolution = BoundVar mempty (dbLevelToIndex (Lv $ length ctx) (Lv $ length localCtx))
                     }
             return $ WithContext candidate localCtx : candidates
           _ -> return candidates

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
@@ -41,7 +41,7 @@ instance Hashable StandardBuiltinType
 
 instance Serialize StandardBuiltinType
 
-convertToNormalisableBuiltins :: DBExpr Builtin -> DBExpr StandardBuiltin
+convertToNormalisableBuiltins :: Expr () Ix Builtin -> Expr () Ix StandardBuiltin
 convertToNormalisableBuiltins = traverseBuiltins $ \p1 p2 b args -> do
   let fn = Builtin p2 $ case b of
         Constructor c -> CConstructor c
@@ -194,14 +194,14 @@ type instance
 
 -----------------------------------------------------------------------------
 
-type TypeCheckedBinder = DBBinder StandardBuiltin
+type TypeCheckedBinder = Binder () Ix StandardBuiltin
 
-type TypeCheckedArg = DBArg StandardBuiltin
+type TypeCheckedArg = Arg () Ix StandardBuiltin
 
-type TypeCheckedExpr = DBExpr StandardBuiltin
+type TypeCheckedExpr = Expr () Ix StandardBuiltin
 
-type TypeCheckedType = DBExpr StandardBuiltin
+type TypeCheckedType = Expr () Ix StandardBuiltin
 
-type TypeCheckedDecl = DBDecl StandardBuiltin
+type TypeCheckedDecl = Decl () Ix StandardBuiltin
 
-type TypeCheckedProg = DBProg StandardBuiltin
+type TypeCheckedProg = Prog () Ix StandardBuiltin

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
@@ -78,11 +78,11 @@ type StandardTypingBoundCtx = TypingBoundCtx StandardBuiltinType
 
 type StandardNormExpr = Value StandardBuiltinType
 
-type StandardNormBinder = NormBinder StandardBuiltinType
+type StandardNormBinder = VBinder StandardBuiltinType
 
-type StandardNormArg = NormArg StandardBuiltinType
+type StandardNormArg = VArg StandardBuiltinType
 
-type StandardNormType = NormType StandardBuiltinType
+type StandardNormType = VType StandardBuiltinType
 
 type StandardSpine = Spine StandardBuiltinType
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
@@ -76,7 +76,7 @@ type StandardTypingBoundCtx = TypingBoundCtx StandardBuiltinType
 -----------------------------------------------------------------------------
 -- Norm expressions
 
-type StandardNormExpr = NormExpr StandardBuiltinType
+type StandardNormExpr = Value StandardBuiltinType
 
 type StandardNormBinder = NormBinder StandardBuiltinType
 

--- a/vehicle/src/Vehicle/Expr/DSL.hs
+++ b/vehicle/src/Vehicle/Expr/DSL.hs
@@ -110,13 +110,13 @@ class DSL expr where
   free :: StdLibFunction -> expr
 
 newtype DSLExpr types = DSL
-  { unDSL :: Provenance -> DBLevel -> NormalisableExpr types
+  { unDSL :: Provenance -> Lv -> NormalisableExpr types
   }
 
 fromDSL :: Provenance -> DSLExpr types -> CheckedExpr types
 fromDSL p e = unDSL e p 0
 
-boundVar :: DBLevel -> DSLExpr types
+boundVar :: Lv -> DSLExpr types
 boundVar i = DSL $ \p j -> BoundVar p (dbLevelToIndex j i)
 
 approxPiForm :: Maybe Name -> Visibility -> BinderDisplayForm

--- a/vehicle/src/Vehicle/Expr/DSL.hs
+++ b/vehicle/src/Vehicle/Expr/DSL.hs
@@ -87,7 +87,6 @@ where
 import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (fromMaybe)
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Linearity.Core
 import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
@@ -113,7 +112,7 @@ newtype DSLExpr types = DSL
   { unDSL :: Provenance -> Lv -> NormalisableExpr types
   }
 
-fromDSL :: Provenance -> DSLExpr types -> CheckedExpr types
+fromDSL :: Provenance -> DSLExpr types -> NormalisableExpr types
 fromDSL p e = unDSL e p 0
 
 boundVar :: Lv -> DSLExpr types

--- a/vehicle/src/Vehicle/Expr/DeBruijn.hs
+++ b/vehicle/src/Vehicle/Expr/DeBruijn.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Vehicle.Expr.DeBruijn
-  ( DBBinding,
-    Ix (..),
+  ( Ix (..),
     Lv (..),
-    DBTelescope,
     Substitution,
     substituteDB,
     substDBInto,
@@ -68,9 +66,6 @@ instance Serialize Lv
 instance Pretty Lv where
   pretty l = "𝓵" <> pretty (unLv l)
 
--- | The type of the data DeBruijn notation stores at binding sites.
-type DBBinding = ()
-
 -- | Converts a `Lv` x to a `Ix` given that we're currently at
 -- level `l`.
 dbLevelToIndex :: Lv -> Lv -> Ix
@@ -78,11 +73,6 @@ dbLevelToIndex l x = Ix (unLv l - unLv x - 1)
 
 shiftDBIndex :: Ix -> Lv -> Ix
 shiftDBIndex i l = Ix (unIx i + unLv l)
-
---------------------------------------------------------------------------------
--- Expressions
-
-type DBTelescope builtin = [Binder () Ix builtin]
 
 --------------------------------------------------------------------------------
 -- Substitution

--- a/vehicle/src/Vehicle/Expr/Normalisable.hs
+++ b/vehicle/src/Vehicle/Expr/Normalisable.hs
@@ -29,16 +29,16 @@ instance (Hashable types) => Hashable (NormalisableBuiltin types)
 -----------------------------------------------------------------------------
 -- Expressions
 
-type NormalisableExpr types = DBExpr (NormalisableBuiltin types)
+type NormalisableExpr types = Expr () Ix (NormalisableBuiltin types)
 
-type NormalisableBinder types = DBBinder (NormalisableBuiltin types)
+type NormalisableBinder types = Binder () Ix (NormalisableBuiltin types)
 
-type NormalisableArg types = DBArg (NormalisableBuiltin types)
+type NormalisableArg types = Arg () Ix (NormalisableBuiltin types)
 
 type NormalisableType types = NormalisableExpr types
 
-type NormalisableDecl types = DBDecl (NormalisableBuiltin types)
+type NormalisableDecl types = Decl () Ix (NormalisableBuiltin types)
 
-type NormalisableProg types = DBProg (NormalisableBuiltin types)
+type NormalisableProg types = Prog () Ix (NormalisableBuiltin types)
 
 type NormalisableTelescope types = DBTelescope (NormalisableBuiltin types)

--- a/vehicle/src/Vehicle/Expr/Normalisable.hs
+++ b/vehicle/src/Vehicle/Expr/Normalisable.hs
@@ -41,4 +41,4 @@ type NormalisableDecl types = Decl () Ix (NormalisableBuiltin types)
 
 type NormalisableProg types = Prog () Ix (NormalisableBuiltin types)
 
-type NormalisableTelescope types = DBTelescope (NormalisableBuiltin types)
+type NormalisableTelescope types = Telescope () Ix (NormalisableBuiltin types)

--- a/vehicle/src/Vehicle/Expr/Normalised.hs
+++ b/vehicle/src/Vehicle/Expr/Normalised.hs
@@ -18,7 +18,7 @@ data NormExpr types
   | VPi (NormBinder types) (NormExpr types)
   | VMeta MetaID (Spine types)
   | VFreeVar Identifier (Spine types)
-  | VBoundVar DBLevel (Spine types)
+  | VBoundVar Lv (Spine types)
   | VBuiltin (NormalisableBuiltin types) (ExplicitSpine types)
   deriving (Eq, Show, Generic)
 
@@ -52,7 +52,7 @@ extendEnv binder value = ((nameOf binder, value) :)
 
 extendEnvOverBinder :: GenericBinder binder expr -> Env types -> Env types
 extendEnvOverBinder binder env =
-  extendEnv binder (VBoundVar (DBLevel $ length env) []) env
+  extendEnv binder (VBoundVar (Lv $ length env) []) env
 
 -----------------------------------------------------------------------------
 -- Patterns

--- a/vehicle/src/Vehicle/Expr/Normalised.hs
+++ b/vehicle/src/Vehicle/Expr/Normalised.hs
@@ -26,7 +26,7 @@ instance (Serialize types) => Serialize (NormExpr types)
 
 type NormArg types = GenericArg (NormExpr types)
 
-type NormBinder types = GenericBinder DBBinding (NormType types)
+type NormBinder types = GenericBinder () (NormType types)
 
 type NormDecl types = GenericDecl (NormExpr types)
 

--- a/vehicle/src/Vehicle/Expr/Normalised.hs
+++ b/vehicle/src/Vehicle/Expr/Normalised.hs
@@ -12,28 +12,28 @@ import Vehicle.Syntax.AST
 
 -- | A normalised expression. Internal invariant is that it should always be
 -- well-typed.
-data NormExpr types
+data Value types
   = VUniverse UniverseLevel
   | VLam (NormBinder types) (Env types) (NormalisableExpr types)
-  | VPi (NormBinder types) (NormExpr types)
+  | VPi (NormBinder types) (Value types)
   | VMeta MetaID (Spine types)
   | VFreeVar Identifier (Spine types)
   | VBoundVar Lv (Spine types)
   | VBuiltin (NormalisableBuiltin types) (ExplicitSpine types)
   deriving (Eq, Show, Generic)
 
-instance (Serialize types) => Serialize (NormExpr types)
+instance (Serialize types) => Serialize (Value types)
 
-type NormArg types = GenericArg (NormExpr types)
+type NormArg types = GenericArg (Value types)
 
 type NormBinder types = GenericBinder () (NormType types)
 
-type NormDecl types = GenericDecl (NormExpr types)
+type NormDecl types = GenericDecl (Value types)
 
 type NormProg types = GenericDecl types
 
 -- | A normalised type
-type NormType types = NormExpr types
+type NormType types = Value types
 
 -----------------------------------------------------------------------------
 -- Spines and environments
@@ -43,11 +43,11 @@ type Spine types = [NormArg types]
 
 -- | A spine type for builtins which enforces the invariant that they should
 -- only ever depend computationally on their explicit arguments.
-type ExplicitSpine types = [NormExpr types]
+type ExplicitSpine types = [Value types]
 
-type Env types = BoundCtx (Maybe Name, NormExpr types)
+type Env types = BoundCtx (Maybe Name, Value types)
 
-extendEnv :: GenericBinder binder expr -> NormExpr types -> Env types -> Env types
+extendEnv :: GenericBinder binder expr -> Value types -> Env types -> Env types
 extendEnv binder value = ((nameOf binder, value) :)
 
 extendEnvOverBinder :: GenericBinder binder expr -> Env types -> Env types
@@ -60,64 +60,64 @@ extendEnvOverBinder binder env =
 pattern VTypeUniverse :: UniverseLevel -> NormType types
 pattern VTypeUniverse l = VUniverse l
 
-pattern VBuiltinFunction :: BuiltinFunction -> ExplicitSpine types -> NormExpr types
+pattern VBuiltinFunction :: BuiltinFunction -> ExplicitSpine types -> Value types
 pattern VBuiltinFunction f spine = VBuiltin (CFunction f) spine
 
-pattern VConstructor :: BuiltinConstructor -> ExplicitSpine types -> NormExpr types
+pattern VConstructor :: BuiltinConstructor -> ExplicitSpine types -> Value types
 pattern VConstructor c args = VBuiltin (CConstructor c) args
 
-pattern VNullaryConstructor :: BuiltinConstructor -> NormExpr types
+pattern VNullaryConstructor :: BuiltinConstructor -> Value types
 pattern VNullaryConstructor c <- VConstructor c []
   where
     VNullaryConstructor c = VConstructor c []
 
-pattern VUnitLiteral :: NormExpr types
+pattern VUnitLiteral :: Value types
 pattern VUnitLiteral = VNullaryConstructor LUnit
 
-pattern VBoolLiteral :: Bool -> NormExpr types
+pattern VBoolLiteral :: Bool -> Value types
 pattern VBoolLiteral x = VNullaryConstructor (LBool x)
 
-pattern VIndexLiteral :: Int -> NormExpr types
+pattern VIndexLiteral :: Int -> Value types
 pattern VIndexLiteral x = VNullaryConstructor (LIndex x)
 
-pattern VNatLiteral :: Int -> NormExpr types
+pattern VNatLiteral :: Int -> Value types
 pattern VNatLiteral x = VNullaryConstructor (LNat x)
 
-pattern VIntLiteral :: Int -> NormExpr types
+pattern VIntLiteral :: Int -> Value types
 pattern VIntLiteral x = VNullaryConstructor (LInt x)
 
-pattern VRatLiteral :: Rational -> NormExpr types
+pattern VRatLiteral :: Rational -> Value types
 pattern VRatLiteral x = VNullaryConstructor (LRat x)
 
-pattern VVecLiteral :: [NormExpr types] -> NormExpr types
+pattern VVecLiteral :: [Value types] -> Value types
 pattern VVecLiteral xs <- VConstructor (LVec _) xs
   where
     VVecLiteral xs = VConstructor (LVec (length xs)) xs
 
-pattern VNil :: NormExpr types
+pattern VNil :: Value types
 pattern VNil = VNullaryConstructor Nil
 
-pattern VCons :: [NormExpr types] -> NormExpr types
+pattern VCons :: [Value types] -> Value types
 pattern VCons xs = VConstructor Cons xs
 
-mkVList :: [NormExpr types] -> NormExpr types
+mkVList :: [Value types] -> Value types
 mkVList = foldr cons nil
   where
     nil = VConstructor Nil []
     cons y ys = VConstructor Cons [y, ys]
 
-mkVLVec :: [NormExpr types] -> NormExpr types
+mkVLVec :: [Value types] -> Value types
 mkVLVec xs = VConstructor (LVec (length xs)) xs
 
-isNTypeUniverse :: NormExpr types -> Bool
+isNTypeUniverse :: Value types -> Bool
 isNTypeUniverse VUniverse {} = True
 isNTypeUniverse _ = False
 
-isNMeta :: NormExpr types -> Bool
+isNMeta :: Value types -> Bool
 isNMeta VMeta {} = True
 isNMeta _ = False
 
-getNMeta :: NormExpr types -> Maybe MetaID
+getNMeta :: Value types -> Maybe MetaID
 getNMeta (VMeta m _) = Just m
 getNMeta _ = Nothing
 
@@ -127,7 +127,7 @@ getNMeta _ = Nothing
 -- | A pair of an unnormalised and normalised expression.
 data GluedExpr types = Glued
   { unnormalised :: NormalisableExpr types,
-    normalised :: NormExpr types
+    normalised :: Value types
   }
   deriving (Show, Generic)
 
@@ -144,7 +144,7 @@ type GluedProg types = GenericProg (GluedExpr types)
 
 type GluedDecl types = GenericDecl (GluedExpr types)
 
-traverseNormalised :: (Monad m) => (NormExpr types -> m (NormExpr types)) -> GluedExpr types -> m (GluedExpr types)
+traverseNormalised :: (Monad m) => (Value types -> m (Value types)) -> GluedExpr types -> m (GluedExpr types)
 traverseNormalised f (Glued u n) = Glued u <$> f n
 
 traverseUnnormalised :: (Monad m) => (NormalisableExpr types -> m (NormalisableExpr types)) -> GluedExpr types -> m (GluedExpr types)

--- a/vehicle/src/Vehicle/Expr/Normalised.hs
+++ b/vehicle/src/Vehicle/Expr/Normalised.hs
@@ -14,8 +14,8 @@ import Vehicle.Syntax.AST
 -- well-typed.
 data Value types
   = VUniverse UniverseLevel
-  | VLam (NormBinder types) (Env types) (NormalisableExpr types)
-  | VPi (NormBinder types) (Value types)
+  | VLam (VBinder types) (Env types) (NormalisableExpr types)
+  | VPi (VBinder types) (Value types)
   | VMeta MetaID (Spine types)
   | VFreeVar Identifier (Spine types)
   | VBoundVar Lv (Spine types)
@@ -24,22 +24,22 @@ data Value types
 
 instance (Serialize types) => Serialize (Value types)
 
-type NormArg types = GenericArg (Value types)
+type VArg types = GenericArg (Value types)
 
-type NormBinder types = GenericBinder () (NormType types)
+type VBinder types = GenericBinder () (VType types)
 
-type NormDecl types = GenericDecl (Value types)
+type VDecl types = GenericDecl (Value types)
 
-type NormProg types = GenericDecl types
+type VProg types = GenericDecl types
 
 -- | A normalised type
-type NormType types = Value types
+type VType types = Value types
 
 -----------------------------------------------------------------------------
 -- Spines and environments
 
 -- | A list of arguments for an application that cannot be normalised.
-type Spine types = [NormArg types]
+type Spine types = [VArg types]
 
 -- | A spine type for builtins which enforces the invariant that they should
 -- only ever depend computationally on their explicit arguments.
@@ -57,7 +57,7 @@ extendEnvOverBinder binder env =
 -----------------------------------------------------------------------------
 -- Patterns
 
-pattern VTypeUniverse :: UniverseLevel -> NormType types
+pattern VTypeUniverse :: UniverseLevel -> VType types
 pattern VTypeUniverse l = VUniverse l
 
 pattern VBuiltinFunction :: BuiltinFunction -> ExplicitSpine types -> Value types

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -57,7 +57,7 @@ parseAndTypeCheckExpr expr = do
   typedExpr <- typeCheckExpr imports (convertToNormalisableBuiltins scopedExpr)
   return typedExpr
 
-parseExprText :: (MonadCompile m) => Text -> m InputExpr
+parseExprText :: (MonadCompile m) => Text -> m (Expr () Name Builtin)
 parseExprText txt =
   case runExcept (parseExpr User =<< readExpr txt) of
     Left err -> throwError $ ParseError err
@@ -104,7 +104,7 @@ typeCheckOrLoadProg modul imports specificationFile = do
       writeObjectFile specificationFile spec result
       return result
 
-parseProgText :: (MonadCompile m) => Module -> Text -> m InputProg
+parseProgText :: (MonadCompile m) => Module -> Text -> m (Prog () Name Builtin)
 parseProgText modul txt = do
   case runExcept (readAndParseProg modul txt) of
     Left err -> throwError $ ParseError err

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/DeBruijn.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/DeBruijn.hs
@@ -20,7 +20,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Subsystem.Standard (StandardExpr, TypeCheckedBinder, TypeCheckedExpr, TypeCheckedType)
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
-import Vehicle.Expr.DeBruijn (DBLevel, liftDBIndices, substDBInto)
+import Vehicle.Expr.DeBruijn (Lv, liftDBIndices, substDBInto)
 import Vehicle.Test.Unit.Common (unitTestCase)
 
 --------------------------------------------------------------------------------
@@ -120,7 +120,7 @@ substTest SubstitutionTest {..} =
 
 data LiftingTest = LiftingTest
   { name :: String,
-    amount :: DBLevel,
+    amount :: Lv,
     input :: TypeCheckedExpr,
     expected :: TypeCheckedExpr
   }

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -11,7 +11,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Subsystem.Standard (StandardBinder, StandardBuiltinType (..), StandardExpr, StandardType)
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
-import Vehicle.Expr.DeBruijn (DBLevel)
+import Vehicle.Expr.DeBruijn (Lv)
 import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
 import Vehicle.Expr.Normalised
 import Vehicle.Test.Unit.Common (unitTestCase)
@@ -58,7 +58,7 @@ normalisationTests =
 
 data NBETest = NBETest
   { name :: String,
-    dbLevel :: DBLevel,
+    dbLevel :: Lv,
     input :: StandardExpr,
     expected :: StandardExpr
   }
@@ -91,5 +91,5 @@ p = mempty
 binding :: StandardType -> StandardBinder
 binding = Binder p (BinderDisplayForm (OnlyName "x") False) Explicit Relevant ()
 
-mkNoOpEnv :: DBLevel -> Env builtin
+mkNoOpEnv :: Lv -> Env builtin
 mkNoOpEnv boundCtxSize = [(Nothing, VBoundVar i []) | i <- reverse [0 .. boundCtxSize - 1]]


### PR DESCRIPTION
This is part of a refactoring to prune the _many_ type aliases for the AST that exist within the codebase:

- Rename DBIndex -> Ix and DBLevel -> Lv
- Rename NormExpr -> Value
- Inline `Vehicle.Expr.DBExpr`
- Inline `Vehicle.Syntax.AST.InputExpr`
- Inline `Vehicle.Compile.Prelude.NamedExpr`
- Inline `Vehicle.Backend.LossFunction.Compile.InputExpr`
- Inline `Vehicle.Backend.Agda.Compile.OutputExpr`
- Inline `Vehicle.Compile.Scope.UnscopedExpr`
- Inline `Vehicle.Compile.Scope.ScopedExpr`
- Inline `Vehicle.Compile.Type.Core.UncheckedExpr`
- Inline `Vehicle.Compile.Type.Core.CheckedExpr`

I believe this PR should be merged ASAP, due to the high risk of conflicts.

Pruning of `NormalisableExpr` and the derived aliases requires a refactoring of the builtin types.