### PR TITLE
Better handling of Marabou being killed with out-of-memory error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@
 
 * Improved informativeness of error messages thrown when attempting to verify properties with multiple network applications.
 
+* Improved error reporting when Marabou is automatically terminated by the OS (e.g. runs out of memory)
+
 ## Version 0.3.0
 
 ### General enhancements

--- a/vehicle/src/Vehicle/Verify.hs
+++ b/vehicle/src/Vehicle/Verify.hs
@@ -34,7 +34,7 @@ verify _loggingSettings VerifyOptions {..} = do
   VerificationPlan specificationPlan resourceIntegrity <- readVerificationPlan verificationPlanFile
   status <- verifySpecification queryFolder verifierImpl verifierExecutable specificationPlan
 
-  programOutput $ pretty status
+  programOutput $ line <> pretty status
   case proofCache of
     Nothing -> return ()
     Just proofCachePath ->

--- a/vehicle/src/Vehicle/Verify/Core.hs
+++ b/vehicle/src/Vehicle/Verify/Core.hs
@@ -30,7 +30,7 @@ type VerifierInvocation =
   VerifierExecutable ->
   MetaNetwork ->
   QueryFile ->
-  m (QueryResult NetworkVariableCounterexample)
+  m (Either Text (QueryResult NetworkVariableCounterexample))
 
 -- | A complete verifier implementation
 data Verifier = Verifier

--- a/vehicle/src/Vehicle/Verify/Verifier/Marabou.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier/Marabou.hs
@@ -60,32 +60,46 @@ prepareNetworkArg metaNetwork = do
   hPutStrLn stderr $ layoutAsText errorMsg
   exitFailure
 
-parseMarabouOutput :: String -> (ExitCode, String, String) -> IO (QueryResult NetworkVariableCounterexample)
+parseMarabouOutput ::
+  String ->
+  (ExitCode, String, String) ->
+  IO (Either Text (QueryResult NetworkVariableCounterexample))
 parseMarabouOutput command (exitCode, out, _err) = case exitCode of
-  ExitFailure _ -> do
-    -- Marabou seems to output its error messages to stdout rather than stderr...
-    let errorDoc =
-          "Marabou threw the following error:"
-            <> line
-            <> indent 2 (pretty out)
-            <> "when running the command:"
-            <> line
-            <> indent 2 (pretty command)
-    hPutStrLn stderr (layoutAsText errorDoc)
-    exitFailure
+  ExitFailure exitValue
+    | exitValue < 0 -> do
+        -- Marabou was killed by the system.
+        -- See System.Process.html#waitForProcess documentation
+        let errorDoc =
+              "Marabou was automatically killed by the OS with signal"
+                <+> quotePretty (-exitValue)
+                <> "."
+                <> line
+                <> "The most common reason for this is an out-of-memory-error."
+        return $ Left $ layoutAsText errorDoc
+    | otherwise -> do
+        -- Marabou seems to output its error messages to stdout rather than stderr...
+        let errorDoc =
+              "Marabou threw the following error:"
+                <> line
+                <> indent 2 (pretty out)
+                <> line
+                <> "when running the command:"
+                <> line
+                <> indent 2 (pretty command)
+        hPutStrLn stderr (layoutAsText errorDoc)
+        exitFailure
   ExitSuccess -> do
-    -- print (layoutAsString $ pretty (lines out))
     let outputLines = fmap Text.pack (lines out)
     let resultIndex = findIndex (\v -> v == "sat" || v == "unsat") outputLines
     case resultIndex of
       Nothing -> malformedOutputError "cannot find 'sat' or 'unsat'"
       Just i
         | outputLines !! i == "unsat" ->
-            return UnSAT
+            return $ Right UnSAT
         | otherwise -> do
             let assignmentOutput = drop (i + 1) outputLines
             ioVarAssignment <- parseSATAssignment (filter (/= "") assignmentOutput)
-            return $ SAT $ Just ioVarAssignment
+            return $ Right $ SAT $ Just ioVarAssignment
 
 parseSATAssignment :: [Text] -> IO (Vector Double)
 parseSATAssignment output = do


### PR DESCRIPTION
Uses the exit code to distinguish between Marabou erroring and it being killed by the OS. Also fixes #480.