### PR TITLE
Compensate for floating point error in Gaussian elimination

### DIFF
--- a/.github/workflows/test-integration-marabou.yml
+++ b/.github/workflows/test-integration-marabou.yml
@@ -60,4 +60,5 @@ jobs:
             --test-show-details=always         \
             --test-option=--color=always       \
             --test-option=--external-only=True \
+            --test-option=--num-threads=1      \
             --test-option=--external=Marabou

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,9 @@
 
 * Added JSON backend target to command-line interface
 
-* Fixed bug where `if` statements which when lifted reduced to trivial assertions were causing a crash.
+* Fixed bug when compiling to verification queries where `if` statements that when lifted reduced to trivial assertions were causing a crash.
+
+* Fixed bug when compiling to verification queries where the error "Could not eliminate variable X" was occasionally thrown.
 
 ## Version 0.5.1
 

--- a/vehicle/src/Vehicle/Compile/Queries.hs
+++ b/vehicle/src/Vehicle/Compile/Queries.hs
@@ -245,9 +245,6 @@ compileQuerySet isPropertyNegated expr = do
         let declIdent = fst declProvenance
         throwError $ UnsupportedVariableType target declIdent p baseName variableType baseType [BuiltinType Rat]
       UnsupportedInequalityOp -> do
-        logDebug MaxDetail "hi"
-        logDebug MaxDetail (prettyVerbose expr)
-        logDebug MaxDetail "hi"
         throwError $ UnsupportedInequality (queryFormatID queryFormat) declProvenance
     Right (quantifiedVariables, maybeTrivialBoolExpr, userVariableReductionInfo) -> do
       queries <- case maybeTrivialBoolExpr of

--- a/vehicle/src/Vehicle/Compile/Queries/LinearExpr.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearExpr.hs
@@ -192,7 +192,11 @@ eliminateVar var solution row = do
     then row
     else do
       let scaleFactor = varCoefficient / lookupCoefficient solution var
-      addExprs 1 row (-scaleFactor) solution
+      let resultExpr = addExprs 1 row (-scaleFactor) solution
+      -- Needed to handle floating point errors....
+      resultExpr
+        { coefficients = Map.delete var $ coefficients resultExpr
+        }
 
 -- | Takes an assertion `a*x_0 + ... + b*x_i + ... c * x_n` and
 -- returns the RHS of the equation: `x_i = -a/b*x_0 + ... -c/b*x_n`

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -79,7 +79,6 @@ typeCheckDecl uncheckedDecl =
       DefAbstract p n r t -> typeCheckAbstractDef p n r t
       DefFunction p n b t e -> typeCheckFunction p n b t e
 
-    -- when (nameOf gluedDecl == "vectorToList") $ developerError "Hi"
     checkAllUnknownsSolved (Proxy @types)
     finalDecl <- substMetas gluedDecl
     logCompilerPassOutput $ prettyFriendly (fmap unnormalised finalDecl)


### PR DESCRIPTION
Need to actually delete the variable from the assertion, not just rely on arithmetic zapping it to zero. We really need a convincing story around floating point....