### PR TITLE
Removed the presence of `NormalisableBuiltin` from type-checking

### DIFF
--- a/vehicle/src/Vehicle/Backend/LossFunction/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/LossFunction/Compile.hs
@@ -293,7 +293,7 @@ reformatLogicalOperators ::
   m (V.Prog V.Name V.StandardBuiltin)
 reformatLogicalOperators logic = traverse (V.traverseBuiltinsM builtinUpdateFunction)
   where
-    builtinUpdateFunction :: V.BuiltinUpdate m () V.Name V.StandardBuiltin V.StandardBuiltin
+    builtinUpdateFunction :: V.BuiltinUpdate m V.Name V.StandardBuiltin V.StandardBuiltin
     builtinUpdateFunction p1 p2 b args = case b of
       V.CFunction V.Not
         | isNothing (compileNot (implementationOf logic)) ->

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -7,7 +7,6 @@ where
 import Control.Monad.Reader (MonadReader (..), Reader, runReader)
 import Vehicle.Compile.Prelude
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised (Spine, VBinder, Value (..))
 
 --------------------------------------------------------------------------------
@@ -83,7 +82,7 @@ instance
   where
   descopeNaive = fmap descopeNaive
 
-instance DescopeNaive (Value types) (Expr Name (NormalisableBuiltin types)) where
+instance DescopeNaive (Value builtin) (Expr Name builtin) where
   descopeNaive = descopeNormExpr descopeDBLevelVarNaive
 
 --------------------------------------------------------------------------------
@@ -154,8 +153,8 @@ descopeArg f = traverse (descopeExpr f)
 -- used for printing `Value`s in a readable form.
 descopeNormExpr ::
   (Provenance -> Lv -> Name) ->
-  Value types ->
-  Expr Name (NormalisableBuiltin types)
+  Value builtin ->
+  Expr Name builtin
 descopeNormExpr f e = case e of
   VUniverse u -> Universe p u
   VMeta m spine -> normAppList p (Meta p m) $ descopeSpine f spine
@@ -181,14 +180,14 @@ descopeNormExpr f e = case e of
 
 descopeSpine ::
   (Provenance -> Lv -> Name) ->
-  Spine types ->
-  [Arg Name (NormalisableBuiltin types)]
+  Spine builtin ->
+  [Arg Name builtin]
 descopeSpine f = fmap (fmap (descopeNormExpr f))
 
 descopeNormBinder ::
   (Provenance -> Lv -> Name) ->
-  VBinder types ->
-  Binder Name (NormalisableBuiltin types)
+  VBinder builtin ->
+  Binder Name builtin
 descopeNormBinder f = fmap (descopeNormExpr f)
 
 descopeDBIndexVar :: (MonadDescope m) => Provenance -> Ix -> m Name

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -10,7 +10,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Subsystem.Linearity.Core
 import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
-import Vehicle.Expr.Normalisable (NormalisableArg)
+import Vehicle.Expr.DeBruijn
 import Vehicle.Syntax.Parse (ParseError)
 import Vehicle.Verify.Core (QueryFormatID)
 
@@ -52,7 +52,7 @@ data CompileError
       StandardType -- The expected type.
   | MissingExplicitArg
       BoundDBCtx -- The context at the time of the failure
-      (NormalisableArg StandardBuiltinType) -- The non-explicit argument
+      (Arg Ix StandardBuiltin) -- The non-explicit argument
       StandardType -- Expected type of the argument
   | UnsolvedConstraints (NonEmpty (WithContext StandardConstraint))
   | UnsolvedMetas (NonEmpty (MetaID, Provenance))

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -340,7 +340,7 @@ instance MeaningfulError CompileError where
               <+> squotes (prettyFriendly $ WithContext expectedType boundCtx)
               <+> "but was found to be of type"
               <+> squotes (prettyFriendly $ WithContext actualType boundCtx)
-          CheckingTypeClass fun args _ _ ->
+          CheckingTypeClass fun args _ ->
             "unable to find a consistent type for the overloaded expression"
               <+> squotes (prettyTypeClassConstraintOriginExpr ctx fun args)
           CheckingAuxiliary ->
@@ -371,7 +371,7 @@ instance MeaningfulError CompileError where
               <+> "to be of type"
               <+> squotes (prettyFriendly $ WithContext expectedType nameCtx)
               <+> "but was unable to prove it."
-          CheckingTypeClass fun args _ _ ->
+          CheckingTypeClass fun args _ ->
             "insufficient information to find a valid type for the overloaded expression"
               <+> squotes (prettyTypeClassConstraintOriginExpr ctx fun args)
           CheckingAuxiliary ->
@@ -413,7 +413,7 @@ instance MeaningfulError CompileError where
                 <> line
                 <> "Type checking has deduced that it is of type:"
                 <> line
-                <> indent 2 (inferredOpType (boundContextOf ctx) tcArgs)
+                <> indent 2 (inferredOpType (boundContextOf ctx) (NonEmpty.toList tcArgs))
                 <> line
                 <> "but the list of valid types for it is:"
                 <> line
@@ -422,7 +422,7 @@ instance MeaningfulError CompileError where
           }
       where
         (tcOp, tcOpArgs, tc, tcArgs) = case origin ctx of
-          CheckingTypeClass tcOp' tcOpArgs' (StandardTypeClass tc') tcArgs' -> (tcOp', tcOpArgs', tc', tcArgs')
+          CheckingTypeClass tcOp' tcOpArgs' (BuiltinExpr _ (CType (StandardTypeClass tc')) tcArgs') -> (tcOp', tcOpArgs', tc', tcArgs')
           _ -> developerError "Type class constraints should only have `CheckingTypeClass` origins"
 
         originExpr :: Doc a
@@ -1508,7 +1508,7 @@ prettyOrdinal object argNo argTotal
       9 -> "ninth"
       _ -> developerError "Cannot convert ordinal"
 
-prettyTypeClassConstraintOriginExpr :: StandardConstraintContext -> TypeCheckedExpr -> [NormalisableArg StandardBuiltinType] -> Doc a
+prettyTypeClassConstraintOriginExpr :: StandardConstraintContext -> TypeCheckedExpr -> [StandardArg] -> Doc a
 prettyTypeClassConstraintOriginExpr ctx fun args = case fun of
   Builtin _ b
     -- Need to check whether the function was introduced as part of desugaring

--- a/vehicle/src/Vehicle/Compile/ExpandResources.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources.hs
@@ -22,7 +22,7 @@ import Vehicle.Compile.Resource
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Compile.Warning (CompileWarning (..))
-import Vehicle.Expr.Normalised (pattern VNatLiteral)
+import Vehicle.Expr.Normalisable (pattern VNatLiteral)
 
 -- | Calculates the context for external resources, reading them from disk and
 -- inferring the values of inferable parameters.

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Dataset/IDX.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Dataset/IDX.hs
@@ -22,6 +22,7 @@ import Vehicle.Compile.ExpandResources.Core
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Subsystem.Standard
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 -- | Reads the IDX dataset from the provided file, checking that the user type

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Network.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Network.hs
@@ -11,6 +11,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Resource
 import Vehicle.Compile.Type.Subsystem.Standard
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
@@ -13,6 +13,7 @@ import Vehicle.Compile.ExpandResources.Core
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Subsystem.Standard
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Normalise/Builtin.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Builtin.hs
@@ -1,0 +1,385 @@
+{-# HLINT ignore "Use <|>" #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Vehicle.Compile.Normalise.Builtin where
+
+import Data.Foldable (foldrM)
+import Vehicle.Compile.Error
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Meta (MetaSet)
+import Vehicle.Compile.Type.Meta.Set qualified as MetaSet (unions)
+import Vehicle.Expr.Normalisable
+import Vehicle.Expr.Normalised
+
+type EvalApp builtin m = Value builtin -> Spine builtin -> m (Value builtin)
+
+type ForceArg builtin m = Value builtin -> m (Value builtin, Bool, MetaSet)
+
+class Normalisable builtin where
+  evalBuiltin ::
+    (MonadCompile m) =>
+    EvalApp builtin m ->
+    builtin ->
+    ExplicitSpine builtin ->
+    m (Value builtin)
+
+  isValue ::
+    builtin ->
+    Bool
+
+  isTypeClassOp ::
+    builtin ->
+    Bool
+
+  forceBuiltin ::
+    (MonadCompile m) =>
+    EvalApp builtin m ->
+    ForceArg builtin m ->
+    builtin ->
+    ExplicitSpine builtin ->
+    m (Maybe (Value builtin), MetaSet)
+
+instance (Normalisable types) => Normalisable (NormalisableBuiltin types) where
+  evalBuiltin evalApp b args = case b of
+    CConstructor {} -> return $ VBuiltin b args
+    CType {} -> return $ VBuiltin b args
+    CFunction f -> evalBuiltinFunction evalApp f args
+
+  isValue = \case
+    CConstructor {} -> True
+    CType {} -> True
+    CFunction {} -> False
+
+  isTypeClassOp b = case b of
+    CConstructor {} -> False
+    CFunction {} -> False
+    CType t -> isTypeClassOp t
+
+  forceBuiltin evalApp forceArg b spine = case b of
+    CConstructor {} -> return (Nothing, mempty)
+    CType {} -> return (Nothing, mempty)
+    CFunction {} -> do
+      (argResults, argsReduced, argBlockingMetas) <- unzip3 <$> traverse forceArg spine
+      let anyArgsReduced = or argsReduced
+      let blockingMetas = MetaSet.unions argBlockingMetas
+      result <-
+        if not anyArgsReduced
+          then return Nothing
+          else do
+            Just <$> evalBuiltin evalApp b argResults
+      return (result, blockingMetas)
+
+-----------------------------------------------------------------------------
+-- Indvidual builtins
+
+evalBuiltinFunction ::
+  (MonadCompile m) =>
+  EvalApp (NormalisableBuiltin builtin) m ->
+  BuiltinFunction ->
+  ExplicitSpine (NormalisableBuiltin builtin) ->
+  m (Value (NormalisableBuiltin builtin))
+evalBuiltinFunction evalApp b args
+  | isDerived b = evalDerivedBuiltin evalApp b args
+  | otherwise = do
+      let result = case b of
+            Quantifier {} -> Nothing
+            Not -> return <$> evalNot args
+            And -> return <$> evalAnd args
+            Or -> return <$> evalOr args
+            Neg dom -> return <$> evalNeg dom args
+            Add dom -> return <$> evalAdd dom args
+            Sub dom -> return <$> evalSub dom args
+            Mul dom -> return <$> evalMul dom args
+            Div dom -> return <$> evalDiv dom args
+            Equals dom op -> return <$> evalEquals dom op args
+            Order dom op -> return <$> evalOrder dom op args
+            If -> return <$> evalIf args
+            At -> return <$> evalAt args
+            ConsVector -> return <$> evalConsVector args
+            Fold dom -> evalFold dom evalApp args
+            FromNat dom -> return <$> evalFromNat dom args
+            FromRat dom -> return <$> evalFromRat dom args
+            Indices -> return <$> evalIndices args
+            Implies -> Just $ compilerDeveloperError $ "Found derived types" <+> pretty b
+
+      case result of
+        Nothing -> return $ VBuiltinFunction b args
+        Just r -> r
+
+isDerived :: BuiltinFunction -> Bool
+isDerived = \case
+  Implies {} -> True
+  _ -> False
+
+evalDerivedBuiltin ::
+  (MonadCompile m) =>
+  EvalApp (NormalisableBuiltin builtin) m ->
+  BuiltinFunction ->
+  ExplicitSpine (NormalisableBuiltin builtin) ->
+  m (Value (NormalisableBuiltin builtin))
+evalDerivedBuiltin evalApp b args = case b of
+  Implies -> evalImplies evalApp args
+  _ -> compilerDeveloperError $ "Invalid derived types" <+> quotePretty b
+
+type EvalBuiltin types m =
+  ExplicitSpine (NormalisableBuiltin types) ->
+  Maybe (m (Value (NormalisableBuiltin types)))
+
+type EvalSimpleBuiltin types =
+  ExplicitSpine (NormalisableBuiltin types) ->
+  Maybe (Value (NormalisableBuiltin types))
+
+evalNot :: EvalSimpleBuiltin types
+evalNot e = case e of
+  [VBoolLiteral x] -> Just $ VBoolLiteral (not x)
+  _ -> Nothing
+
+evalAnd :: EvalSimpleBuiltin types
+evalAnd = \case
+  [VBoolLiteral x, VBoolLiteral y] -> Just $ VBoolLiteral (x && y)
+  _ -> Nothing
+
+evalOr :: EvalSimpleBuiltin types
+evalOr = \case
+  [VBoolLiteral x, VBoolLiteral y] -> Just $ VBoolLiteral (x || y)
+  _ -> Nothing
+
+evalNeg :: NegDomain -> EvalSimpleBuiltin types
+evalNeg = \case
+  NegInt -> evalNegInt
+  NegRat -> evalNegRat
+
+evalNegInt :: EvalSimpleBuiltin types
+evalNegInt = \case
+  [VIntLiteral x] -> Just $ VIntLiteral (-x)
+  _ -> Nothing
+
+evalNegRat :: EvalSimpleBuiltin types
+evalNegRat = \case
+  [VRatLiteral x] -> Just $ VRatLiteral (-x)
+  _ -> Nothing
+
+evalAdd :: AddDomain -> EvalSimpleBuiltin types
+evalAdd = \case
+  AddNat -> evalAddNat
+  AddInt -> evalAddInt
+  AddRat -> evalAddRat
+
+evalAddNat :: EvalSimpleBuiltin types
+evalAddNat = \case
+  [VNatLiteral x, VNatLiteral y] -> Just $ VNatLiteral (x + y)
+  _ -> Nothing
+
+evalAddInt :: EvalSimpleBuiltin types
+evalAddInt = \case
+  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x + y)
+  _ -> Nothing
+
+evalAddRat :: EvalSimpleBuiltin types
+evalAddRat = \case
+  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x + y)
+  _ -> Nothing
+
+evalSub :: SubDomain -> EvalSimpleBuiltin types
+evalSub = \case
+  SubInt -> evalSubInt
+  SubRat -> evalSubRat
+
+evalSubInt :: EvalSimpleBuiltin types
+evalSubInt = \case
+  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x - y)
+  _ -> Nothing
+
+evalSubRat :: EvalSimpleBuiltin types
+evalSubRat = \case
+  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x - y)
+  _ -> Nothing
+
+evalMul :: MulDomain -> EvalSimpleBuiltin types
+evalMul = \case
+  MulNat -> evalMulNat
+  MulInt -> evalMulInt
+  MulRat -> evalMulRat
+
+evalMulNat :: EvalSimpleBuiltin types
+evalMulNat = \case
+  [VNatLiteral x, VNatLiteral y] -> Just $ VNatLiteral (x * y)
+  _ -> Nothing
+
+evalMulInt :: EvalSimpleBuiltin types
+evalMulInt = \case
+  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x * y)
+  _ -> Nothing
+
+evalMulRat :: EvalSimpleBuiltin types
+evalMulRat = \case
+  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x * y)
+  _ -> Nothing
+
+evalDiv :: DivDomain -> EvalSimpleBuiltin types
+evalDiv = \case
+  DivRat -> evalDivRat
+
+evalDivRat :: EvalSimpleBuiltin types
+evalDivRat = \case
+  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x / y)
+  _ -> Nothing
+
+evalOrder :: OrderDomain -> OrderOp -> EvalSimpleBuiltin types
+evalOrder = \case
+  OrderIndex -> evalOrderIndex
+  OrderNat -> evalOrderNat
+  OrderInt -> evalOrderInt
+  OrderRat -> evalOrderRat
+
+evalOrderIndex :: OrderOp -> EvalSimpleBuiltin types
+evalOrderIndex op = \case
+  [VIndexLiteral x, VIndexLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
+  _ -> Nothing
+
+evalOrderNat :: OrderOp -> EvalSimpleBuiltin types
+evalOrderNat op = \case
+  [VNatLiteral x, VNatLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
+  _ -> Nothing
+
+evalOrderInt :: OrderOp -> EvalSimpleBuiltin types
+evalOrderInt op = \case
+  [VIntLiteral x, VIntLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
+  _ -> Nothing
+
+evalOrderRat :: OrderOp -> EvalSimpleBuiltin types
+evalOrderRat op = \case
+  [VRatLiteral x, VRatLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
+  _ -> Nothing
+
+evalEquals :: EqualityDomain -> EqualityOp -> EvalSimpleBuiltin types
+evalEquals = \case
+  EqIndex -> evalEqualityIndex
+  EqNat -> evalEqualityNat
+  EqInt -> evalEqualityInt
+  EqRat -> evalEqualityRat
+
+evalEqualityIndex :: EqualityOp -> EvalSimpleBuiltin types
+evalEqualityIndex op = \case
+  [VIndexLiteral x, VIndexLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
+  _ -> Nothing
+
+evalEqualityNat :: EqualityOp -> EvalSimpleBuiltin types
+evalEqualityNat op = \case
+  [VNatLiteral x, VNatLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
+  _ -> Nothing
+
+evalEqualityInt :: EqualityOp -> EvalSimpleBuiltin types
+evalEqualityInt op = \case
+  [VIntLiteral x, VIntLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
+  _ -> Nothing
+
+evalEqualityRat :: EqualityOp -> EvalSimpleBuiltin types
+evalEqualityRat op = \case
+  [VRatLiteral x, VRatLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
+  _ -> Nothing
+
+evalFromNat :: FromNatDomain -> EvalSimpleBuiltin types
+evalFromNat = \case
+  FromNatToIndex -> evalFromNatToIndex
+  FromNatToNat -> evalFromNatToNat
+  FromNatToInt -> evalFromNatToInt
+  FromNatToRat -> evalFromNatToRat
+
+evalFromNatToIndex :: EvalSimpleBuiltin types
+evalFromNatToIndex = \case
+  [VNatLiteral x] -> Just $ VIndexLiteral x
+  _ -> Nothing
+
+evalFromNatToNat :: EvalSimpleBuiltin types
+evalFromNatToNat = \case
+  [x] -> Just x
+  _ -> Nothing
+
+evalFromNatToInt :: EvalSimpleBuiltin types
+evalFromNatToInt = \case
+  [VNatLiteral x] -> Just $ VIntLiteral x
+  _ -> Nothing
+
+evalFromNatToRat :: EvalSimpleBuiltin types
+evalFromNatToRat = \case
+  [VNatLiteral x] -> Just $ VRatLiteral (fromIntegral x)
+  _ -> Nothing
+
+evalFromRat :: FromRatDomain -> EvalSimpleBuiltin types
+evalFromRat = \case
+  FromRatToRat -> evalFromRatToRat
+
+evalFromRatToRat :: EvalSimpleBuiltin types
+evalFromRatToRat = \case
+  [x] -> Just x
+  _ -> Nothing
+
+evalIf :: EvalSimpleBuiltin types
+evalIf = \case
+  [VBoolLiteral True, e1, _e2] -> Just e1
+  [VBoolLiteral False, _e1, e2] -> Just e2
+  _ -> Nothing
+
+evalAt :: EvalSimpleBuiltin types
+evalAt = \case
+  [VVecLiteral xs, VIndexLiteral i] -> Just $ case xs !!? fromIntegral i of
+    Nothing -> developerError $ "out of bounds error:" <+> pretty (length xs) <+> "<=" <+> pretty i
+    Just xsi -> xsi
+  _ -> Nothing
+
+evalConsVector :: EvalSimpleBuiltin types
+evalConsVector = \case
+  [x, VVecLiteral xs] -> Just $ VVecLiteral (x : xs)
+  _ -> Nothing
+
+evalFold :: (MonadCompile m) => FoldDomain -> EvalApp (NormalisableBuiltin types) m -> EvalBuiltin types m
+evalFold = \case
+  FoldList -> evalFoldList
+  FoldVector -> evalFoldVector
+
+evalFoldList :: (MonadCompile m) => EvalApp (NormalisableBuiltin types) m -> EvalBuiltin types m
+evalFoldList evalApp = \case
+  [_f, e, VNil] ->
+    Just $ return e
+  [f, e, VCons [x, xs']] -> Just $ do
+    r <- evalBuiltinFunction evalApp (Fold FoldList) [f, e, xs']
+    evalApp f [ExplicitArg mempty x, ExplicitArg mempty r]
+  _ -> Nothing
+
+evalFoldVector :: (MonadCompile m) => EvalApp (NormalisableBuiltin types) m -> EvalBuiltin types m
+evalFoldVector evalApp = \case
+  [f, e, VVecLiteral xs] ->
+    Just $
+      foldrM f' e (zip [0 ..] xs)
+    where
+      f' (l, x) r =
+        evalApp
+          f
+          [ ImplicitArg mempty (VNatLiteral l),
+            ExplicitArg mempty x,
+            ExplicitArg mempty r
+          ]
+  _ -> Nothing
+
+evalIndices :: EvalSimpleBuiltin types
+evalIndices = \case
+  [VNatLiteral n] -> Just $ mkVLVec (fmap VIndexLiteral [0 .. n - 1])
+  _ -> Nothing
+
+-----------------------------------------------------------------------------
+-- Derived
+
+type EvalDerived types m =
+  ExplicitSpine (NormalisableBuiltin types) ->
+  m (Value (NormalisableBuiltin types))
+
+-- TODO define in terms of language
+
+evalImplies :: (MonadCompile m) => EvalApp (NormalisableBuiltin types) m -> EvalDerived types m
+evalImplies evalApp = \case
+  [e1, e2] -> do
+    ne1 <- evalBuiltinFunction evalApp Not [e1]
+    evalBuiltinFunction evalApp Or [ne1, e2]
+  args -> return $ VBuiltinFunction Implies args

--- a/vehicle/src/Vehicle/Compile/Normalise/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Monad.hs
@@ -1,0 +1,82 @@
+{-# HLINT ignore "Use <|>" #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Vehicle.Compile.Normalise.Monad where
+
+import Control.Monad.Except (MonadError (..))
+import Control.Monad.Reader (ReaderT (..), asks)
+import Control.Monad.State (StateT)
+import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Writer (WriterT)
+import Data.Data (Proxy (..))
+import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.Builtin
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Print
+import Vehicle.Compile.Type.Core
+
+-----------------------------------------------------------------------------
+-- Normalisation monad
+
+newtype EvalOptions = EvalOptions
+  { evalFiniteQuantifiers :: Bool
+  }
+
+defaultEvalOptions :: EvalOptions
+defaultEvalOptions =
+  EvalOptions
+    { evalFiniteQuantifiers = True
+    }
+
+class (MonadCompile m, PrintableBuiltin builtin, Normalisable builtin) => MonadNorm builtin m where
+  getEvalOptions :: Proxy builtin -> m EvalOptions
+  getDeclSubstitution :: m (NormDeclCtx builtin)
+  getMetaSubstitution :: m (MetaSubstitution builtin)
+
+instance (MonadNorm builtin m) => MonadNorm builtin (StateT s m) where
+  getEvalOptions = lift . getEvalOptions
+  getDeclSubstitution = lift getDeclSubstitution
+  getMetaSubstitution = lift getMetaSubstitution
+
+instance (Monoid s, MonadNorm builtin m) => MonadNorm builtin (WriterT s m) where
+  getEvalOptions = lift . getEvalOptions
+  getDeclSubstitution = lift getDeclSubstitution
+  getMetaSubstitution = lift getMetaSubstitution
+
+instance (MonadNorm builtin m) => MonadNorm builtin (ReaderT s m) where
+  getEvalOptions = lift . getEvalOptions
+  getDeclSubstitution = lift getDeclSubstitution
+  getMetaSubstitution = lift getMetaSubstitution
+
+newtype NormT builtin m a = NormT
+  { unnormT :: ReaderT (EvalOptions, NormDeclCtx builtin, MetaSubstitution builtin) m a
+  }
+  deriving (Functor, Applicative, Monad)
+
+runNormT :: EvalOptions -> NormDeclCtx builtin -> MetaSubstitution builtin -> NormT builtin m a -> m a
+runNormT opts declSubst metaSubst x = runReaderT (unnormT x) (opts, declSubst, metaSubst)
+
+runEmptyNormT :: NormT builtin m a -> m a
+runEmptyNormT = runNormT defaultEvalOptions mempty mempty
+
+instance MonadTrans (NormT builtin) where
+  lift = NormT . lift
+
+instance (MonadLogger m) => MonadLogger (NormT builtin m) where
+  setCallDepth = lift . setCallDepth
+  getCallDepth = lift getCallDepth
+  incrCallDepth = lift incrCallDepth
+  decrCallDepth = lift decrCallDepth
+  getDebugLevel = lift getDebugLevel
+  logMessage = lift . logMessage
+
+instance (MonadError e m) => MonadError e (NormT builtin m) where
+  throwError = lift . throwError
+  catchError m f = NormT (catchError (unnormT m) (unnormT . f))
+
+instance (MonadCompile m, PrintableBuiltin builtin, Normalisable builtin) => MonadNorm builtin (NormT builtin m) where
+  getEvalOptions _ = NormT $ asks (\(opts, _, _) -> opts)
+  getDeclSubstitution = NormT $ asks (\(_, declCtx, _) -> declCtx)
+  getMetaSubstitution = NormT $ asks (\(_, _, metaCtx) -> metaCtx)

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -1,5 +1,4 @@
 {-# HLINT ignore "Use <|>" #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
@@ -9,33 +8,24 @@ module Vehicle.Compile.Normalise.NBE
     defaultEvalOptions,
     eval,
     evalApp,
-    evalBuiltin,
     extendEnv,
     extendEnvOverBinder,
     lookupFreeVar,
     forceHead,
-    forceArg,
     reeval,
     NormT,
     runNormT,
     runEmptyNormT,
-    MonadNorm (..),
-    evalMul,
-    evalAddNat,
   )
 where
 
-import Control.Monad.Except (MonadError (..))
-import Control.Monad.Reader (ReaderT (..), asks)
-import Control.Monad.State (StateT)
-import Control.Monad.Trans (MonadTrans (..))
-import Control.Monad.Writer (WriterT)
 import Data.Data (Proxy (..))
-import Data.Foldable (foldrM)
 import Data.List.NonEmpty as NonEmpty (toList)
 import Data.Map qualified as Map (lookup)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.Builtin (Normalisable (..))
+import Vehicle.Compile.Normalise.Monad
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Core
@@ -43,7 +33,6 @@ import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (StdLibFunction (..))
 
@@ -51,80 +40,16 @@ import Vehicle.Libraries.StandardLibrary (StdLibFunction (..))
 -- Main method
 
 whnf ::
-  (MonadNorm types m) =>
-  Env types ->
-  NormalisableExpr types ->
-  m (Value types)
+  (MonadNorm builtin m) =>
+  Env builtin ->
+  Expr Ix builtin ->
+  m (Value builtin)
 whnf = eval
-
------------------------------------------------------------------------------
--- Normalisation monad
-
-newtype EvalOptions = EvalOptions
-  { evalFiniteQuantifiers :: Bool
-  }
-
-defaultEvalOptions :: EvalOptions
-defaultEvalOptions =
-  EvalOptions
-    { evalFiniteQuantifiers = True
-    }
-
-class (MonadCompile m, PrintableBuiltin types) => MonadNorm types m where
-  getEvalOptions :: Proxy types -> m EvalOptions
-  getDeclSubstitution :: m (NormDeclCtx types)
-  getMetaSubstitution :: m (MetaSubstitution types)
-
-instance (MonadNorm types m) => MonadNorm types (StateT s m) where
-  getEvalOptions = lift . getEvalOptions
-  getDeclSubstitution = lift getDeclSubstitution
-  getMetaSubstitution = lift getMetaSubstitution
-
-instance (Monoid s, MonadNorm types m) => MonadNorm types (WriterT s m) where
-  getEvalOptions = lift . getEvalOptions
-  getDeclSubstitution = lift getDeclSubstitution
-  getMetaSubstitution = lift getMetaSubstitution
-
-instance (MonadNorm types m) => MonadNorm types (ReaderT s m) where
-  getEvalOptions = lift . getEvalOptions
-  getDeclSubstitution = lift getDeclSubstitution
-  getMetaSubstitution = lift getMetaSubstitution
-
-newtype NormT types m a = NormT
-  { unnormT :: ReaderT (EvalOptions, NormDeclCtx types, MetaSubstitution types) m a
-  }
-  deriving (Functor, Applicative, Monad)
-
-runNormT :: EvalOptions -> NormDeclCtx types -> MetaSubstitution types -> NormT types m a -> m a
-runNormT opts declSubst metaSubst x = runReaderT (unnormT x) (opts, declSubst, metaSubst)
-
-runEmptyNormT :: NormT types m a -> m a
-runEmptyNormT = runNormT defaultEvalOptions mempty mempty
-
-instance MonadTrans (NormT types) where
-  lift = NormT . lift
-
-instance (MonadLogger m) => MonadLogger (NormT types m) where
-  setCallDepth = lift . setCallDepth
-  getCallDepth = lift getCallDepth
-  incrCallDepth = lift incrCallDepth
-  decrCallDepth = lift decrCallDepth
-  getDebugLevel = lift getDebugLevel
-  logMessage = lift . logMessage
-
-instance (MonadError e m) => MonadError e (NormT types m) where
-  throwError = lift . throwError
-  catchError m f = NormT (catchError (unnormT m) (unnormT . f))
-
-instance (MonadCompile m, PrintableBuiltin types) => MonadNorm types (NormT types m) where
-  getEvalOptions _ = NormT $ asks (\(opts, _, _) -> opts)
-  getDeclSubstitution = NormT $ asks (\(_, declCtx, _) -> declCtx)
-  getMetaSubstitution = NormT $ asks (\(_, _, metaCtx) -> metaCtx)
 
 -----------------------------------------------------------------------------
 -- Evaluation
 
-eval :: (MonadNorm types m) => Env types -> NormalisableExpr types -> m (Value types)
+eval :: (MonadNorm builtin m) => Env builtin -> Expr Ix builtin -> m (Value builtin)
 eval env expr = do
   showEntry env expr
   result <- case expr of
@@ -157,11 +82,11 @@ eval env expr = do
   showExit env result
   return result
 
-lookupFreeVar :: forall types m. (MonadNorm types m) => Identifier -> m (Value types)
+lookupFreeVar :: forall builtin m. (MonadNorm builtin m) => Identifier -> m (Value builtin)
 lookupFreeVar ident = do
   declSubst <- getDeclSubstitution
   let isFiniteQuantifier = ident == identifierOf StdForallIndex || ident == identifierOf StdExistsIndex
-  evalFiniteQuants <- evalFiniteQuantifiers <$> getEvalOptions (Proxy @types)
+  evalFiniteQuants <- evalFiniteQuantifiers <$> getEvalOptions (Proxy @builtin)
   if isFiniteQuantifier && not evalFiniteQuants
     then return $ VFreeVar ident []
     else case Map.lookup ident declSubst of
@@ -169,10 +94,10 @@ lookupFreeVar ident = do
         | isInlinable declAnns -> return declExpr
       _ -> return $ VFreeVar ident []
 
-evalBinder :: (MonadNorm types m) => Env types -> NormalisableBinder types -> m (VBinder types)
+evalBinder :: (MonadNorm builtin m) => Env builtin -> Binder Ix builtin -> m (VBinder builtin)
 evalBinder env = traverse (eval env)
 
-evalApp :: (MonadNorm types m) => Value types -> Spine types -> m (Value types)
+evalApp :: (MonadNorm builtin m) => Value builtin -> Spine builtin -> m (Value builtin)
 evalApp fun [] = return fun
 evalApp fun (arg : args) = do
   showApp fun (arg : args)
@@ -190,8 +115,8 @@ evalApp fun (arg : args) = do
             [] -> return body'
             (a : as) -> evalApp body' (a : as)
     VBuiltin b spine
-      | not (isTypeClassOperation b) -> do
-          evalBuiltin b (spine <> mapMaybe getExplicitArg (arg : args))
+      | not (isTypeClassOp b) -> do
+          evalBuiltin evalApp b (spine <> mapMaybe getExplicitArg (arg : args))
       | otherwise -> do
           let (inst, remainingArgs) = findInstanceArg args
           evalApp inst remainingArgs
@@ -200,10 +125,10 @@ evalApp fun (arg : args) = do
 
 -- | This evaluates a free variable applied to an application.
 evalFreeVarApp ::
-  (MonadNorm types m) =>
+  (MonadNorm builtin m) =>
   Identifier ->
-  Spine types ->
-  m (Value types)
+  Spine builtin ->
+  m (Value builtin)
 evalFreeVarApp ident spine = do
   declSubst <- getDeclSubstitution
   case Map.lookup ident declSubst of
@@ -212,20 +137,30 @@ evalFreeVarApp ident spine = do
     -- substitute it through and evaluate.
     Just NormDeclCtxEntry {..}
       | not (isInlinable declAnns) && length spine == declArity -> do
-          let allExplicitArgsAreValues = all (isValue . argExpr) $ filter isExplicit spine
+          let allExplicitArgsAreValues = all (isFullyReduced . argExpr) $ filter isExplicit spine
           if allExplicitArgsAreValues
             then evalApp declExpr spine
             else return $ VFreeVar ident spine
     _ -> return $ VFreeVar ident spine
 
+isFullyReduced :: (Normalisable builtin) => Value builtin -> Bool
+isFullyReduced = \case
+  VUniverse {} -> True
+  VLam {} -> True
+  VPi {} -> True
+  VMeta {} -> False
+  VFreeVar {} -> False
+  VBoundVar {} -> False
+  VBuiltin b _ -> isValue b
+
 -----------------------------------------------------------------------------
 -- Reevaluation
 
 reeval ::
-  (MonadNorm types m) =>
-  Env types ->
-  Value types ->
-  m (Value types)
+  (MonadNorm builtin m) =>
+  Env builtin ->
+  Value builtin ->
+  m (Value builtin)
 reeval env expr = do
   showNormEntry env expr
   result <- case expr of
@@ -246,11 +181,11 @@ reeval env expr = do
           spine' <- reevalSpine env spine
           evalApp value spine'
     VBuiltin b spine ->
-      evalBuiltin b =<< traverse (reeval env) spine
+      evalBuiltin evalApp b =<< traverse (reeval env) spine
   showNormExit env result
   return result
 
-reevalSpine :: (MonadNorm types m) => Env types -> Spine types -> m (Spine types)
+reevalSpine :: (MonadNorm builtin m) => Env builtin -> Spine builtin -> m (Spine builtin)
 reevalSpine env = traverse (traverse (reeval env))
 
 -----------------------------------------------------------------------------
@@ -258,7 +193,7 @@ reevalSpine env = traverse (traverse (reeval env))
 
 -- | Recursively forces the evaluation of any meta-variables at the head
 -- of the expresson.
-forceHead :: (MonadNorm types m) => ConstraintContext types -> Value types -> m (Value types, MetaSet)
+forceHead :: (MonadNorm builtin m) => ConstraintContext builtin -> Value builtin -> m (Value builtin, MetaSet)
 forceHead ctx expr = do
   (maybeForcedExpr, blockingMetas) <- forceExpr expr
   forcedExpr <- case maybeForcedExpr of
@@ -271,16 +206,16 @@ forceHead ctx expr = do
 
 -- | Recursively forces the evaluation of any meta-variables that are blocking
 -- evaluation.
-forceExpr :: forall types m. (MonadNorm types m) => Value types -> m (Maybe (Value types), MetaSet)
+forceExpr :: forall builtin m. (MonadNorm builtin m) => Value builtin -> m (Maybe (Value builtin), MetaSet)
 forceExpr = go
   where
-    go :: Value types -> m (Maybe (Value types), MetaSet)
+    go :: Value builtin -> m (Maybe (Value builtin), MetaSet)
     go = \case
       VMeta m spine -> goMeta m spine
-      VBuiltin b spine -> forceBuiltin b spine
+      VBuiltin b spine -> forceBuiltin evalApp forceArg b spine
       _ -> return (Nothing, mempty)
 
-    goMeta :: MetaID -> Spine types -> m (Maybe (Value types), MetaSet)
+    goMeta :: MetaID -> Spine builtin -> m (Maybe (Value builtin), MetaSet)
     goMeta m spine = do
       metaSubst <- getMetaSubstitution
       case MetaMap.lookup m metaSubst of
@@ -291,347 +226,12 @@ forceExpr = go
           return (forcedExpr, blockingMetas)
         Nothing -> return (Nothing, MetaSet.singleton m)
 
-forceArg :: (MonadNorm types m) => Value types -> m (Value types, Bool, MetaSet)
+forceArg :: (MonadNorm builtin m) => Value builtin -> m (Value builtin, Bool, MetaSet)
 forceArg expr = do
   (maybeResult, blockingMetas) <- forceExpr expr
   let result = fromMaybe expr maybeResult
   let reduced = isJust maybeResult
   return (result, reduced, blockingMetas)
-
-forceBuiltin ::
-  (MonadNorm types m) =>
-  NormalisableBuiltin types ->
-  ExplicitSpine types ->
-  m (Maybe (Value types), MetaSet)
-forceBuiltin b spine = case b of
-  CConstructor {} -> return (Nothing, mempty)
-  CType {} -> return (Nothing, mempty)
-  CFunction {} -> do
-    (argResults, argsReduced, argBlockingMetas) <- unzip3 <$> traverse forceArg spine
-    let anyArgsReduced = or argsReduced
-    let blockingMetas = MetaSet.unions argBlockingMetas
-    result <-
-      if not anyArgsReduced
-        then return Nothing
-        else do
-          Just <$> evalBuiltin b argResults
-    return (result, blockingMetas)
-
------------------------------------------------------------------------------
--- Normalisation of builtins
------------------------------------------------------------------------------
-
-evalBuiltin ::
-  (MonadNorm types m) =>
-  NormalisableBuiltin types ->
-  ExplicitSpine types ->
-  m (Value types)
-evalBuiltin b args = case b of
-  CConstructor {} -> return $ VBuiltin b args
-  CType {} -> return $ VBuiltin b args
-  CFunction f -> evalBuiltinFunction f args
-
-evalBuiltinFunction :: (MonadNorm types m) => BuiltinFunction -> ExplicitSpine types -> m (Value types)
-evalBuiltinFunction b args
-  | isDerived b = evalDerivedBuiltin b args
-  | otherwise = do
-      let result = case b of
-            Quantifier {} -> Nothing
-            Not -> return <$> evalNot args
-            And -> return <$> evalAnd args
-            Or -> return <$> evalOr args
-            Neg dom -> return <$> evalNeg dom args
-            Add dom -> return <$> evalAdd dom args
-            Sub dom -> return <$> evalSub dom args
-            Mul dom -> return <$> evalMul dom args
-            Div dom -> return <$> evalDiv dom args
-            Equals dom op -> return <$> evalEquals dom op args
-            Order dom op -> return <$> evalOrder dom op args
-            If -> return <$> evalIf args
-            At -> return <$> evalAt args
-            ConsVector -> return <$> evalConsVector args
-            Fold dom -> evalFold dom args
-            FromNat dom -> return <$> evalFromNat dom args
-            FromRat dom -> return <$> evalFromRat dom args
-            Indices -> return <$> evalIndices args
-            Implies -> Just $ compilerDeveloperError $ "Found derived types" <+> pretty b
-
-      case result of
-        Nothing -> return $ VBuiltinFunction b args
-        Just r -> r
-
-isDerived :: BuiltinFunction -> Bool
-isDerived = \case
-  Implies {} -> True
-  _ -> False
-
-evalDerivedBuiltin ::
-  (MonadNorm types m) =>
-  BuiltinFunction ->
-  ExplicitSpine types ->
-  m (Value types)
-evalDerivedBuiltin b args = case b of
-  Implies -> evalImplies args
-  _ -> compilerDeveloperError $ "Invalid derived types" <+> quotePretty b
-
------------------------------------------------------------------------------
--- Indvidual builtins
-
-type EvalBuiltin types m = ExplicitSpine types -> Maybe (m (Value types))
-
-type EvalSimpleBuiltin types = ExplicitSpine types -> Maybe (Value types)
-
-evalNot :: EvalSimpleBuiltin types
-evalNot e = case e of
-  [VBoolLiteral x] -> Just $ VBoolLiteral (not x)
-  _ -> Nothing
-
-evalAnd :: EvalSimpleBuiltin types
-evalAnd = \case
-  [VBoolLiteral x, VBoolLiteral y] -> Just $ VBoolLiteral (x && y)
-  _ -> Nothing
-
-evalOr :: EvalSimpleBuiltin types
-evalOr = \case
-  [VBoolLiteral x, VBoolLiteral y] -> Just $ VBoolLiteral (x || y)
-  _ -> Nothing
-
-evalNeg :: NegDomain -> EvalSimpleBuiltin types
-evalNeg = \case
-  NegInt -> evalNegInt
-  NegRat -> evalNegRat
-
-evalNegInt :: EvalSimpleBuiltin types
-evalNegInt = \case
-  [VIntLiteral x] -> Just $ VIntLiteral (-x)
-  _ -> Nothing
-
-evalNegRat :: EvalSimpleBuiltin types
-evalNegRat = \case
-  [VRatLiteral x] -> Just $ VRatLiteral (-x)
-  _ -> Nothing
-
-evalAdd :: AddDomain -> EvalSimpleBuiltin types
-evalAdd = \case
-  AddNat -> evalAddNat
-  AddInt -> evalAddInt
-  AddRat -> evalAddRat
-
-evalAddNat :: EvalSimpleBuiltin types
-evalAddNat = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VNatLiteral (x + y)
-  _ -> Nothing
-
-evalAddInt :: EvalSimpleBuiltin types
-evalAddInt = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x + y)
-  _ -> Nothing
-
-evalAddRat :: EvalSimpleBuiltin types
-evalAddRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x + y)
-  _ -> Nothing
-
-evalSub :: SubDomain -> EvalSimpleBuiltin types
-evalSub = \case
-  SubInt -> evalSubInt
-  SubRat -> evalSubRat
-
-evalSubInt :: EvalSimpleBuiltin types
-evalSubInt = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x - y)
-  _ -> Nothing
-
-evalSubRat :: EvalSimpleBuiltin types
-evalSubRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x - y)
-  _ -> Nothing
-
-evalMul :: MulDomain -> EvalSimpleBuiltin types
-evalMul = \case
-  MulNat -> evalMulNat
-  MulInt -> evalMulInt
-  MulRat -> evalMulRat
-
-evalMulNat :: EvalSimpleBuiltin types
-evalMulNat = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VNatLiteral (x * y)
-  _ -> Nothing
-
-evalMulInt :: EvalSimpleBuiltin types
-evalMulInt = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x * y)
-  _ -> Nothing
-
-evalMulRat :: EvalSimpleBuiltin types
-evalMulRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x * y)
-  _ -> Nothing
-
-evalDiv :: DivDomain -> EvalSimpleBuiltin types
-evalDiv = \case
-  DivRat -> evalDivRat
-
-evalDivRat :: EvalSimpleBuiltin types
-evalDivRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x / y)
-  _ -> Nothing
-
-evalOrder :: OrderDomain -> OrderOp -> EvalSimpleBuiltin types
-evalOrder = \case
-  OrderIndex -> evalOrderIndex
-  OrderNat -> evalOrderNat
-  OrderInt -> evalOrderInt
-  OrderRat -> evalOrderRat
-
-evalOrderIndex :: OrderOp -> EvalSimpleBuiltin types
-evalOrderIndex op = \case
-  [VIndexLiteral x, VIndexLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
-
-evalOrderNat :: OrderOp -> EvalSimpleBuiltin types
-evalOrderNat op = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
-
-evalOrderInt :: OrderOp -> EvalSimpleBuiltin types
-evalOrderInt op = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
-
-evalOrderRat :: OrderOp -> EvalSimpleBuiltin types
-evalOrderRat op = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
-
-evalEquals :: EqualityDomain -> EqualityOp -> EvalSimpleBuiltin types
-evalEquals = \case
-  EqIndex -> evalEqualityIndex
-  EqNat -> evalEqualityNat
-  EqInt -> evalEqualityInt
-  EqRat -> evalEqualityRat
-
-evalEqualityIndex :: EqualityOp -> EvalSimpleBuiltin types
-evalEqualityIndex op = \case
-  [VIndexLiteral x, VIndexLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
-
-evalEqualityNat :: EqualityOp -> EvalSimpleBuiltin types
-evalEqualityNat op = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
-
-evalEqualityInt :: EqualityOp -> EvalSimpleBuiltin types
-evalEqualityInt op = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
-
-evalEqualityRat :: EqualityOp -> EvalSimpleBuiltin types
-evalEqualityRat op = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
-
-evalFromNat :: FromNatDomain -> EvalSimpleBuiltin types
-evalFromNat = \case
-  FromNatToIndex -> evalFromNatToIndex
-  FromNatToNat -> evalFromNatToNat
-  FromNatToInt -> evalFromNatToInt
-  FromNatToRat -> evalFromNatToRat
-
-evalFromNatToIndex :: EvalSimpleBuiltin types
-evalFromNatToIndex = \case
-  [VNatLiteral x] -> Just $ VIndexLiteral x
-  _ -> Nothing
-
-evalFromNatToNat :: EvalSimpleBuiltin types
-evalFromNatToNat = \case
-  [x] -> Just x
-  _ -> Nothing
-
-evalFromNatToInt :: EvalSimpleBuiltin types
-evalFromNatToInt = \case
-  [VNatLiteral x] -> Just $ VIntLiteral x
-  _ -> Nothing
-
-evalFromNatToRat :: EvalSimpleBuiltin types
-evalFromNatToRat = \case
-  [VNatLiteral x] -> Just $ VRatLiteral (fromIntegral x)
-  _ -> Nothing
-
-evalFromRat :: FromRatDomain -> EvalSimpleBuiltin types
-evalFromRat = \case
-  FromRatToRat -> evalFromRatToRat
-
-evalFromRatToRat :: EvalSimpleBuiltin types
-evalFromRatToRat = \case
-  [x] -> Just x
-  _ -> Nothing
-
-evalIf :: EvalSimpleBuiltin types
-evalIf = \case
-  [VBoolLiteral True, e1, _e2] -> Just e1
-  [VBoolLiteral False, _e1, e2] -> Just e2
-  _ -> Nothing
-
-evalAt :: EvalSimpleBuiltin types
-evalAt = \case
-  [VVecLiteral xs, VIndexLiteral i] -> Just $ case xs !!? fromIntegral i of
-    Nothing -> developerError $ "out of bounds error:" <+> pretty (length xs) <+> "<=" <+> pretty i
-    Just xsi -> xsi
-  _ -> Nothing
-
-evalConsVector :: EvalSimpleBuiltin types
-evalConsVector = \case
-  [x, VVecLiteral xs] -> Just $ VVecLiteral (x : xs)
-  _ -> Nothing
-
-evalFold :: (MonadNorm types m) => FoldDomain -> EvalBuiltin types m
-evalFold = \case
-  FoldList -> evalFoldList
-  FoldVector -> evalFoldVector
-
-evalFoldList :: (MonadNorm types m) => EvalBuiltin types m
-evalFoldList = \case
-  [_f, e, VNil] ->
-    Just $ return e
-  [f, e, VCons [x, xs']] -> Just $ do
-    r <- evalBuiltinFunction (Fold FoldList) [f, e, xs']
-    evalApp f [ExplicitArg mempty x, ExplicitArg mempty r]
-  _ -> Nothing
-
-evalFoldVector :: (MonadNorm types m) => EvalBuiltin types m
-evalFoldVector = \case
-  [f, e, VVecLiteral xs] ->
-    Just $
-      foldrM f' e (zip [0 ..] xs)
-    where
-      f' (l, x) r =
-        evalApp
-          f
-          [ ImplicitArg mempty (VNatLiteral l),
-            ExplicitArg mempty x,
-            ExplicitArg mempty r
-          ]
-  _ -> Nothing
-
-evalIndices :: EvalSimpleBuiltin types
-evalIndices = \case
-  [VNatLiteral n] -> Just $ mkVLVec (fmap VIndexLiteral [0 .. n - 1])
-  _ -> Nothing
-
------------------------------------------------------------------------------
--- Derived
-
-type EvalDerived types m = ExplicitSpine types -> m (Value types)
-
--- TODO define in terms of language
-
-evalImplies :: (MonadNorm types m) => EvalDerived types m
-evalImplies = \case
-  [e1, e2] -> do
-    ne1 <- evalBuiltinFunction Not [e1]
-    evalBuiltinFunction Or [ne1, e2]
-  args -> return $ VBuiltinFunction Implies args
 
 -----------------------------------------------------------------------------
 -- Other
@@ -639,35 +239,35 @@ evalImplies = \case
 currentPass :: Doc ()
 currentPass = "normalisation by evaluation"
 
-showEntry :: (MonadNorm types m) => Env types -> NormalisableExpr types -> m ()
+showEntry :: (MonadNorm builtin m) => Env builtin -> Expr Ix builtin -> m ()
 showEntry _env _expr = do
   -- logDebug MidDetail $ "nbe-entry" <+> prettyVerbose expr -- <+> "   { env=" <+> prettyVerbose env <+> "}"
   -- logDebug MidDetail $ "nbe-entry" <+> prettyFriendly (WithContext expr (fmap fst env)) -- <+> "   { env=" <+> hang 0 (prettyVerbose env) <+> "}"
   -- incrCallDepth
   return ()
 
-showExit :: (MonadNorm types m) => Env types -> Value types -> m ()
+showExit :: (MonadNorm builtin m) => Env builtin -> Value builtin -> m ()
 showExit _env _result = do
   -- decrCallDepth
   -- logDebug MidDetail $ "nbe-exit" <+> prettyVerbose result
   -- logDebug MidDetail $ "nbe-exit" <+> prettyFriendly (WithContext result (fmap fst env))
   return ()
 
-showNormEntry :: (MonadNorm types m) => Env types -> Value types -> m ()
+showNormEntry :: (MonadNorm builtin m) => Env builtin -> Value builtin -> m ()
 showNormEntry _env _expr = do
   -- logDebug MidDetail $ "reeval-entry" <+> prettyVerbose expr -- <+> "   { env=" <+> prettyVerbose env <+> "}"
   -- logDebug MidDetail $ "reeval-entry" <+> prettyFriendly (WithContext expr (fmap fst env)) -- <+> "   { env=" <+> hang 0 (prettyVerbose env) <+> "}"
   -- incrCallDepth
   return ()
 
-showNormExit :: (MonadNorm types m) => Env types -> Value types -> m ()
+showNormExit :: (MonadNorm builtin m) => Env builtin -> Value builtin -> m ()
 showNormExit _env _result = do
   -- decrCallDepth
   -- logDebug MidDetail $ "reeval-exit" <+> prettyVerbose result
   -- logDebug MidDetail $ "reeval-exit" <+> prettyFriendly (WithContext result (fmap fst env))
   return ()
 
-showApp :: (MonadNorm types m) => Value types -> Spine types -> m ()
+showApp :: (MonadNorm builtin m) => Value builtin -> Spine builtin -> m ()
 showApp _fun _spine =
   return ()
 

--- a/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
@@ -3,7 +3,6 @@ module Vehicle.Compile.Normalise.Quote where
 import Vehicle.Compile.Error (MonadCompile, runCompileMonadSilently)
 import Vehicle.Compile.Prelude
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 -- | Converts from a normalised representation to an unnormalised representation.
@@ -20,7 +19,7 @@ unnormalise level e = runCompileMonadSilently "unquoting" (quote mempty level e)
 class Quote a b where
   quote :: (MonadCompile m) => Provenance -> Lv -> a -> m b
 
-instance Quote (Value types) (NormalisableExpr types) where
+instance Quote (Value builtin) (Expr Ix builtin) where
   quote p level = \case
     VUniverse u -> return $ Universe p u
     VMeta m spine -> quoteApp level p (Meta p m) spine
@@ -42,16 +41,16 @@ instance Quote (Value types) (NormalisableExpr types) where
       -- quotedBody <- quote (level + 1) normBody
       return $ Lam mempty quotedBinder quotedBody
 
-instance Quote (VBinder types) (NormalisableBinder types) where
+instance Quote (VBinder builtin) (Binder Ix builtin) where
   quote p level = traverse (quote p level)
 
-instance Quote (VArg types) (NormalisableArg types) where
+instance Quote (VArg builtin) (Arg Ix builtin) where
   quote p level = traverse (quote p level)
 
-quoteApp :: (MonadCompile m) => Lv -> Provenance -> NormalisableExpr types -> Spine types -> m (NormalisableExpr types)
+quoteApp :: (MonadCompile m) => Lv -> Provenance -> Expr Ix builtin -> Spine builtin -> m (Expr Ix builtin)
 quoteApp l p fn spine = normAppList p fn <$> traverse (quote p l) spine
 
-envSubst :: BoundCtx (NormalisableExpr types) -> Substitution (NormalisableExpr types)
+envSubst :: BoundCtx (Expr Ix builtin) -> Substitution (Expr Ix builtin)
 envSubst env i = case lookupIx env i of
   Just v -> Right v
   Nothing ->

--- a/vehicle/src/Vehicle/Compile/Prelude.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude.hs
@@ -46,7 +46,7 @@ mapObject f WithContext {..} = WithContext {objectIn = f objectIn, ..}
 -- Utilities for traversing auxiliary arguments.
 
 -- | Function for updating an auxiliary argument (which may be missing)
-type BuiltinUpdate m binder var builtin1 builtin2 =
+type BuiltinUpdate m var builtin1 builtin2 =
   Provenance -> Provenance -> builtin1 -> [Arg var builtin2] -> m (Expr var builtin2)
 
 -- | Traverses all the auxiliary type arguments in the provided element,
@@ -54,7 +54,7 @@ type BuiltinUpdate m binder var builtin1 builtin2 =
 -- where they should be).
 traverseBuiltinsM ::
   (Monad m) =>
-  BuiltinUpdate m binder var builtin1 builtin2 ->
+  BuiltinUpdate m var builtin1 builtin2 ->
   Expr var builtin1 ->
   m (Expr var builtin2)
 traverseBuiltinsM f expr = case expr of
@@ -73,10 +73,10 @@ traverseBuiltinsM f expr = case expr of
   Hole p n -> return $ Hole p n
   Meta p m -> return $ Meta p m
 
-traverseBuiltinsArg :: (Monad m) => BuiltinUpdate m binder var builtin1 builtin2 -> Arg var builtin1 -> m (Arg var builtin2)
+traverseBuiltinsArg :: (Monad m) => BuiltinUpdate m var builtin1 builtin2 -> Arg var builtin1 -> m (Arg var builtin2)
 traverseBuiltinsArg f = traverse (traverseBuiltinsM f)
 
-traverseBuiltinsBinder :: (Monad m) => BuiltinUpdate m binder var builtin1 builtin2 -> Binder var builtin1 -> m (Binder var builtin2)
+traverseBuiltinsBinder :: (Monad m) => BuiltinUpdate m var builtin1 builtin2 -> Binder var builtin1 -> m (Binder var builtin2)
 traverseBuiltinsBinder f = traverse (traverseBuiltinsM f)
 
 traverseBuiltins ::

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -9,6 +9,7 @@ module Vehicle.Compile.Print
     PrettyFriendly,
     PrettyVerbose,
     PrettyExternal,
+    PrintableBuiltin (..),
     Tags (..),
     prettyVerbose,
     prettyFriendly,
@@ -33,7 +34,7 @@ import Vehicle.Compile.Type.Meta.Map (MetaMap (..))
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.Boolean
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
+import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
 import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Print
 
@@ -121,9 +122,9 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor ('Unnamed tags) (Arg Ix builtin) = 'DescopeNaively (StrategyFor tags (Arg Name builtin))
   StrategyFor ('Unnamed tags) (Binder Ix builtin) = 'DescopeNaively (StrategyFor tags (Binder Name builtin))
   -- To print a normalised expr in an unnamed representation, simply naively descope.
-  StrategyFor ('Unnamed tags) (Value types) = 'DescopeNaively (StrategyFor tags (Expr Name (NormalisableBuiltin types)))
-  StrategyFor ('Unnamed tags) (VArg types) = 'DescopeNaively (StrategyFor tags (Arg Name (NormalisableBuiltin types)))
-  StrategyFor ('Unnamed tags) (VBinder types) = 'DescopeNaively (StrategyFor tags (Binder Name (NormalisableBuiltin types)))
+  StrategyFor ('Unnamed tags) (Value builtin) = 'DescopeNaively (StrategyFor tags (Expr Name builtin))
+  StrategyFor ('Unnamed tags) (VArg builtin) = 'DescopeNaively (StrategyFor tags (Arg Name builtin))
+  StrategyFor ('Unnamed tags) (VBinder builtin) = 'DescopeNaively (StrategyFor tags (Binder Name builtin))
   -- To standardise builtins
   StrategyFor ('StandardiseBuiltin tags) (Prog Name builtin) = 'ConvertBuiltins (StrategyFor tags (Prog Name Builtin))
   StrategyFor ('StandardiseBuiltin tags) (Decl Name builtin) = 'ConvertBuiltins (StrategyFor tags (Decl Name Builtin))
@@ -145,7 +146,7 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor ('Named tags) (Contextualised (Arg Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags (Arg Name Builtin))
   StrategyFor ('Named tags) (Contextualised (Binder Ix builtin) BoundDBCtx) = 'DescopeWithNames (StrategyFor tags (Binder Name Builtin))
   -- To convert a named normalised expr, first denormalise to a checked expr.
-  StrategyFor ('Named tags) (Contextualised (Value types) BoundDBCtx) = 'Denormalise (StrategyFor ('Named tags) (Contextualised (Expr Ix (NormalisableBuiltin types)) BoundDBCtx))
+  StrategyFor ('Named tags) (Contextualised (Value builtin) BoundDBCtx) = 'Denormalise (StrategyFor ('Named tags) (Contextualised (Expr Ix builtin) BoundDBCtx))
   -- To convert an assertion simply defer to normalised expressions
   StrategyFor tags UnreducedAssertion = StrategyFor tags StandardNormExpr
   StrategyFor tags (Contextualised UnreducedAssertion BoundDBCtx) = StrategyFor tags (Contextualised StandardNormExpr BoundDBCtx)
@@ -154,12 +155,12 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor tags Text = 'Pretty
   StrategyFor tags (Contextualised Text ctx) = StrategyFor tags Text
   -- Objects for which we want to block the strategy computation on.
-  StrategyFor ('Named tags) (Contextualised (Constraint types) (ConstraintContext types)) = 'KeepConstraintCtx (StrategyFor ('Named tags) (Contextualised StandardNormExpr BoundDBCtx))
-  StrategyFor ('Named tags) (Contextualised (TypeClassConstraint types) (ConstraintContext types)) = 'KeepConstraintCtx (StrategyFor ('Named tags) (Contextualised StandardNormExpr BoundDBCtx))
-  StrategyFor ('Named tags) (Contextualised (UnificationConstraint types) (ConstraintContext types)) = 'KeepConstraintCtx (StrategyFor ('Named tags) (Contextualised StandardNormExpr BoundDBCtx))
-  StrategyFor tags (Contextualised (Constraint types) (ConstraintContext types)) = 'DiscardConstraintCtx (StrategyFor tags StandardNormExpr)
-  StrategyFor tags (Contextualised (TypeClassConstraint types) (ConstraintContext types)) = 'DiscardConstraintCtx (StrategyFor tags StandardNormExpr)
-  StrategyFor tags (Contextualised (UnificationConstraint types) (ConstraintContext types)) = 'DiscardConstraintCtx (StrategyFor tags StandardNormExpr)
+  StrategyFor ('Named tags) (Contextualised (Constraint builtin) (ConstraintContext builtin)) = 'KeepConstraintCtx (StrategyFor ('Named tags) (Contextualised StandardNormExpr BoundDBCtx))
+  StrategyFor ('Named tags) (Contextualised (TypeClassConstraint builtin) (ConstraintContext builtin)) = 'KeepConstraintCtx (StrategyFor ('Named tags) (Contextualised StandardNormExpr BoundDBCtx))
+  StrategyFor ('Named tags) (Contextualised (UnificationConstraint builtin) (ConstraintContext builtin)) = 'KeepConstraintCtx (StrategyFor ('Named tags) (Contextualised StandardNormExpr BoundDBCtx))
+  StrategyFor tags (Contextualised (Constraint builtin) (ConstraintContext builtin)) = 'DiscardConstraintCtx (StrategyFor tags StandardNormExpr)
+  StrategyFor tags (Contextualised (TypeClassConstraint builtin) (ConstraintContext builtin)) = 'DiscardConstraintCtx (StrategyFor tags StandardNormExpr)
+  StrategyFor tags (Contextualised (UnificationConstraint builtin) (ConstraintContext builtin)) = 'DiscardConstraintCtx (StrategyFor tags StandardNormExpr)
   StrategyFor tags (MetaMap a) = 'Opaque (StrategyFor tags a)
   -- Simplification
   StrategyFor ('Uninserted tags) a = 'UninsertArgsAndBinders (StrategyFor tags a)
@@ -248,7 +249,7 @@ instance PrettyUsing ('PrintAs 'External) (Binder Name Builtin) where
 
 --------------------------------------------------------------------------------
 -- Converting the basic builtins
-
+{-
 instance (PrettyUsing rest (Prog Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Prog Name Builtin) where
   prettyUsing = prettyUsing @rest
 
@@ -263,52 +264,73 @@ instance (PrettyUsing rest (Arg Name Builtin)) => PrettyUsing ('ConvertBuiltins 
 
 instance (PrettyUsing rest (Binder Name Builtin)) => PrettyUsing ('ConvertBuiltins rest) (Binder Name Builtin) where
   prettyUsing = prettyUsing @rest
+-}
+--------------------------------------------------------------------------------
+-- Printing builtins
+
+class (Eq builtin) => PrintableBuiltin builtin where
+  -- | Convert expressions with the builtin back to expressions with the standard
+  -- builtin type. Used for printing.
+  convertBuiltin ::
+    Provenance ->
+    builtin ->
+    Expr var Builtin
+
+instance (PrintableBuiltin types) => PrintableBuiltin (NormalisableBuiltin types) where
+  convertBuiltin p b = case b of
+    CConstructor t -> Builtin p (Constructor t)
+    CFunction t -> Builtin p (BuiltinFunction t)
+    CType t -> convertBuiltin p t
+
+instance PrintableBuiltin Builtin where
+  convertBuiltin = Builtin
+
+instance PrintableBuiltin StandardBuiltinType where
+  convertBuiltin p b = Builtin p $ case b of
+    StandardBuiltinType t -> BuiltinType t
+    StandardTypeClass t -> TypeClass t
+    StandardTypeClassOp t -> TypeClassOp t
 
 --------------------------------------------------------------------------------
 -- Converting builtins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest (Prog Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (Prog Name (NormalisableBuiltin types))
+  (PrintableBuiltin builtin, PrettyUsing rest (Prog Name Builtin)) =>
+  PrettyUsing ('ConvertBuiltins rest) (Prog Name builtin)
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest (Decl Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (Decl Name (NormalisableBuiltin types))
+  (PrintableBuiltin builtin, PrettyUsing rest (Decl Name Builtin)) =>
+  PrettyUsing ('ConvertBuiltins rest) (Decl Name builtin)
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest (Expr Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (Expr Name (NormalisableBuiltin types))
+  (PrintableBuiltin builtin, PrettyUsing rest (Expr Name Builtin)) =>
+  PrettyUsing ('ConvertBuiltins rest) (Expr Name builtin)
   where
   prettyUsing = prettyUsing @rest . convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest (Arg Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (Arg Name (NormalisableBuiltin types))
+  (PrintableBuiltin builtin, PrettyUsing rest (Arg Name Builtin)) =>
+  PrettyUsing ('ConvertBuiltins rest) (Arg Name builtin)
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 instance
-  (PrintableBuiltin types, PrettyUsing rest (Binder Name Builtin)) =>
-  PrettyUsing ('ConvertBuiltins rest) (Binder Name (NormalisableBuiltin types))
+  (PrintableBuiltin builtin, PrettyUsing rest (Binder Name Builtin)) =>
+  PrettyUsing ('ConvertBuiltins rest) (Binder Name builtin)
   where
   prettyUsing = prettyUsing @rest . fmap convertExprBuiltins
 
 convertExprBuiltins ::
-  forall types var.
-  (PrintableBuiltin types) =>
-  Expr var (NormalisableBuiltin types) ->
+  forall builtin var.
+  (PrintableBuiltin builtin) =>
+  Expr var builtin ->
   Expr var Builtin
-convertExprBuiltins = traverseBuiltins $ \p1 p2 b args -> do
-  let fn = case b of
-        CConstructor c -> Builtin p2 $ Constructor c
-        CFunction f -> Builtin p2 $ BuiltinFunction f
-        CType t -> convertBuiltin p2 t
-
-  normAppList p1 fn args
+convertExprBuiltins = traverseBuiltins $ \p1 p2 b args ->
+  normAppList p1 (convertBuiltin p2 b) args
 
 --------------------------------------------------------------------------------
 -- Convert closed terms from DeBruijn representation to named representation naively
@@ -328,13 +350,13 @@ instance (PrettyUsing rest (Arg Name builtin)) => PrettyUsing ('DescopeNaively r
 instance (PrettyUsing rest (Binder Name builtin)) => PrettyUsing ('DescopeNaively rest) (Binder Ix builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (Expr Name (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (Value types) where
+instance (PrettyUsing rest (Expr Name builtin)) => PrettyUsing ('DescopeNaively rest) (Value builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (Arg Name (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VArg types) where
+instance (PrettyUsing rest (Arg Name builtin)) => PrettyUsing ('DescopeNaively rest) (VArg builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
-instance (PrettyUsing rest (Binder Name (NormalisableBuiltin types))) => PrettyUsing ('DescopeNaively rest) (VBinder types) where
+instance (PrettyUsing rest (Binder Name builtin)) => PrettyUsing ('DescopeNaively rest) (VBinder builtin) where
   prettyUsing = prettyUsing @rest . descopeNaive
 
 --------------------------------------------------------------------------------
@@ -441,18 +463,18 @@ instance
 -- Instances for normalised types
 
 instance
-  (PrettyUsing rest (Contextualised (Expr Ix (NormalisableBuiltin types)) BoundDBCtx)) =>
-  PrettyUsing ('Denormalise rest) (Contextualised (Value types) BoundDBCtx)
+  (PrettyUsing rest (Contextualised (Expr Ix builtin) BoundDBCtx)) =>
+  PrettyUsing ('Denormalise rest) (Contextualised (Value builtin) BoundDBCtx)
   where
   prettyUsing (WithContext e ctx) = do
-    let e' = unnormalise @(Value types) @(Expr Ix (NormalisableBuiltin types)) (Lv $ length ctx) e
+    let e' = unnormalise @(Value builtin) @(Expr Ix builtin) (Lv $ length ctx) e
     prettyUsing @rest (WithContext e' ctx)
 
-instance (PrettyUsing rest (Expr Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (Value types) where
-  prettyUsing e = prettyUsing @rest (unnormalise @(Value types) @(Expr Ix (NormalisableBuiltin types)) 0 e)
+instance (PrettyUsing rest (Expr Ix builtin)) => PrettyUsing ('Denormalise rest) (Value builtin) where
+  prettyUsing e = prettyUsing @rest (unnormalise @(Value builtin) @(Expr Ix builtin) 0 e)
 
-instance (PrettyUsing rest (Arg Ix (NormalisableBuiltin types))) => PrettyUsing ('Denormalise rest) (VArg types) where
-  prettyUsing e = prettyUsing @rest (unnormalise @(VArg types) @(Arg Ix (NormalisableBuiltin types)) 0 e)
+instance (PrettyUsing rest (Arg Ix builtin)) => PrettyUsing ('Denormalise rest) (VArg builtin) where
+  prettyUsing e = prettyUsing @rest (unnormalise @(VArg builtin) @(Arg Ix builtin) 0 e)
 
 --------------------------------------------------------------------------------
 -- Instances for unreduced assertions
@@ -497,31 +519,30 @@ prettyUnify e1 e2 = e1 <+> "~" <+> e2
 prettyTypeClass :: MetaID -> Doc a -> Doc a
 prettyTypeClass m expr = pretty m <+> "<=" <+> expr
 
-prettyConstraintContext :: Doc a -> ConstraintContext types -> Doc a
+prettyConstraintContext :: Doc a -> ConstraintContext builtin -> Doc a
 prettyConstraintContext constraint ctx =
   "#" <> pretty (constraintID ctx) <> ". " <+> constraint -- <+> pretty (originalProvenance ctx)
 
 instance
-  (PrettyUsing rest (Value types)) =>
-  PrettyUsing ('DiscardConstraintCtx rest) (Contextualised (UnificationConstraint types) (ConstraintContext types))
+  (PrettyUsing rest (Value builtin)) =>
+  PrettyUsing ('DiscardConstraintCtx rest) (Contextualised (UnificationConstraint builtin) (ConstraintContext builtin))
   where
   prettyUsing (WithContext (Unify e1 e2) ctx) = do
-    let e1' = prettyUsing @rest (e1 :: Value types)
-    let e2' = prettyUsing @rest (e2 :: Value types)
+    let e1' = prettyUsing @rest (e1 :: Value builtin)
+    let e2' = prettyUsing @rest (e2 :: Value builtin)
     prettyConstraintContext (prettyUnify e1' e2') ctx
 
 instance
-  (PrettyUsing rest (Value types)) =>
-  PrettyUsing ('DiscardConstraintCtx rest) (Contextualised (TypeClassConstraint types) (ConstraintContext types))
+  (PrettyUsing rest (Value builtin)) =>
+  PrettyUsing ('DiscardConstraintCtx rest) (Contextualised (TypeClassConstraint builtin) (ConstraintContext builtin))
   where
-  prettyUsing (WithContext (Has m tc args) ctx) = do
-    let expr = VBuiltin (CType tc) args
-    let expr' = prettyUsing @rest (expr :: Value types)
+  prettyUsing (WithContext (Has m expr) ctx) = do
+    let expr' = prettyUsing @rest (expr :: Value builtin)
     prettyConstraintContext (prettyTypeClass m expr') ctx
 
 instance
-  (PrettyUsing rest (Contextualised (Value types) BoundDBCtx)) =>
-  PrettyUsing ('KeepConstraintCtx rest) (Contextualised (UnificationConstraint types) (ConstraintContext types))
+  (PrettyUsing rest (Contextualised (Value builtin) BoundDBCtx)) =>
+  PrettyUsing ('KeepConstraintCtx rest) (Contextualised (UnificationConstraint builtin) (ConstraintContext builtin))
   where
   prettyUsing (WithContext (Unify e1 e2) ctx) = do
     let e1' = prettyUsing @rest (WithContext e1 (boundContextOf ctx))
@@ -529,19 +550,18 @@ instance
     prettyConstraintContext (prettyUnify e1' e2') ctx
 
 instance
-  (PrettyUsing rest (Contextualised (Value types) BoundDBCtx)) =>
-  PrettyUsing ('KeepConstraintCtx rest) (Contextualised (TypeClassConstraint types) (ConstraintContext types))
+  (PrettyUsing rest (Contextualised (Value builtin) BoundDBCtx)) =>
+  PrettyUsing ('KeepConstraintCtx rest) (Contextualised (TypeClassConstraint builtin) (ConstraintContext builtin))
   where
-  prettyUsing (WithContext (Has m tc args) ctx) = do
-    let expr = VBuiltin (CType tc) args
+  prettyUsing (WithContext (Has m expr) ctx) = do
     let expr' = prettyUsing @rest (WithContext expr (boundContextOf ctx))
     prettyConstraintContext (prettyTypeClass m expr') ctx
 
 instance
-  ( PrettyUsing rest (Contextualised (UnificationConstraint types) (ConstraintContext types)),
-    PrettyUsing rest (Contextualised (TypeClassConstraint types) (ConstraintContext types))
+  ( PrettyUsing rest (Contextualised (UnificationConstraint builtin) (ConstraintContext builtin)),
+    PrettyUsing rest (Contextualised (TypeClassConstraint builtin) (ConstraintContext builtin))
   ) =>
-  PrettyUsing rest (Contextualised (Constraint types) (ConstraintContext types))
+  PrettyUsing rest (Contextualised (Constraint builtin) (ConstraintContext builtin))
   where
   prettyUsing (WithContext c ctx) = case c of
     UnificationConstraint uc -> prettyUsing @rest (WithContext uc ctx)

--- a/vehicle/src/Vehicle/Compile/Queries.hs
+++ b/vehicle/src/Vehicle/Compile/Queries.hs
@@ -26,6 +26,7 @@ import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
 import Vehicle.Expr.Boolean
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (StdLibFunction (StdEqualsVector))
 import Vehicle.Verify.Core

--- a/vehicle/src/Vehicle/Compile/Queries/IfElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/IfElimination.hs
@@ -10,6 +10,7 @@ where
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Subsystem.Standard
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Queries/LinearityAndPolarityErrors.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/LinearityAndPolarityErrors.hs
@@ -73,16 +73,16 @@ diagnoseAlternatingQuantifiers queryFormat prog propertyIdentifier = do
     _ -> compilerDeveloperError $ "Unexpected polarity type for property" <+> quotePretty propertyIdentifier
 
 typeCheckWithSubsystem ::
-  forall types m.
-  (TypableBuiltin types, MonadCompile m) =>
+  forall builtin m.
+  (TypableBuiltin builtin, MonadCompile m) =>
   StandardGluedProg ->
-  m (GluedProg types)
+  m (GluedProg builtin)
 typeCheckWithSubsystem prog = do
   let unnormalisedProg = fmap unnormalised prog
   typeClassFreeProg <- resolveInstanceArguments unnormalisedProg
   monomorphisedProg <- monomorphise False typeClassFreeProg
   implicitFreeProg <- removeImplicitAndInstanceArgs monomorphisedProg
-  runTypeChecker @m @types mempty $
+  runTypeChecker @m @builtin mempty $
     typeCheckProg mempty implicitFreeProg
 
 resolveInstanceArguments :: forall m. (MonadCompile m) => StandardProg -> m StandardProg
@@ -92,7 +92,7 @@ resolveInstanceArguments prog =
     logCompilerPassOutput $ prettyFriendly result
     return result
   where
-    builtinUpdateFunction :: BuiltinUpdate m () Ix StandardBuiltin StandardBuiltin
+    builtinUpdateFunction :: BuiltinUpdate m Ix StandardBuiltin StandardBuiltin
     builtinUpdateFunction p1 p2 b args = case b of
       CType (StandardTypeClassOp {}) -> do
         let (inst, remainingArgs) = findInstanceArg args

--- a/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/NetworkElimination.hs
@@ -35,6 +35,7 @@ import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.Boolean (BooleanExpr (..), DisjunctAll (..))
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Hashing ()
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (StdLibFunction (..))
 import Vehicle.Verify.Core

--- a/vehicle/src/Vehicle/Compile/Queries/QuerySetStructure.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/QuerySetStructure.hs
@@ -32,7 +32,7 @@ import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
 import Vehicle.Expr.Boolean
 import Vehicle.Expr.DeBruijn (Ix (..), Lv (..), dbLevelToIndex)
-import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (StdLibFunction (StdEqualsVector), fromFiniteQuantifier)
 import Vehicle.Verify.Core
@@ -470,7 +470,7 @@ calculateVariableDimensions binder = go (typeOf binder)
 --------------------------------------------------------------------------------
 -- Builtin and free variable tracking
 
-type QueryDeclCtx = DeclCtx (NormDeclCtxEntry StandardBuiltinType, UsedFunctionsInfo)
+type QueryDeclCtx = DeclCtx (NormDeclCtxEntry StandardBuiltin, UsedFunctionsInfo)
 
 queryDeclCtxToNormDeclCtx :: QueryDeclCtx -> StandardNormDeclCtx
 queryDeclCtxToNormDeclCtx = fmap fst
@@ -525,7 +525,7 @@ getUsedNormFunctions declCtx boundCtx expr = case expr of
     builtinInfo <> spineInfo
 
 getUsedFunctionsBuiltin ::
-  NormalisableBuiltin StandardBuiltinType ->
+  StandardBuiltin ->
   UsedFunctionsInfo
 getUsedFunctionsBuiltin = \case
   CFunction f -> (HashSet.singleton f, mempty)

--- a/vehicle/src/Vehicle/Compile/Queries/UserVariableElimination.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/UserVariableElimination.hs
@@ -23,7 +23,8 @@ import Data.Set qualified as Set
 import Data.Traversable (for)
 import Data.Vector.Unboxed qualified as Vector
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (defaultEvalOptions, evalMul, reeval, runNormT)
+import Vehicle.Compile.Normalise.Builtin (evalMul)
+import Vehicle.Compile.Normalise.NBE (defaultEvalOptions, reeval, runNormT)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Queries.FourierMotzkinElimination (fourierMotzkinElimination)
@@ -38,6 +39,7 @@ import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Compile.Warning (CompileWarning (ResortingtoFMElimination))
 import Vehicle.Expr.Boolean
 import Vehicle.Expr.DeBruijn
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (StdLibFunction (..))
 import Vehicle.Verify.Core

--- a/vehicle/src/Vehicle/Compile/Queries/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Queries/Variable.hs
@@ -47,6 +47,7 @@ import Prettyprinter (brackets, list)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.DeBruijn (Lv (..))
+import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (fromFiniteQuantifier, toFiniteQuantifier)
 
@@ -333,7 +334,14 @@ lookupAndRemoveAll assignment = foldM op ([], assignment)
 --------------------------------------------------------------------------------
 -- Other
 
-pattern VInfiniteQuantifier :: Quantifier -> QuantifierDomain -> [StandardNormExpr] -> StandardNormBinder -> StandardEnv -> TypeCheckedExpr -> StandardNormExpr
+pattern VInfiniteQuantifier ::
+  Quantifier ->
+  QuantifierDomain ->
+  [StandardNormExpr] ->
+  StandardNormBinder ->
+  StandardEnv ->
+  TypeCheckedExpr ->
+  StandardNormExpr
 pattern VInfiniteQuantifier q dom args binder env body <-
   VBuiltinFunction (Quantifier q dom) (reverse -> VLam binder env body : args)
   where

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -249,7 +249,7 @@ logScopeEntry e = do
   incrCallDepth
   logDebug MaxDetail $ "scope-entry" <+> prettyVerbose e -- <+> "in" <+> pretty ctx
 
-logScopeExit :: MonadTraverse m => NormalisableExpr -> m ()
+logScopeExit :: MonadTraverse m => Expr Ix -> m ()
 logScopeExit e = do
   logDebug MaxDetail $ "scope-exit " <+> prettyVerbose e
   decrCallDepth

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -13,7 +13,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map qualified as Map (fromList)
 import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (getMetaSubstitution)
+import Vehicle.Compile.Normalise.Monad (getMetaSubstitution)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Bidirectional
@@ -28,41 +28,40 @@ import Vehicle.Compile.Type.Meta.Substitution
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 -------------------------------------------------------------------------------
 -- Algorithm
 
 typeCheckProg ::
-  (TypableBuiltin types, MonadCompile m) =>
-  Imports types ->
-  NormalisableProg StandardBuiltinType ->
-  m (GluedProg types)
+  (TypableBuiltin builtin, MonadCompile m) =>
+  Imports builtin ->
+  Prog Ix StandardBuiltin ->
+  m (GluedProg builtin)
 typeCheckProg imports (Main uncheckedProg) =
   logCompilerPass MinDetail "type checking" $
     runTypeChecker (createDeclCtx imports) $ do
       Main <$> typeCheckDecls uncheckedProg
 
 typeCheckExpr ::
-  forall types m.
-  (TypableBuiltin types, MonadCompile m) =>
-  Imports types ->
-  NormalisableExpr types ->
-  m (NormalisableExpr types)
+  forall builtin m.
+  (TypableBuiltin builtin, MonadCompile m) =>
+  Imports builtin ->
+  Expr Ix builtin ->
+  m (Expr Ix builtin)
 typeCheckExpr imports expr1 =
   runTypeChecker (createDeclCtx imports) $ do
     (expr3, _exprType) <- runReaderT (inferExpr expr1) mempty
-    solveConstraints @types Nothing
+    solveConstraints @builtin Nothing
     expr4 <- substMetas expr3
     expr5 <- removeIrrelevantCode expr4
-    checkAllUnknownsSolved (Proxy @types)
+    checkAllUnknownsSolved (Proxy @builtin)
     return expr5
 
 -------------------------------------------------------------------------------
 -- Type-class for things that can be type-checked
 
-typeCheckDecls :: (TCM types m) => [NormalisableDecl StandardBuiltinType] -> m [GluedDecl types]
+typeCheckDecls :: (TCM builtin m) => [Decl Ix StandardBuiltin] -> m [GluedDecl builtin]
 typeCheckDecls = \case
   [] -> return []
   d : ds -> do
@@ -70,7 +69,7 @@ typeCheckDecls = \case
     checkedDecls <- addDeclContext typedDecl $ typeCheckDecls ds
     return $ typedDecl : checkedDecls
 
-typeCheckDecl :: forall types m. (TCM types m) => NormalisableDecl StandardBuiltinType -> m (GluedDecl types)
+typeCheckDecl :: forall builtin m. (TCM builtin m) => Decl Ix StandardBuiltin -> m (GluedDecl builtin)
 typeCheckDecl uncheckedDecl =
   logCompilerPass MaxDetail ("declaration" <+> quotePretty (identifierOf uncheckedDecl)) $ do
     convertedDecl <- traverse convertExprFromStandardTypes uncheckedDecl
@@ -79,33 +78,26 @@ typeCheckDecl uncheckedDecl =
       DefAbstract p n r t -> typeCheckAbstractDef p n r t
       DefFunction p n b t e -> typeCheckFunction p n b t e
 
-    checkAllUnknownsSolved (Proxy @types)
+    checkAllUnknownsSolved (Proxy @builtin)
     finalDecl <- substMetas gluedDecl
     logCompilerPassOutput $ prettyFriendly (fmap unnormalised finalDecl)
 
     return finalDecl
 
 convertExprFromStandardTypes ::
-  forall types m.
-  (TypableBuiltin types, TCM types m) =>
-  NormalisableExpr StandardBuiltinType ->
-  m (NormalisableExpr types)
-convertExprFromStandardTypes = traverseBuiltinsM builtinUpdateFunction
-  where
-    builtinUpdateFunction :: BuiltinUpdate m () Ix StandardBuiltin (NormalisableBuiltin types)
-    builtinUpdateFunction p1 p2 b args = do
-      case b of
-        CConstructor c -> return $ normAppList p1 (Builtin p2 (CConstructor c)) args
-        CFunction f -> return $ normAppList p1 (Builtin p2 (CFunction f)) args
-        CType t -> convertFromStandardTypes p2 t args
+  forall builtin m.
+  (TypableBuiltin builtin, TCM builtin m) =>
+  Expr Ix StandardBuiltin ->
+  m (Expr Ix builtin)
+convertExprFromStandardTypes = traverseBuiltinsM convertFromStandardTypes
 
 typeCheckAbstractDef ::
-  (TCM types m) =>
+  (TCM builtin m) =>
   Provenance ->
   Identifier ->
   DefAbstractSort ->
-  NormalisableType types ->
-  m (GluedDecl types)
+  Type Ix builtin ->
+  m (GluedDecl builtin)
 typeCheckAbstractDef p ident defSort uncheckedType = do
   checkedType <- checkDeclType ident uncheckedType
   let checkedDecl = DefAbstract p ident defSort checkedType
@@ -131,13 +123,13 @@ typeCheckAbstractDef p ident defSort uncheckedType = do
   return gluedDecl
 
 typeCheckFunction ::
-  (TCM types m) =>
+  (TCM builtin m) =>
   Provenance ->
   Identifier ->
   [Annotation] ->
-  NormalisableType types ->
-  NormalisableExpr types ->
-  m (GluedDecl types)
+  Type Ix builtin ->
+  Expr Ix builtin ->
+  m (GluedDecl builtin)
 typeCheckFunction p ident anns typ body = do
   checkedType <- checkDeclType ident typ
 
@@ -171,7 +163,7 @@ typeCheckFunction p ident anns typ body = do
       gluedDecl <- traverse (glueNBE mempty) checkedDecl3
       return gluedDecl
 
-checkDeclType :: (TCM types m) => Identifier -> NormalisableExpr types -> m (NormalisableType types)
+checkDeclType :: (TCM builtin m) => Identifier -> Expr Ix builtin -> m (Type Ix builtin)
 checkDeclType ident declType = do
   let pass = bidirectionalPassDoc <+> "type of" <+> quotePretty ident
   logCompilerPass MidDetail pass $ do
@@ -180,11 +172,11 @@ checkDeclType ident declType = do
     return checkedType
 
 restrictAbstractDefType ::
-  (TCM types m) =>
+  (TCM builtin m) =>
   DefAbstractSort ->
   DeclProvenance ->
-  GluedType types ->
-  m (NormalisableType types)
+  GluedType builtin ->
+  m (Type Ix builtin)
 restrictAbstractDefType resource decl@(ident, _) defType = do
   let resourceName = pretty resource <+> squotes (pretty ident)
   logCompilerPass MidDetail ("checking suitability of the type of" <+> resourceName) $ do
@@ -194,7 +186,7 @@ restrictAbstractDefType resource decl@(ident, _) defType = do
       NetworkDef -> restrictNetworkType decl defType
       PostulateDef -> return $ unnormalised defType
 
-assertDeclTypeIsType :: (TCM types m) => Identifier -> NormalisableType types -> m ()
+assertDeclTypeIsType :: (TCM builtin m) => Identifier -> Type Ix builtin -> m ()
 -- This is a bit of a hack to get around having to have a solver for universe
 -- levels. As type definitions will always have an annotated Type 0 inserted
 -- by delaboration, we can match on it here. Anything else will be unified
@@ -213,13 +205,13 @@ assertDeclTypeIsType ident actualType = do
 -- | Tries to solve constraints. Passes in the type of the current declaration
 -- being checked, as metas are handled different according to whether they
 -- occur in the type or not.
-solveConstraints :: forall types m. (TCM types m) => Maybe (NormalisableDecl types) -> m ()
+solveConstraints :: forall builtin m. (TCM builtin m) => Maybe (Decl Ix builtin) -> m ()
 solveConstraints d = logCompilerPass MidDetail "constraint solving" $ do
   loopOverConstraints mempty 1 d
   where
-    loopOverConstraints :: (TCM types m) => MetaSet -> Int -> Maybe (NormalisableDecl types) -> m ()
+    loopOverConstraints :: (TCM builtin m) => MetaSet -> Int -> Maybe (Decl Ix builtin) -> m ()
     loopOverConstraints recentlySolvedMetas loopNumber decl = do
-      unsolvedConstraints <- getActiveConstraints @types
+      unsolvedConstraints <- getActiveConstraints @builtin
 
       updatedDecl <- traverse substMetas decl
       logUnsolvedUnknowns updatedDecl (Just recentlySolvedMetas)
@@ -239,14 +231,14 @@ solveConstraints d = logCompilerPass MidDetail "constraint solving" $ do
             let passDoc = "constraint solving pass" <+> pretty loopNumber
             newMetasSolved <- logCompilerPass MaxDetail passDoc $ do
               metasSolvedDuringUnification <-
-                trackSolvedMetas (Proxy @types) $
-                  runUnificationSolver (Proxy @types) recentlySolvedMetas
+                trackSolvedMetas (Proxy @builtin) $
+                  runUnificationSolver (Proxy @builtin) recentlySolvedMetas
 
               logUnsolvedUnknowns updatedDecl (Just recentlySolvedMetas)
 
               metasSolvedDuringInstanceResolution <-
-                trackSolvedMetas (Proxy @types) $
-                  runInstanceSolver (Proxy @types) metasSolvedDuringUnification
+                trackSolvedMetas (Proxy @builtin) $
+                  runInstanceSolver (Proxy @builtin) metasSolvedDuringUnification
               return metasSolvedDuringInstanceResolution
 
             loopOverConstraints newMetasSolved (loopNumber + 1) updatedDecl
@@ -254,10 +246,10 @@ solveConstraints d = logCompilerPass MidDetail "constraint solving" $ do
 -- | Attempts to solve as many type-class constraints as possible. Takes in
 -- the set of meta-variables solved since the solver was last run and outputs
 -- the set of meta-variables solved during this run.
-runInstanceSolver :: forall types m. (TCM types m) => Proxy types -> MetaSet -> m ()
+runInstanceSolver :: forall builtin m. (TCM builtin m) => Proxy builtin -> MetaSet -> m ()
 runInstanceSolver _ metasSolved =
   logCompilerPass MaxDetail ("instance solver run" <> line) $
-    runConstraintSolver @types
+    runConstraintSolver @builtin
       getActiveTypeClassConstraints
       setTypeClassConstraints
       solveInstance
@@ -266,10 +258,10 @@ runInstanceSolver _ metasSolved =
 -- | Attempts to solve as many unification constraints as possible. Takes in
 -- the set of meta-variables solved since unification was last run and outputs
 -- the set of meta-variables solved during this run.
-runUnificationSolver :: forall types m. (TCM types m) => Proxy types -> MetaSet -> m ()
+runUnificationSolver :: forall builtin m. (TCM builtin m) => Proxy builtin -> MetaSet -> m ()
 runUnificationSolver _ metasSolved =
   logCompilerPass MaxDetail "unification solver run" $
-    runConstraintSolver @types
+    runConstraintSolver @builtin
       getActiveUnificationConstraints
       setUnificationConstraints
       solveUnificationConstraint
@@ -278,7 +270,7 @@ runUnificationSolver _ metasSolved =
 -------------------------------------------------------------------------------
 -- Unsolved constraint checks
 
-checkAllUnknownsSolved :: (TCM types m) => Proxy types -> m ()
+checkAllUnknownsSolved :: (TCM builtin m) => Proxy builtin -> m ()
 checkAllUnknownsSolved proxy = do
   -- First check all user constraints (i.e. unification and type-class
   -- constraints) are solved.
@@ -290,14 +282,14 @@ checkAllUnknownsSolved proxy = do
   -- ...and the fresh names
   clearFreshNames proxy
 
-checkAllConstraintsSolved :: forall types m. (TCM types m) => Proxy types -> m ()
+checkAllConstraintsSolved :: forall builtin m. (TCM builtin m) => Proxy builtin -> m ()
 checkAllConstraintsSolved _ = do
-  constraints <- getActiveConstraints @types
+  constraints <- getActiveConstraints @builtin
   case constraints of
     [] -> return ()
     (c : cs) -> handleTypingError $ UnsolvableConstraints (c :| cs)
 
-checkAllMetasSolved :: (TCM types m) => Proxy types -> m ()
+checkAllMetasSolved :: (TCM builtin m) => Proxy builtin -> m ()
 checkAllMetasSolved proxy = do
   unsolvedMetas <- getUnsolvedMetas proxy
   case MetaSet.toList unsolvedMetas of
@@ -312,15 +304,15 @@ checkAllMetasSolved proxy = do
           )
       throwError $ UnsolvedMetas metasAndOrigins
 
-logUnsolvedUnknowns :: forall types m. (TCM types m) => Maybe (NormalisableDecl types) -> Maybe MetaSet -> m ()
+logUnsolvedUnknowns :: forall builtin m. (TCM builtin m) => Maybe (Decl Ix builtin) -> Maybe MetaSet -> m ()
 logUnsolvedUnknowns maybeDecl maybeSolvedMetas = do
   logDebugM MaxDetail $ do
-    newSubstitution <- getMetaSubstitution @types
+    newSubstitution <- getMetaSubstitution @builtin
     updatedSubst <- substMetas newSubstitution
 
-    unsolvedMetas <- getUnsolvedMetas (Proxy @types)
-    unsolvedMetasDoc <- prettyMetas (Proxy @types) unsolvedMetas
-    unsolvedConstraints <- getActiveConstraints @types
+    unsolvedMetas <- getUnsolvedMetas (Proxy @builtin)
+    unsolvedMetasDoc <- prettyMetas (Proxy @builtin) unsolvedMetas
+    unsolvedConstraints <- getActiveConstraints @builtin
 
     let constraintsDoc = case maybeSolvedMetas of
           Nothing ->
@@ -360,7 +352,7 @@ logUnsolvedUnknowns maybeDecl maybeSolvedMetas = do
         <> constraintsDoc
         <> declDoc
 
-prettyBlockedConstraints :: (PrintableBuiltin types) => [WithContext (Constraint types)] -> Doc a
+prettyBlockedConstraints :: (PrintableBuiltin builtin) => [WithContext (Constraint builtin)] -> Doc a
 prettyBlockedConstraints constraints = do
   let pairs = fmap (\c -> prettyFriendly c <> "   " <> pretty (blockedBy $ contextOf c)) constraints
   prettySetLike pairs
@@ -371,12 +363,12 @@ bidirectionalPassDoc = "bidirectional pass over"
 -------------------------------------------------------------------------------
 -- Other
 
-createDeclCtx :: Imports types -> TypingDeclCtx types
+createDeclCtx :: Imports builtin -> TypingDeclCtx builtin
 createDeclCtx imports =
   Map.fromList $
     [getEntry d | imp <- imports, let Main ds = imp, d <- ds]
   where
-    getEntry :: GluedDecl types -> (Identifier, TypingDeclCtxEntry types)
+    getEntry :: GluedDecl builtin -> (Identifier, TypingDeclCtxEntry builtin)
     getEntry d = do
       let ident = identifierOf d
       (ident, mkTypingDeclCtxEntry d)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -13,8 +13,6 @@ where
 import Control.Monad (forM_)
 import Data.Data (Proxy (..))
 import Data.List (partition)
-import Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty qualified as NonEmpty
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
@@ -23,18 +21,18 @@ import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Compile.Type.Monad (MonadTypeChecker, TCM, copyContext, freshMetaIdAndExpr, solveMeta, trackSolvedMetas)
-import Vehicle.Expr.Normalisable (NormalisableBuiltin (..), NormalisableExpr)
+import Vehicle.Expr.DeBruijn (Ix)
 import Vehicle.Expr.Normalised
 
 -- | Attempts to solve as many constraints as possible. Takes in
 -- the set of meta-variables solved since the solver was last run and outputs
 -- the set of meta-variables solved during this run.
 runConstraintSolver ::
-  forall types m constraint.
-  (TCM types m, PrettyExternal (Contextualised constraint (ConstraintContext types))) =>
-  m [Contextualised constraint (ConstraintContext types)] ->
-  ([Contextualised constraint (ConstraintContext types)] -> m ()) ->
-  (Contextualised constraint (ConstraintContext types) -> m ()) ->
+  forall builtin m constraint.
+  (TCM builtin m, PrettyExternal (Contextualised constraint (ConstraintContext builtin))) =>
+  m [Contextualised constraint (ConstraintContext builtin)] ->
+  ([Contextualised constraint (ConstraintContext builtin)] -> m ()) ->
+  (Contextualised constraint (ConstraintContext builtin) -> m ()) ->
   MetaSet ->
   m ()
 runConstraintSolver getConstraints setConstraints attemptToSolveConstraint = loop 0
@@ -55,7 +53,7 @@ runConstraintSolver getConstraints setConstraints attemptToSolveConstraint = loo
               -- We have made useful progress so start a new pass
               setConstraints blockedConstraints
 
-              solvedMetas <- trackSolvedMetas (Proxy @types) $ do
+              solvedMetas <- trackSolvedMetas (Proxy @builtin) $ do
                 forM_ unblockedConstraints $ \constraint -> do
                   logCompilerSection MaxDetail ("trying:" <+> prettyExternal constraint) $ do
                     attemptToSolveConstraint constraint
@@ -67,24 +65,24 @@ blockOn metas = do
   logDebug MaxDetail $ "stuck-on metas" <+> pretty metas
   return $ Stuck $ MetaSet.fromList metas
 
-malformedConstraintError :: (PrintableBuiltin types, MonadCompile m) => WithContext (TypeClassConstraint types) -> m a
+malformedConstraintError :: (PrintableBuiltin builtin, MonadCompile m) => WithContext (TypeClassConstraint builtin) -> m a
 malformedConstraintError c =
   compilerDeveloperError $ "Malformed type-class constraint:" <+> prettyVerbose c
 
 unify ::
-  (MonadTypeChecker types m) =>
-  ConstraintContext types ->
-  Value types ->
-  Value types ->
-  m (WithContext (Constraint types))
+  (MonadTypeChecker builtin m) =>
+  ConstraintContext builtin ->
+  Value builtin ->
+  Value builtin ->
+  m (WithContext (Constraint builtin))
 unify ctx e1 e2 = WithContext (UnificationConstraint $ Unify e1 e2) <$> copyContext ctx
 
 {-
 unifyWithPiType ::
-  TCM types m =>
-  ConstraintContext types ->
-  Value types ->
-  m (WithContext (Constraint types), Value types, Value types)
+  TCM builtin m =>
+  ConstraintContext builtin ->
+  Value builtin ->
+  m (WithContext (Constraint builtin), Value builtin, Value builtin)
 unifyWithPiType ctx expr = do
   let p = provenanceOf ctx
   let boundCtx = boundContext ctx
@@ -96,22 +94,20 @@ unifyWithPiType ctx expr = do
 -}
 
 createTC ::
-  (TCM types m) =>
-  ConstraintContext types ->
-  types ->
-  NonEmpty (VType types) ->
-  m (NormalisableExpr types, WithContext (Constraint types))
-createTC c tc argExprs = do
+  (TCM builtin m) =>
+  ConstraintContext builtin ->
+  Value builtin ->
+  m (Expr Ix builtin, WithContext (Constraint builtin))
+createTC c t = do
   let p = provenanceOf c
   ctx <- copyContext c
   let dbLevel = contextDBLevel c
-  let nArgs = ExplicitArg p <$> argExprs
-  newTypeClassExpr <- BuiltinExpr p (CType tc) <$> traverse (quote mempty dbLevel) nArgs
+  newTypeClassExpr <- quote p dbLevel t
   (meta, metaExpr) <- freshMetaIdAndExpr p newTypeClassExpr (boundContext c)
-  let newConstraint = TypeClassConstraint (Has meta tc (NonEmpty.toList argExprs))
+  let newConstraint = TypeClassConstraint (Has meta t)
   return (unnormalised metaExpr, WithContext newConstraint ctx)
 
-solveTypeClassMeta :: (TCM types m) => ConstraintContext types -> MetaID -> Value types -> m ()
+solveTypeClassMeta :: (TCM builtin m) => ConstraintContext builtin -> MetaID -> Value builtin -> m ()
 solveTypeClassMeta ctx meta solution = do
   quotedSolution <- quote mempty (contextDBLevel ctx) solution
   solveMeta meta quotedSolution (boundContext ctx)

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -18,7 +18,6 @@ import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 
 --------------------------------------------------------------------------------
 -- Type-class generalisation
@@ -27,9 +26,9 @@ import Vehicle.Expr.Normalisable
 -- metas that occur in the type of the declaration. It then appends these
 -- constraints as instance arguments to the declaration.
 generaliseOverUnsolvedConstraints ::
-  (TCM types m) =>
-  NormalisableDecl types ->
-  m (NormalisableDecl types)
+  (TCM builtin m) =>
+  Decl Ix builtin ->
+  m (Decl Ix builtin)
 generaliseOverUnsolvedConstraints decl =
   logCompilerPass MidDetail "generalisation over unsolved type-class constraints" $ do
     unsolvedTypeClassConstraints <- traverse substMetas =<< getActiveTypeClassConstraints
@@ -41,11 +40,11 @@ generaliseOverUnsolvedConstraints decl =
     return generalisedDecl
 
 generaliseOverConstraint ::
-  (TCM types m) =>
-  [WithContext (Constraint types)] ->
-  (NormalisableDecl types, [WithContext (TypeClassConstraint types)]) ->
-  WithContext (TypeClassConstraint types) ->
-  m (NormalisableDecl types, [WithContext (TypeClassConstraint types)])
+  (TCM builtin m) =>
+  [WithContext (Constraint builtin)] ->
+  (Decl Ix builtin, [WithContext (TypeClassConstraint builtin)]) ->
+  WithContext (TypeClassConstraint builtin) ->
+  m (Decl Ix builtin, [WithContext (TypeClassConstraint builtin)])
 generaliseOverConstraint allConstraints (decl, rejected) c@(WithContext tc ctx) = do
   -- Find any unsolved meta variables that are transitively linked
   -- by constraints of the same type.
@@ -65,14 +64,14 @@ generaliseOverConstraint allConstraints (decl, rejected) c@(WithContext tc ctx) 
       return (generalisedDecl, rejected)
 
 prependConstraint ::
-  (TCM types m) =>
-  NormalisableDecl types ->
-  WithContext (TypeClassConstraint types) ->
-  m (NormalisableDecl types)
-prependConstraint decl (WithContext constraint@(Has meta tc _) ctx) = do
+  (TCM builtin m) =>
+  Decl Ix builtin ->
+  WithContext (TypeClassConstraint builtin) ->
+  m (Decl Ix builtin)
+prependConstraint decl (WithContext (Has meta expr) ctx) = do
   let p = originalProvenance ctx
-  typeClass <- quote p 0 (tcNormExpr constraint)
-  relevancy <- typeClassRelevancy tc
+  typeClass <- quote p 0 expr
+  relevancy <- typeClassRelevancy expr
 
   substTypeClass <- substMetas typeClass
   logCompilerPass MaxDetail ("generalisation over" <+> prettyVerbose substTypeClass) $
@@ -85,10 +84,10 @@ prependConstraint decl (WithContext constraint@(Has meta tc _) ctx) = do
 -- each such meta, it then prepends a new quantified variable to the declaration
 -- type and then solves the meta as that new variable.
 generaliseOverUnsolvedMetaVariables ::
-  forall types m.
-  (TCM types m) =>
-  NormalisableDecl types ->
-  m (NormalisableDecl types)
+  forall builtin m.
+  (TCM builtin m) =>
+  Decl Ix builtin ->
+  m (Decl Ix builtin)
 generaliseOverUnsolvedMetaVariables decl = do
   let declType = typeOf decl
 
@@ -105,11 +104,11 @@ generaliseOverUnsolvedMetaVariables decl = do
           substMetas result
 
 quantifyOverMeta ::
-  forall types m.
-  (TCM types m) =>
-  NormalisableDecl types ->
+  forall builtin m.
+  (TCM builtin m) =>
+  Decl Ix builtin ->
   MetaID ->
-  m (NormalisableDecl types)
+  m (Decl Ix builtin)
 quantifyOverMeta decl meta = do
   metaType <- substMetas =<< getMetaType meta
   if isMeta metaType
@@ -118,7 +117,7 @@ quantifyOverMeta decl meta = do
         "Haven't thought about what to do when type of unsolved meta is also"
           <+> "an unsolved meta."
     else do
-      metaDoc <- prettyMeta (Proxy @types) meta
+      metaDoc <- prettyMeta (Proxy @builtin) meta
       logCompilerPass MidDetail ("generalisation over" <+> metaDoc) $ do
         -- Prepend the implicit binders for the new generalised variable.
         binderName <- getBinderNameOrFreshName Nothing metaType
@@ -134,15 +133,15 @@ isMeta _ = False
 -- Utilities
 
 prependBinderAndSolveMeta ::
-  forall types m.
-  (TCM types m) =>
+  forall builtin m.
+  (TCM builtin m) =>
   MetaID ->
   BinderDisplayForm ->
   Visibility ->
   Relevance ->
-  NormalisableType types ->
-  NormalisableDecl types ->
-  m (NormalisableDecl types)
+  Type Ix builtin ->
+  Decl Ix builtin ->
+  m (Decl Ix builtin)
 prependBinderAndSolveMeta meta f v r binderType decl = do
   -- All the metas contained within the type of the binder about to be
   -- appended cannot have any dependencies on variables later on in the expression.
@@ -167,7 +166,7 @@ prependBinderAndSolveMeta meta f v r binderType decl = do
   let updatedDecl = addNewArgumentToMetaUses meta prependedDecl
 
   -- We now solve the meta as the newly bound variable
-  metaCtx <- getMetaCtx @types meta
+  metaCtx <- getMetaCtx @builtin meta
   let p = provenanceOf prependedDecl
   let solution = BoundVar p (Ix $ length metaCtx - 1)
   solveMeta meta solution metaCtx
@@ -181,15 +180,15 @@ prependBinderAndSolveMeta meta f v r binderType decl = do
   return resultDecl
 
 removeContextsOfMetasIn ::
-  forall types m.
-  (TCM types m) =>
-  NormalisableType types ->
-  NormalisableDecl types ->
-  m (NormalisableType types, NormalisableDecl types)
+  forall builtin m.
+  (TCM builtin m) =>
+  Type Ix builtin ->
+  Decl Ix builtin ->
+  m (Type Ix builtin, Decl Ix builtin)
 removeContextsOfMetasIn binderType decl =
   logCompilerPass MaxDetail "removing dependencies from dependent metas" $ do
     metasInBinder <- metasIn binderType
-    newMetas <- or <$> forM (MetaSet.toList metasInBinder) (removeMetaDependencies (Proxy @types))
+    newMetas <- or <$> forM (MetaSet.toList metasInBinder) (removeMetaDependencies (Proxy @builtin))
 
     if not newMetas
       then return (binderType, decl)
@@ -199,10 +198,10 @@ removeContextsOfMetasIn binderType decl =
         logCompilerPassOutput (prettyVerbose substDecl)
         return (substBinderType, substDecl)
 
-addNewArgumentToMetaUses :: MetaID -> NormalisableDecl types -> NormalisableDecl types
+addNewArgumentToMetaUses :: MetaID -> Decl Ix builtin -> Decl Ix builtin
 addNewArgumentToMetaUses meta = fmap (go (-1))
   where
-    go :: Lv -> NormalisableExpr types -> NormalisableExpr types
+    go :: Lv -> Expr Ix builtin -> Expr Ix builtin
     go d expr = case expr of
       Meta p m
         | m == meta -> App p (Meta p m) [newVar p]

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -6,6 +6,8 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.Builtin (Normalisable (..))
+import Vehicle.Compile.Normalise.Monad
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
@@ -13,7 +15,6 @@ import Vehicle.Compile.Type.Meta.Map (MetaMap (..))
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Meta.Variable (MetaInfo (..))
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised (GluedExpr (..), Value (..))
 
 -- | Substitutes meta-variables through the provided object, returning the
@@ -45,7 +46,7 @@ instance (MetaSubstitutable m a) => MetaSubstitutable m (GenericArg a) where
 instance (MetaSubstitutable m a) => MetaSubstitutable m (GenericBinder a) where
   subst = traverse subst
 
-instance (MonadNorm types m) => MetaSubstitutable m (NormalisableExpr types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (Expr Ix builtin) where
   subst expr =
     -- logCompilerPass MaxDetail (prettyVerbose ex) $
     case expr of
@@ -67,24 +68,24 @@ instance (MonadNorm types m) => MetaSubstitutable m (NormalisableExpr types) whe
 -- clogging up our program so this function detects meta applications and normalises
 -- them as it substitutes the meta in.
 substApp ::
-  forall types m.
-  (MonadNorm types m) =>
+  forall builtin m.
+  (MonadNorm builtin m) =>
   Provenance ->
-  (NormalisableExpr types, [NormalisableArg types]) ->
-  m (NormalisableExpr types)
+  (Expr Ix builtin, [Arg Ix builtin]) ->
+  m (Expr Ix builtin)
 substApp p (fun@(Meta _ m), mArgs) = do
   metaSubst <- getMetaSubstitution
   case MetaMap.lookup m metaSubst of
     Just value -> subst =<< substArgs (unnormalised value) mArgs
     Nothing -> normAppList p fun <$> subst mArgs
   where
-    substArgs :: NormalisableExpr types -> [NormalisableArg types] -> m (NormalisableExpr types)
+    substArgs :: Expr Ix builtin -> [Arg Ix builtin] -> m (Expr Ix builtin)
     substArgs (Lam _ _ body) (arg : args) = do
       substArgs (argExpr arg `substDBInto` body) args
     substArgs e args = return $ normAppList p e args
 substApp p (fun, args) = normAppList p <$> subst fun <*> subst args
 
-instance (MonadNorm types m) => MetaSubstitutable m (Value types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (Value builtin) where
   subst expr = case expr of
     VMeta m args -> do
       metaSubst <- getMetaSubstitution
@@ -103,14 +104,14 @@ instance (MonadNorm types m) => MetaSubstitutable m (Value types) where
     VBoundVar v spine -> VBoundVar v <$> traverse subst spine
     VBuiltin b spine -> do
       spine' <- traverse subst spine
-      evalBuiltin b spine'
+      evalBuiltin evalApp b spine'
 
     -- NOTE: no need to lift the substitutions here as we're passing under the binders
     -- because by construction every meta-variable solution is a closed term.
     VLam binder env body -> VLam <$> subst binder <*> subst env <*> subst body
     VPi binder body -> VPi <$> subst binder <*> subst body
 
-instance (MonadNorm types m) => MetaSubstitutable m (GluedExpr types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (GluedExpr builtin) where
   subst (Glued a b) = Glued <$> subst a <*> subst b
 
 instance (MetaSubstitutable m expr) => MetaSubstitutable m (GenericDecl expr) where
@@ -119,23 +120,23 @@ instance (MetaSubstitutable m expr) => MetaSubstitutable m (GenericDecl expr) wh
 instance (MetaSubstitutable m expr) => MetaSubstitutable m (GenericProg expr) where
   subst (Main ds) = Main <$> traverse subst ds
 
-instance (MonadNorm types m) => MetaSubstitutable m (UnificationConstraint types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (UnificationConstraint builtin) where
   subst (Unify e1 e2) = Unify <$> subst e1 <*> subst e2
 
-instance (MonadNorm types m) => MetaSubstitutable m (TypeClassConstraint types) where
-  subst (Has m tc es) = Has m tc <$> subst es
+instance (MonadNorm builtin m) => MetaSubstitutable m (TypeClassConstraint builtin) where
+  subst (Has m e) = Has m <$> subst e
 
-instance (MonadNorm types m) => MetaSubstitutable m (Constraint types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (Constraint builtin) where
   subst = \case
     UnificationConstraint c -> UnificationConstraint <$> subst c
     TypeClassConstraint c -> TypeClassConstraint <$> subst c
 
-instance (MetaSubstitutable m constraint) => MetaSubstitutable m (Contextualised constraint (ConstraintContext types)) where
+instance (MetaSubstitutable m constraint) => MetaSubstitutable m (Contextualised constraint (ConstraintContext builtin)) where
   subst (WithContext constraint context) = do
     newConstraint <- subst constraint
     return $ WithContext newConstraint context
 
-instance (MonadNorm types m) => MetaSubstitutable m (ConstraintContext types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (ConstraintContext builtin) where
   subst ConstraintContext {..} = do
     substOrigin <- subst origin
     return $
@@ -144,15 +145,15 @@ instance (MonadNorm types m) => MetaSubstitutable m (ConstraintContext types) wh
           ..
         }
 
-instance (MonadNorm types m) => MetaSubstitutable m (ConstraintOrigin types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (ConstraintOrigin builtin) where
   subst = \case
     CheckingExprType e t1 t2 -> CheckingExprType <$> subst e <*> subst t1 <*> subst t2
     CheckingBinderType n t1 t2 -> CheckingBinderType n <$> subst t1 <*> subst t2
-    CheckingTypeClass op opArgs tc tcArgs -> CheckingTypeClass <$> subst op <*> subst opArgs <*> pure tc <*> subst tcArgs
+    CheckingTypeClass op opArgs tc -> CheckingTypeClass <$> subst op <*> subst opArgs <*> subst tc
     CheckingAuxiliary -> return CheckingAuxiliary
 
 instance (MetaSubstitutable m a) => MetaSubstitutable m (MetaMap a) where
   subst (MetaMap t) = MetaMap <$> traverse subst t
 
-instance (MonadNorm types m) => MetaSubstitutable m (MetaInfo types) where
+instance (MonadNorm builtin m) => MetaSubstitutable m (MetaInfo builtin) where
   subst (MetaInfo p t ctx) = MetaInfo p <$> subst t <*> pure ctx

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -45,34 +45,33 @@ where
 import Control.Monad (when)
 import Control.Monad.Except (MonadError (..), runExceptT)
 import Control.Monad.Trans.Except (ExceptT)
-import Data.List.NonEmpty qualified as NonEmpty
 import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Error (CompileError (..), compilerDeveloperError)
+import Vehicle.Compile.Normalise.Monad (MonadNorm)
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad.Class
 import Vehicle.Compile.Type.Monad.Instance
-import Vehicle.Expr.Normalisable
+import Vehicle.Expr.DeBruijn (Ix)
 import Vehicle.Expr.Normalised
 
 -- | The type-checking monad.
-type TCM types m =
-  ( MonadTypeChecker types m,
-    MonadNorm types m,
-    TypableBuiltin types
+type TCM builtin m =
+  ( MonadTypeChecker builtin m,
+    MonadNorm builtin m,
+    TypableBuiltin builtin
   )
 
-runTypeChecker :: (Monad m) => TypingDeclCtx types -> TypeCheckerT types m a -> m a
+runTypeChecker :: (Monad m) => TypingDeclCtx builtin -> TypeCheckerT builtin m a -> m a
 runTypeChecker declCtx e = fst <$> runTypeCheckerT declCtx emptyTypeCheckerState e
 
 -- | Runs a hypothetical computation in the type-checker,
 -- returning the resulting state of the type-checker.
 runTypeCheckerHypothetically ::
-  (TCM types m) =>
-  TypeCheckerT types (ExceptT CompileError m) a ->
-  m (Either CompileError (a, TypeCheckerState types))
+  (TCM builtin m) =>
+  TypeCheckerT builtin (ExceptT CompileError m) a ->
+  m (Either CompileError (a, TypeCheckerState builtin))
 runTypeCheckerHypothetically e = do
   callDepth <- getCallDepth
   declCtx <- getDeclContext
@@ -88,68 +87,62 @@ runTypeCheckerHypothetically e = do
         return $ Left err
 
 -- | Accepts the hypothetical outcome of the type-checker.
-adoptHypotheticalState :: (TCM types m) => TypeCheckerState types -> m ()
+adoptHypotheticalState :: (TCM builtin m) => TypeCheckerState builtin -> m ()
 adoptHypotheticalState = modifyMetaCtx . const
 
 freshMetaIdAndExpr ::
-  forall types m.
-  (TCM types m) =>
+  forall builtin m.
+  (TCM builtin m) =>
   Provenance ->
-  NormalisableType types ->
-  TypingBoundCtx types ->
-  m (MetaID, GluedExpr types)
+  Type Ix builtin ->
+  TypingBoundCtx builtin ->
+  m (MetaID, GluedExpr builtin)
 freshMetaIdAndExpr p t boundCtx = do
-  let ctx = if useDependentMetas (Proxy @types) then boundCtx else mempty
+  let ctx = if useDependentMetas (Proxy @builtin) then boundCtx else mempty
   freshMeta p t ctx
 
 freshMetaExpr ::
-  forall types m.
-  (TCM types m) =>
+  forall builtin m.
+  (TCM builtin m) =>
   Provenance ->
-  NormalisableType types ->
-  TypingBoundCtx types ->
-  m (GluedExpr types)
+  Type Ix builtin ->
+  TypingBoundCtx builtin ->
+  m (GluedExpr builtin)
 freshMetaExpr p t boundCtx = snd <$> freshMetaIdAndExpr p t boundCtx
 
 -- | Adds an entirely new type-class constraint (as opposed to one
 -- derived from another constraint).
 createFreshTypeClassConstraint ::
-  forall types m.
-  (TCM types m) =>
-  TypingBoundCtx types ->
-  (NormalisableExpr types, [NormalisableArg types]) ->
-  NormalisableType types ->
-  m (GluedExpr types)
+  forall builtin m.
+  (TCM builtin m) =>
+  TypingBoundCtx builtin ->
+  (Expr Ix builtin, [Arg Ix builtin]) ->
+  Type Ix builtin ->
+  m (GluedExpr builtin)
 createFreshTypeClassConstraint boundCtx (fun, funArgs) tcExpr = do
-  (tc, tcArgs) <- case tcExpr of
-    BuiltinExpr _ (CType tc) args -> return (tc, NonEmpty.toList args)
-    _ ->
-      compilerDeveloperError $
-        "Malformed type class constraint" <+> prettyVerbose tcExpr
-
   let env = typingBoundContextToEnv boundCtx
-  nArgs <- traverse (traverse (whnf env)) tcArgs
 
   let p = provenanceOf fun
   (meta, metaExpr) <- freshMetaIdAndExpr p tcExpr boundCtx
 
-  let origin = CheckingTypeClass fun funArgs tc tcArgs
+  let origin = CheckingTypeClass fun funArgs tcExpr
   let originProvenance = provenanceOf tcExpr
-  cid <- generateFreshConstraintID (Proxy @types)
+  cid <- generateFreshConstraintID (Proxy @builtin)
   let context = ConstraintContext cid originProvenance origin p unknownBlockingStatus boundCtx
-  let constraint = WithContext (Has meta tc (fmap argExpr nArgs)) context
+  nTCExpr <- whnf env tcExpr
+  let constraint = WithContext (Has meta nTCExpr) context
 
   addTypeClassConstraints [constraint]
 
   return metaExpr
 
 instantiateArgForNonExplicitBinder ::
-  (TCM types m) =>
-  TypingBoundCtx types ->
+  (TCM builtin m) =>
+  TypingBoundCtx builtin ->
   Provenance ->
-  (NormalisableExpr types, [NormalisableArg types]) ->
-  NormalisableBinder types ->
-  m (GluedArg types)
+  (Expr Ix builtin, [Arg Ix builtin]) ->
+  Binder Ix builtin ->
+  m (GluedArg builtin)
 instantiateArgForNonExplicitBinder boundCtx p origin binder = do
   let binderType = typeOf binder
   checkedExpr <- case visibilityOf binder of
@@ -158,7 +151,7 @@ instantiateArgForNonExplicitBinder boundCtx p origin binder = do
     Instance {} -> createFreshTypeClassConstraint boundCtx origin binderType
   return $ Arg p (markInserted $ visibilityOf binder) (relevanceOf binder) checkedExpr
 
-debugError :: forall types m. (TCM types m) => Proxy types -> Int -> m ()
+debugError :: forall builtin m. (TCM builtin m) => Proxy builtin -> Int -> m ()
 debugError _ limit = do
-  idd <- generateFreshConstraintID (Proxy @types)
+  idd <- generateFreshConstraintID (Proxy @builtin)
   when (idd > limit) $ compilerDeveloperError "Hi"

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -9,9 +9,11 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Error (MonadCompile, compilerDeveloperError)
+import Vehicle.Compile.Normalise.Builtin (Normalisable)
+import Vehicle.Compile.Normalise.Monad
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Print (prettyExternal, prettyFriendly, prettyVerbose)
+import Vehicle.Compile.Print (PrintableBuiltin, prettyExternal, prettyFriendly, prettyVerbose)
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta
   ( HasMetas (..),
@@ -24,7 +26,7 @@ import Vehicle.Compile.Type.Meta.Set (MetaSet)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Compile.Type.Meta.Substitution
 import Vehicle.Compile.Type.Subsystem.Standard.Core
-import Vehicle.Expr.Normalisable
+import Vehicle.Expr.DeBruijn (Ix)
 import Vehicle.Expr.Normalised
 
 --------------------------------------------------------------------------------
@@ -63,19 +65,19 @@ exitSolvedMetaTrackingRegion (SolvedMetaState state) = SolvedMetaState $
 type FreshNameState = Int
 
 -- | The meta-variables and constraints relating the variables currently in scope.
-data TypeCheckerState types = TypeCheckerState
+data TypeCheckerState builtin = TypeCheckerState
   { -- | The origin and type of each meta variable.
     -- NB: these are stored in *reverse* order from which they were created.
-    metaInfo :: [MetaInfo types],
-    currentSubstitution :: MetaSubstitution types,
-    unificationConstraints :: [WithContext (UnificationConstraint types)],
-    typeClassConstraints :: [WithContext (TypeClassConstraint types)],
+    metaInfo :: [MetaInfo builtin],
+    currentSubstitution :: MetaSubstitution builtin,
+    unificationConstraints :: [WithContext (UnificationConstraint builtin)],
+    typeClassConstraints :: [WithContext (TypeClassConstraint builtin)],
     freshNameState :: FreshNameState,
     solvedMetaState :: SolvedMetaState,
     nextConstraintID :: ConstraintID
   }
 
-emptyTypeCheckerState :: TypeCheckerState types
+emptyTypeCheckerState :: TypeCheckerState builtin
 emptyTypeCheckerState =
   TypeCheckerState
     { metaInfo = mempty,
@@ -91,15 +93,15 @@ emptyTypeCheckerState =
 -- The type-checking monad class
 
 -- | The type-checking monad.
-class (MonadCompile m, MonadNorm types m) => MonadTypeChecker types m where
-  getDeclContext :: m (TypingDeclCtx types)
-  addDeclContext :: GluedDecl types -> m a -> m a
-  getMetaState :: m (TypeCheckerState types)
-  modifyMetaCtx :: (TypeCheckerState types -> TypeCheckerState types) -> m ()
-  getFreshName :: NormalisableType types -> m Name
-  clearFreshNames :: Proxy types -> m ()
+class (MonadCompile m, MonadNorm builtin m) => MonadTypeChecker builtin m where
+  getDeclContext :: m (TypingDeclCtx builtin)
+  addDeclContext :: GluedDecl builtin -> m a -> m a
+  getMetaState :: m (TypeCheckerState builtin)
+  modifyMetaCtx :: (TypeCheckerState builtin -> TypeCheckerState builtin) -> m ()
+  getFreshName :: Type Ix builtin -> m Name
+  clearFreshNames :: Proxy builtin -> m ()
 
-instance (Monoid w, MonadTypeChecker types m) => MonadTypeChecker types (WriterT w m) where
+instance (Monoid w, MonadTypeChecker builtin m) => MonadTypeChecker builtin (WriterT w m) where
   getDeclContext = lift getDeclContext
   addDeclContext d = mapWriterT (addDeclContext d)
   getMetaState = lift getMetaState
@@ -107,7 +109,7 @@ instance (Monoid w, MonadTypeChecker types m) => MonadTypeChecker types (WriterT
   getFreshName = lift . getFreshName
   clearFreshNames = lift . clearFreshNames
 
-instance (Monoid w, MonadTypeChecker types m) => MonadTypeChecker types (ReaderT w m) where
+instance (Monoid w, MonadTypeChecker builtin m) => MonadTypeChecker builtin (ReaderT w m) where
   getDeclContext = lift getDeclContext
   addDeclContext d = mapReaderT (addDeclContext d)
   getMetaState = lift getMetaState
@@ -115,7 +117,7 @@ instance (Monoid w, MonadTypeChecker types m) => MonadTypeChecker types (ReaderT
   getFreshName = lift . getFreshName
   clearFreshNames = lift . clearFreshNames
 
-instance (MonadTypeChecker types m) => MonadTypeChecker types (StateT s m) where
+instance (MonadTypeChecker builtin m) => MonadTypeChecker builtin (StateT s m) where
   getDeclContext = lift getDeclContext
   addDeclContext d = mapStateT (addDeclContext d)
   getMetaState = lift getMetaState
@@ -127,95 +129,92 @@ instance (MonadTypeChecker types m) => MonadTypeChecker types (StateT s m) where
 -- Abstract interface for a type system.
 
 -- | A class that provides an abstract interface for a set of builtins.
-class (PrintableBuiltin types) => TypableBuiltin types where
+class (PrintableBuiltin builtin, Normalisable builtin) => TypableBuiltin builtin where
   convertFromStandardTypes ::
-    (MonadTypeChecker types m) =>
-    Provenance ->
-    StandardBuiltinType ->
-    [NormalisableArg types] ->
-    m (NormalisableExpr types)
+    (MonadTypeChecker builtin m) =>
+    BuiltinUpdate m Ix StandardBuiltin builtin
 
   -- | Can meta-variables be dependent on their context?
-  useDependentMetas :: Proxy types -> Bool
+  useDependentMetas :: Proxy builtin -> Bool
 
   -- | Construct a type for the builtin
   typeBuiltin ::
-    Provenance -> NormalisableBuiltin types -> NormalisableType types
+    Provenance -> builtin -> Type Ix builtin
 
   restrictNetworkType ::
-    (MonadTypeChecker types m) =>
+    (MonadTypeChecker builtin m) =>
     DeclProvenance ->
-    GluedType types ->
-    m (NormalisableType types)
+    GluedType builtin ->
+    m (Type Ix builtin)
 
   restrictDatasetType ::
-    (MonadTypeChecker types m) =>
+    (MonadTypeChecker builtin m) =>
     DeclProvenance ->
-    GluedType types ->
-    m (NormalisableType types)
+    GluedType builtin ->
+    m (Type Ix builtin)
 
   restrictParameterType ::
-    (MonadTypeChecker types m) =>
+    (MonadTypeChecker builtin m) =>
     ParameterSort ->
     DeclProvenance ->
-    GluedType types ->
-    m (NormalisableType types)
+    GluedType builtin ->
+    m (Type Ix builtin)
 
   restrictPropertyType ::
-    (MonadTypeChecker types m) =>
+    (MonadTypeChecker builtin m) =>
     DeclProvenance ->
-    GluedType types ->
+    GluedType builtin ->
     m ()
 
-  typeClassRelevancy :: (MonadCompile m) => types -> m Relevance
+  typeClassRelevancy :: (MonadCompile m) => Value builtin -> m Relevance
 
   addAuxiliaryInputOutputConstraints ::
-    (MonadTypeChecker types m) => NormalisableDecl types -> m (NormalisableDecl types)
+    (MonadTypeChecker builtin m) => Decl Ix builtin -> m (Decl Ix builtin)
 
   generateDefaultConstraint ::
-    (MonadTypeChecker types m) =>
-    Maybe (NormalisableDecl types) ->
+    (MonadTypeChecker builtin m) =>
+    Maybe (Decl Ix builtin) ->
     m Bool
 
   -- | Solves a type-class constraint
   solveInstance ::
-    (MonadNorm types m, MonadTypeChecker types m) => WithContext (TypeClassConstraint types) -> m ()
+    (MonadNorm builtin m, MonadTypeChecker builtin m) => WithContext (TypeClassConstraint builtin) -> m ()
 
   handleTypingError ::
-    (MonadCompile m) => TypingError types -> m a
+    (MonadCompile m) => TypingError builtin -> m a
 
 --------------------------------------------------------------------------------
 -- Operations
 
-getsMetaCtx :: (MonadTypeChecker types m) => (TypeCheckerState types -> a) -> m a
+getsMetaCtx :: (MonadTypeChecker builtin m) => (TypeCheckerState builtin -> a) -> m a
 getsMetaCtx f = f <$> getMetaState
 
-getNumberOfMetasCreated :: forall types m. (MonadTypeChecker types m) => Proxy types -> m Int
-getNumberOfMetasCreated _ = getsMetaCtx @types (length . metaInfo)
+getNumberOfMetasCreated :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m Int
+getNumberOfMetasCreated _ = getsMetaCtx @builtin (length . metaInfo)
 
 -- | Track the metas solved while performing the provided computation.
 -- Multiple calls can be nested arbitrarily deepily.
-trackSolvedMetas :: forall types m. (MonadTypeChecker types m) => Proxy types -> m () -> m MetaSet
+trackSolvedMetas :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m () -> m MetaSet
 trackSolvedMetas _ performComputation = do
   modifySolvedMetaState enterSolvedMetaTrackingRegion
 
   performComputation
 
-  solvedMetas <- getsMetaCtx @types (getMostRecentlySolvedMetas . solvedMetaState)
+  solvedMetas <- getsMetaCtx @builtin (getMostRecentlySolvedMetas . solvedMetaState)
   modifySolvedMetaState exitSolvedMetaTrackingRegion
 
   return solvedMetas
   where
     modifySolvedMetaState :: (SolvedMetaState -> SolvedMetaState) -> m ()
-    modifySolvedMetaState f = modifyMetaCtx @types $ \TypeCheckerState {..} ->
+    modifySolvedMetaState f = modifyMetaCtx @builtin $ \TypeCheckerState {..} ->
       TypeCheckerState
         { solvedMetaState = f solvedMetaState,
           ..
         }
 
-getUnsolvedMetas :: forall types m. (MonadTypeChecker types m) => Proxy types -> m MetaSet
+getUnsolvedMetas :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m MetaSet
 getUnsolvedMetas proxy = do
-  metasSolved <- MetaMap.keys <$> getMetaSubstitution @types
+  metasSolved <- MetaMap.keys <$> getMetaSubstitution @builtin
   numberOfMetasCreated <- getNumberOfMetasCreated proxy
   let metasCreated = MetaSet.fromList $ fmap MetaID [0 .. numberOfMetasCreated - 1]
   return $ MetaSet.difference metasCreated metasSolved
@@ -231,11 +230,11 @@ getUnsolvedMetas proxy = do
 -- It returns the name of the meta and the expression of it applied to every
 -- variable in the context.
 freshMeta ::
-  (MonadTypeChecker types m) =>
+  (MonadTypeChecker builtin m) =>
   Provenance ->
-  NormalisableType types ->
-  TypingBoundCtx types ->
-  m (MetaID, GluedExpr types)
+  Type Ix builtin ->
+  TypingBoundCtx builtin ->
+  m (MetaID, GluedExpr builtin)
 freshMeta p metaType boundCtx = do
   -- Create a fresh id for the meta
   TypeCheckerState {..} <- getMetaState
@@ -260,9 +259,9 @@ freshMeta p metaType boundCtx = do
 
 -- | Ensures the meta has no dependencies on the bound context. Returns true
 -- if dependencies were removed to achieve this.
-removeMetaDependencies :: forall types m. (MonadTypeChecker types m) => Proxy types -> MetaID -> m Bool
+removeMetaDependencies :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> MetaID -> m Bool
 removeMetaDependencies _ m = do
-  MetaInfo p t ctx <- getMetaInfo @types m
+  MetaInfo p t ctx <- getMetaInfo @builtin m
   if null ctx
     then return False
     else do
@@ -273,7 +272,7 @@ removeMetaDependencies _ m = do
 --------------------------------------------------------------------------------
 -- Meta information retrieval
 
-getMetaInfo :: (MonadTypeChecker types m) => MetaID -> m (MetaInfo types)
+getMetaInfo :: (MonadTypeChecker builtin m) => MetaID -> m (MetaInfo builtin)
 getMetaInfo m = do
   TypeCheckerState {..} <- getMetaState
   case metaInfo !!? getMetaIndex metaInfo m of
@@ -282,23 +281,23 @@ getMetaInfo m = do
       compilerDeveloperError $
         "Requesting info for unknown meta" <+> pretty m <+> "not in context"
 
-getMetaIndex :: [MetaInfo types] -> MetaID -> Int
+getMetaIndex :: [MetaInfo builtin] -> MetaID -> Int
 getMetaIndex metaInfo (MetaID m) = length metaInfo - m - 1
 
-getMetaProvenance :: forall types m. (MonadTypeChecker types m) => Proxy types -> MetaID -> m Provenance
-getMetaProvenance _ m = metaProvenance <$> getMetaInfo @types m
+getMetaProvenance :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> MetaID -> m Provenance
+getMetaProvenance _ m = metaProvenance <$> getMetaInfo @builtin m
 
-getMetaType :: (MonadTypeChecker types m) => MetaID -> m (NormalisableType types)
+getMetaType :: (MonadTypeChecker builtin m) => MetaID -> m (Type Ix builtin)
 getMetaType m = metaType <$> getMetaInfo m
 
-getSubstMetaType :: (MonadTypeChecker types m) => MetaID -> m (NormalisableType types)
+getSubstMetaType :: (MonadTypeChecker builtin m) => MetaID -> m (Type Ix builtin)
 getSubstMetaType m = substMetas =<< getMetaType m
 
 -- | Get the bound context the meta-variable was created in.
-getMetaCtx :: (MonadTypeChecker types m) => MetaID -> m (TypingBoundCtx types)
+getMetaCtx :: (MonadTypeChecker builtin m) => MetaID -> m (TypingBoundCtx builtin)
 getMetaCtx m = metaCtx <$> getMetaInfo m
 
-extendBoundCtxOfMeta :: (MonadTypeChecker types m) => MetaID -> NormalisableBinder types -> m ()
+extendBoundCtxOfMeta :: (MonadTypeChecker builtin m) => MetaID -> Binder Ix builtin -> m ()
 extendBoundCtxOfMeta m binder =
   modifyMetaCtx
     ( \TypeCheckerState {..} -> do
@@ -315,28 +314,28 @@ extendBoundCtxOfMeta m binder =
               }
     )
 
-clearMetaSubstitution :: forall types m. (MonadTypeChecker types m) => Proxy types -> m ()
-clearMetaSubstitution _ = modifyMetaCtx @types $ \TypeCheckerState {..} ->
+clearMetaSubstitution :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m ()
+clearMetaSubstitution _ = modifyMetaCtx @builtin $ \TypeCheckerState {..} ->
   TypeCheckerState {currentSubstitution = mempty, ..}
 
-getSubstMetaTypes :: (MonadTypeChecker types m) => MetaSet -> m [(MetaID, NormalisableType types)]
+getSubstMetaTypes :: (MonadTypeChecker builtin m) => MetaSet -> m [(MetaID, Type Ix builtin)]
 getSubstMetaTypes metas = traverse (\m -> (m,) <$> getSubstMetaType m) (MetaSet.toList metas)
 
 -- | Computes the set of all metas that are related via constraints to the
 -- metas in the provided expression as long as the types of those metas
 -- satisfy the provided predicate.
 getMetasLinkedToMetasIn ::
-  forall types m.
-  (MonadTypeChecker types m) =>
-  [WithContext (Constraint types)] ->
-  NormalisableType types ->
+  forall builtin m.
+  (MonadTypeChecker builtin m) =>
+  [WithContext (Constraint builtin)] ->
+  Type Ix builtin ->
   m MetaSet
 getMetasLinkedToMetasIn allConstraints typeOfInterest = do
   let constraints = fmap objectIn allConstraints
   metasInType <- metasIn typeOfInterest
   loopOverConstraints constraints metasInType
   where
-    loopOverConstraints :: [Constraint types] -> MetaSet -> m MetaSet
+    loopOverConstraints :: [Constraint builtin] -> MetaSet -> m MetaSet
     loopOverConstraints constraints metas = do
       (unrelatedConstraints, newMetas) <- foldM processConstraint ([], metas) constraints
       if metas /= newMetas
@@ -344,9 +343,9 @@ getMetasLinkedToMetasIn allConstraints typeOfInterest = do
         else return metas
 
     processConstraint ::
-      ([Constraint types], MetaSet) ->
-      Constraint types ->
-      m ([Constraint types], MetaSet)
+      ([Constraint builtin], MetaSet) ->
+      Constraint builtin ->
+      m ([Constraint builtin], MetaSet)
     processConstraint (nonRelatedConstraints, typeMetas) constraint = do
       constraintMetas <- metasIn constraint
       return $
@@ -354,7 +353,7 @@ getMetasLinkedToMetasIn allConstraints typeOfInterest = do
           then (constraint : nonRelatedConstraints, typeMetas)
           else (nonRelatedConstraints, MetaSet.unions [constraintMetas, typeMetas])
 
-abstractOverCtx :: TypingBoundCtx types -> NormalisableExpr types -> NormalisableExpr types
+abstractOverCtx :: TypingBoundCtx builtin -> Expr Ix builtin -> Expr Ix builtin
 abstractOverCtx ctx body = do
   let p = mempty
   let lamBinderForm (n, _) = BinderDisplayForm (OnlyName (fromMaybe "_" n)) True
@@ -364,7 +363,13 @@ abstractOverCtx ctx body = do
   let lam i@(_, _t) = Lam p (Binder p (lamBinderForm i) Explicit Relevant (TypeUniverse p 0))
   foldr lam body (reverse ctx)
 
-solveMeta :: forall types m. (MonadTypeChecker types m) => MetaID -> NormalisableExpr types -> TypingBoundCtx types -> m ()
+solveMeta ::
+  forall builtin m.
+  (MonadTypeChecker builtin m) =>
+  MetaID ->
+  Expr Ix builtin ->
+  TypingBoundCtx builtin ->
+  m ()
 solveMeta m solution solutionCtx = do
   MetaInfo p _ metaCtx <- getMetaInfo m
   let abstractedSolution = abstractOverCtx metaCtx solution
@@ -378,7 +383,7 @@ solveMeta m solution solutionCtx = do
       <+> prettyExternal (WithContext abstractedSolution (boundContextOf solutionCtx))
   -- "as" <+> prettyFriendly (WithContext abstractedSolution (boundContextOf ctx))
 
-  metaSubst <- getMetaSubstitution @types
+  metaSubst <- getMetaSubstitution @builtin
   case MetaMap.lookup m metaSubst of
     Just existing ->
       compilerDeveloperError $
@@ -404,24 +409,24 @@ solveMeta m solution solutionCtx = do
             ..
           }
 
-prettyMetas :: forall types m a. (MonadTypeChecker types m) => Proxy types -> MetaSet -> m (Doc a)
+prettyMetas :: forall builtin m a. (MonadTypeChecker builtin m) => Proxy builtin -> MetaSet -> m (Doc a)
 prettyMetas _ metas = do
-  typedMetaList <- getSubstMetaTypes @types metas
+  typedMetaList <- getSubstMetaTypes @builtin metas
   let docs = fmap (uncurry prettyMetaInternal) typedMetaList
   return $ prettySetLike docs
 
-prettyMeta :: forall types m a. (MonadTypeChecker types m) => Proxy types -> MetaID -> m (Doc a)
-prettyMeta _ meta = prettyMetaInternal meta <$> getMetaType @types meta
+prettyMeta :: forall builtin m a. (MonadTypeChecker builtin m) => Proxy builtin -> MetaID -> m (Doc a)
+prettyMeta _ meta = prettyMetaInternal meta <$> getMetaType @builtin meta
 
-prettyMetaInternal :: (PrintableBuiltin types) => MetaID -> NormalisableType types -> Doc a
+prettyMetaInternal :: (PrintableBuiltin builtin) => MetaID -> Type Ix builtin -> Doc a
 prettyMetaInternal m t = pretty m <+> ":" <+> prettyVerbose t
 
-clearMetaCtx :: forall types m. (MonadTypeChecker types m) => Proxy types -> m ()
+clearMetaCtx :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m ()
 clearMetaCtx _ = do
   logDebug MaxDetail "Clearing meta-variable context"
-  modifyMetaCtx @types (const emptyTypeCheckerState)
+  modifyMetaCtx @builtin (const emptyTypeCheckerState)
 
-getDeclType :: (MonadTypeChecker types m) => Provenance -> Identifier -> m (NormalisableType types)
+getDeclType :: (MonadTypeChecker builtin m) => Provenance -> Identifier -> m (Type Ix builtin)
 getDeclType p ident = do
   ctx <- getDeclContext
   case Map.lookup ident ctx of
@@ -441,46 +446,46 @@ getDeclType p ident = do
 --------------------------------------------------------------------------------
 -- Constraints
 
-generateFreshConstraintID :: forall types m. (MonadTypeChecker types m) => Proxy types -> m ConstraintID
+generateFreshConstraintID :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m ConstraintID
 generateFreshConstraintID _ = do
-  freshID <- getsMetaCtx @types nextConstraintID
-  modifyMetaCtx @types $ \TypeCheckerState {..} ->
+  freshID <- getsMetaCtx @builtin nextConstraintID
+  modifyMetaCtx @builtin $ \TypeCheckerState {..} ->
     TypeCheckerState {nextConstraintID = nextConstraintID + 1, ..}
   return freshID
 
-getActiveConstraints :: (MonadTypeChecker types m) => m [WithContext (Constraint types)]
+getActiveConstraints :: (MonadTypeChecker builtin m) => m [WithContext (Constraint builtin)]
 getActiveConstraints = do
   us <- fmap (mapObject UnificationConstraint) <$> getActiveUnificationConstraints
   ts <- fmap (mapObject TypeClassConstraint) <$> getActiveTypeClassConstraints
   return $ us <> ts
 
-getActiveUnificationConstraints :: (MonadTypeChecker types m) => m [WithContext (UnificationConstraint types)]
+getActiveUnificationConstraints :: (MonadTypeChecker builtin m) => m [WithContext (UnificationConstraint builtin)]
 getActiveUnificationConstraints = getsMetaCtx unificationConstraints
 
-getActiveTypeClassConstraints :: (MonadTypeChecker types m) => m [WithContext (TypeClassConstraint types)]
+getActiveTypeClassConstraints :: (MonadTypeChecker builtin m) => m [WithContext (TypeClassConstraint builtin)]
 getActiveTypeClassConstraints = getsMetaCtx typeClassConstraints
 
-setConstraints :: (MonadTypeChecker types m) => [WithContext (Constraint types)] -> m ()
+setConstraints :: (MonadTypeChecker builtin m) => [WithContext (Constraint builtin)] -> m ()
 setConstraints constraints = do
   let (us, ts) = separateConstraints constraints
   setUnificationConstraints us
   setTypeClassConstraints ts
 
-setTypeClassConstraints :: (MonadTypeChecker types m) => [WithContext (TypeClassConstraint types)] -> m ()
+setTypeClassConstraints :: (MonadTypeChecker builtin m) => [WithContext (TypeClassConstraint builtin)] -> m ()
 setTypeClassConstraints newConstraints = modifyMetaCtx $ \TypeCheckerState {..} ->
   TypeCheckerState {typeClassConstraints = newConstraints, ..}
 
-setUnificationConstraints :: (MonadTypeChecker types m) => [WithContext (UnificationConstraint types)] -> m ()
+setUnificationConstraints :: (MonadTypeChecker builtin m) => [WithContext (UnificationConstraint builtin)] -> m ()
 setUnificationConstraints newConstraints = modifyMetaCtx $ \TypeCheckerState {..} ->
   TypeCheckerState {unificationConstraints = newConstraints, ..}
 
-addConstraints :: (MonadTypeChecker types m) => [WithContext (Constraint types)] -> m ()
+addConstraints :: (MonadTypeChecker builtin m) => [WithContext (Constraint builtin)] -> m ()
 addConstraints constraints = do
   let (us, ts) = separateConstraints constraints
   addUnificationConstraints us
   addTypeClassConstraints ts
 
-addUnificationConstraints :: (MonadTypeChecker types m) => [WithContext (UnificationConstraint types)] -> m ()
+addUnificationConstraints :: (MonadTypeChecker builtin m) => [WithContext (UnificationConstraint builtin)] -> m ()
 addUnificationConstraints constraints = do
   unless (null constraints) $ do
     logDebug MaxDetail ("add-constraints " <> align (prettyExternal constraints))
@@ -488,7 +493,7 @@ addUnificationConstraints constraints = do
   modifyMetaCtx $ \TypeCheckerState {..} ->
     TypeCheckerState {unificationConstraints = unificationConstraints ++ constraints, ..}
 
-addTypeClassConstraints :: (MonadTypeChecker types m) => [WithContext (TypeClassConstraint types)] -> m ()
+addTypeClassConstraints :: (MonadTypeChecker builtin m) => [WithContext (TypeClassConstraint builtin)] -> m ()
 addTypeClassConstraints constraints = do
   unless (null constraints) $ do
     logDebug MaxDetail ("add-constraints " <> align (prettyExternal constraints))
@@ -499,19 +504,19 @@ addTypeClassConstraints constraints = do
 -- | Adds an entirely new unification constraint (as opposed to one
 -- derived from another constraint).
 createFreshUnificationConstraint ::
-  forall types m.
-  (MonadTypeChecker types m) =>
+  forall builtin m.
+  (MonadTypeChecker builtin m) =>
   Provenance ->
-  TypingBoundCtx types ->
-  ConstraintOrigin types ->
-  NormalisableType types ->
-  NormalisableType types ->
+  TypingBoundCtx builtin ->
+  ConstraintOrigin builtin ->
+  Type Ix builtin ->
+  Type Ix builtin ->
   m ()
 createFreshUnificationConstraint p ctx origin expectedType actualType = do
   let env = typingBoundContextToEnv ctx
   normExpectedType <- whnf env expectedType
   normActualType <- whnf env actualType
-  cid <- generateFreshConstraintID (Proxy @types)
+  cid <- generateFreshConstraintID (Proxy @builtin)
   let context = ConstraintContext cid p origin p unknownBlockingStatus ctx
   let unification = Unify normExpectedType normActualType
   let constraint = WithContext unification context
@@ -519,19 +524,19 @@ createFreshUnificationConstraint p ctx origin expectedType actualType = do
   addUnificationConstraints [constraint]
 
 -- | Create a new fresh copy of the context for a new constraint
-copyContext :: forall types m. (MonadTypeChecker types m) => ConstraintContext types -> m (ConstraintContext types)
+copyContext :: forall builtin m. (MonadTypeChecker builtin m) => ConstraintContext builtin -> m (ConstraintContext builtin)
 copyContext (ConstraintContext _cid originProv originalConstraint creationProv _blockingStatus ctx) = do
-  freshID <- generateFreshConstraintID (Proxy @types)
+  freshID <- generateFreshConstraintID (Proxy @builtin)
   return $ ConstraintContext freshID originProv originalConstraint creationProv unknownBlockingStatus ctx
 
 --------------------------------------------------------------------------------
 -- Constraints
 --------------------------------------------------------------------------------
 
-getBinderNameOrFreshName :: (MonadTypeChecker types m) => Maybe Name -> NormalisableType types -> m Name
+getBinderNameOrFreshName :: (MonadTypeChecker builtin m) => Maybe Name -> Type Ix builtin -> m Name
 getBinderNameOrFreshName piName typ = case piName of
   Just x -> return x
   Nothing -> getFreshName typ
 
-glueNBE :: (MonadNorm types m) => Env types -> NormalisableExpr types -> m (GluedExpr types)
+glueNBE :: (MonadNorm builtin m) => Env builtin -> Expr Ix builtin -> m (GluedExpr builtin)
 glueNBE env e = Glued e <$> whnf env e

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/InputOutputInsertion.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/InputOutputInsertion.hs
@@ -8,7 +8,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Meta.Map (MetaMap (..))
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Monad (TCM, createFreshTypeClassConstraint, freshMetaExpr)
-import Vehicle.Expr.Normalisable
+import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 
 -------------------------------------------------------------------------------
@@ -19,10 +19,10 @@ import Vehicle.Expr.Normalised
 -- meta variables, and then relates the the two by adding a new suitable
 -- constraint.
 addFunctionAuxiliaryInputOutputConstraints ::
-  (TCM types m) =>
-  (FunctionPosition -> types) ->
-  NormalisableDecl types ->
-  m (NormalisableDecl types)
+  (TCM builtin m) =>
+  (FunctionPosition -> builtin) ->
+  Decl Ix builtin ->
+  m (Decl Ix builtin)
 addFunctionAuxiliaryInputOutputConstraints mkConstraint = \case
   DefFunction p ident anns t e -> do
     logCompilerPass MaxDetail "insertion of input/output constraints" $ do
@@ -31,12 +31,12 @@ addFunctionAuxiliaryInputOutputConstraints mkConstraint = \case
   d -> return d
 
 decomposePiType ::
-  (TCM types m, MonadState (MetaMap (NormalisableExpr types)) m) =>
-  (FunctionPosition -> types) ->
+  (TCM builtin m, MonadState (MetaMap (Expr Ix builtin)) m) =>
+  (FunctionPosition -> builtin) ->
   DeclProvenance ->
   Int ->
-  NormalisableType types ->
-  m (NormalisableType types)
+  Type Ix builtin ->
+  m (Type Ix builtin)
 decomposePiType mkConstraint declProv@(ident, p) inputNumber = \case
   Pi p' binder res
     | isExplicit binder -> do
@@ -54,11 +54,11 @@ decomposePiType mkConstraint declProv@(ident, p) inputNumber = \case
     addFunctionConstraint mkConstraint (p, position) outputType
 
 addFunctionConstraint ::
-  (TCM types m, MonadState (MetaMap (NormalisableExpr types)) m) =>
-  (FunctionPosition -> types) ->
+  (TCM builtin m, MonadState (MetaMap (Expr Ix builtin)) m) =>
+  (FunctionPosition -> builtin) ->
   (Provenance, FunctionPosition) ->
-  NormalisableExpr types ->
-  m (NormalisableExpr types)
+  Expr Ix builtin ->
+  m (Expr Ix builtin)
 addFunctionConstraint mkConstraint (declProv, position) existingExpr = do
   let p = provenanceOf existingExpr
   newExpr <- case existingExpr of
@@ -76,7 +76,7 @@ addFunctionConstraint mkConstraint (declProv, position) existingExpr = do
         ExplicitArg p <$> case position of
           FunctionInput {} -> [newExpr, existingExpr]
           FunctionOutput {} -> [existingExpr, newExpr]
-  let tcExpr = BuiltinExpr declProv (CType $ mkConstraint position) constraintArgs
+  let tcExpr = BuiltinExpr declProv (mkConstraint position) constraintArgs
 
   _ <- createFreshTypeClassConstraint mempty (existingExpr, mempty) tcExpr
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity.hs
@@ -5,21 +5,29 @@ module Vehicle.Compile.Type.Subsystem.Linearity
   )
 where
 
-import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Normalise.Builtin (Normalisable (..))
+import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.InputOutputInsertion
 import Vehicle.Compile.Type.Subsystem.Linearity.AnnotationRestrictions (assertConstantLinearity, checkNetworkType)
 import Vehicle.Compile.Type.Subsystem.Linearity.Core as Core
 import Vehicle.Compile.Type.Subsystem.Linearity.LinearitySolver
 import Vehicle.Compile.Type.Subsystem.Linearity.Type
+import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
+import Vehicle.Expr.Normalised (Value (..))
 import Vehicle.Prelude
 import Vehicle.Syntax.AST
 
 instance PrintableBuiltin LinearityType where
   convertBuiltin = convertFromLinearityTypes
-  isTypeClassOp = const False
 
-instance TypableBuiltin LinearityType where
+instance Normalisable LinearityType where
+  evalBuiltin _ l spine = return $ VBuiltin l spine
+  isValue = return True
+  isTypeClassOp = const False
+  forceBuiltin _ _ _ _ = return (Nothing, mempty)
+
+instance TypableBuiltin LinearityBuiltin where
   convertFromStandardTypes = convertToLinearityTypes
   useDependentMetas _ = False
   typeBuiltin = typeLinearityBuiltin
@@ -30,7 +38,7 @@ instance TypableBuiltin LinearityType where
   handleTypingError = handleLinearityTypingError
   typeClassRelevancy = const $ return Relevant
   solveInstance = solveLinearityConstraint
-  addAuxiliaryInputOutputConstraints = addFunctionAuxiliaryInputOutputConstraints (LinearityTypeClass . FunctionLinearity)
+  addAuxiliaryInputOutputConstraints = addFunctionAuxiliaryInputOutputConstraints (CType . LinearityTypeClass . FunctionLinearity)
   generateDefaultConstraint = const $ return False
 
 -------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/AnnotationRestrictions.hs
@@ -10,15 +10,16 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Linearity.Core
+import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 
 checkNetworkType ::
   forall m.
-  (MonadTypeChecker LinearityType m) =>
+  (MonadTypeChecker LinearityBuiltin m) =>
   DeclProvenance ->
-  GluedType LinearityType ->
-  m (NormalisableType LinearityType)
+  GluedType LinearityBuiltin ->
+  m (Type Ix LinearityBuiltin)
 checkNetworkType (ident, p) networkType = case normalised networkType of
   -- \|Decomposes the Pi types in a network type signature, checking that the
   -- binders are explicit and their types are equal. Returns a function that
@@ -39,10 +40,10 @@ checkNetworkType (ident, p) networkType = case normalised networkType of
   _ -> compilerDeveloperError "Invalid network type should have been caught by the main type system"
 
 assertConstantLinearity ::
-  (MonadTypeChecker LinearityType m) =>
+  (MonadTypeChecker LinearityBuiltin m) =>
   DeclProvenance ->
-  GluedType LinearityType ->
-  m (NormalisableType LinearityType)
+  GluedType LinearityBuiltin ->
+  m (Type Ix LinearityBuiltin)
 assertConstantLinearity (_, p) t = do
   createFreshUnificationConstraint p mempty CheckingAuxiliary (LinearityExpr p Constant) (unnormalised t)
   return $ unnormalised t

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Linearity/Core.hs
@@ -127,33 +127,35 @@ instance Pretty LinearityTypeClass where
 type LinearityBuiltin = NormalisableBuiltin LinearityType
 
 -- Value
-type LinearityNormExpr = Value LinearityType
+type LinearityNormExpr = Value LinearityBuiltin
 
-type LinearityNormBinder = VBinder LinearityType
+type LinearityNormBinder = VBinder LinearityBuiltin
 
-type LinearityNormArg = VArg LinearityType
+type LinearityNormArg = VArg LinearityBuiltin
 
-type LinearityNormType = VType LinearityType
+type LinearityNormType = VType LinearityBuiltin
 
-type LinearitySpine = Spine LinearityType
+type LinearitySpine = Spine LinearityBuiltin
 
-type LinearityEnv = Env LinearityType
+type LinearityExplicitSpine = ExplicitSpine LinearityBuiltin
+
+type LinearityEnv = Env LinearityBuiltin
 
 -- Constraint
-type LinearityConstraintProgress = ConstraintProgress LinearityType
+type LinearityConstraintProgress = ConstraintProgress LinearityBuiltin
 
-type LinearityTypeClassConstraint = TypeClassConstraint LinearityType
+type LinearityTypeClassConstraint = TypeClassConstraint LinearityBuiltin
 
-type LinearityUnificationConstraint = UnificationConstraint LinearityType
+type LinearityUnificationConstraint = UnificationConstraint LinearityBuiltin
 
-type LinearityConstraintContext = ConstraintContext LinearityType
+type LinearityConstraintContext = ConstraintContext LinearityBuiltin
 
-type LinearityConstraint = Constraint LinearityType
+type LinearityConstraint = Constraint LinearityBuiltin
 
 -----------------------------------------------------------------------------
 -- Patterns
 
-pattern LinearityExpr :: Provenance -> Linearity -> Expr var (NormalisableBuiltin LinearityType)
+pattern LinearityExpr :: Provenance -> Linearity -> Expr var LinearityBuiltin
 pattern LinearityExpr p lin = Builtin p (CType (Linearity lin))
 
 pattern VLinearityExpr :: Linearity -> LinearityNormExpr

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity.hs
@@ -5,21 +5,29 @@ module Vehicle.Compile.Type.Subsystem.Polarity
   )
 where
 
-import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Normalise.Builtin
+import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.InputOutputInsertion
 import Vehicle.Compile.Type.Subsystem.Polarity.AnnotationRestrictions (assertUnquantifiedPolarity, checkNetworkType)
 import Vehicle.Compile.Type.Subsystem.Polarity.Core as Core
 import Vehicle.Compile.Type.Subsystem.Polarity.PolaritySolver
 import Vehicle.Compile.Type.Subsystem.Polarity.Type
+import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
+import Vehicle.Expr.Normalised (Value (..))
 import Vehicle.Prelude
 import Vehicle.Syntax.AST
 
 instance PrintableBuiltin PolarityType where
   convertBuiltin = convertFromPolarityTypes
-  isTypeClassOp = const False
 
-instance TypableBuiltin PolarityType where
+instance Normalisable PolarityType where
+  evalBuiltin _ l spine = return $ VBuiltin l spine
+  isValue = return True
+  isTypeClassOp = const False
+  forceBuiltin _ _ _ _ = return (Nothing, mempty)
+
+instance TypableBuiltin PolarityBuiltin where
   convertFromStandardTypes = convertToPolarityTypes
   useDependentMetas _ = False
   typeBuiltin = typePolarityBuiltin
@@ -30,7 +38,7 @@ instance TypableBuiltin PolarityType where
   handleTypingError = handlePolarityTypingError
   typeClassRelevancy = const $ return Relevant
   solveInstance = solvePolarityConstraint
-  addAuxiliaryInputOutputConstraints = addFunctionAuxiliaryInputOutputConstraints (PolarityTypeClass . FunctionPolarity)
+  addAuxiliaryInputOutputConstraints = addFunctionAuxiliaryInputOutputConstraints (CType . PolarityTypeClass . FunctionPolarity)
   generateDefaultConstraint = const $ return False
 
 -------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/AnnotationRestrictions.hs
@@ -10,15 +10,15 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Polarity.Core
-import Vehicle.Expr.Normalisable
+import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 
 checkNetworkType ::
   forall m.
-  (MonadTypeChecker PolarityType m) =>
+  (MonadTypeChecker PolarityBuiltin m) =>
   DeclProvenance ->
-  GluedType PolarityType ->
-  m (NormalisableType PolarityType)
+  GluedType PolarityBuiltin ->
+  m (Type Ix PolarityBuiltin)
 checkNetworkType (_, p) networkType = case normalised networkType of
   -- \|Decomposes the Pi types in a network type signature, checking that the
   -- binders are explicit and their types are equal. Returns a function that
@@ -33,10 +33,10 @@ checkNetworkType (_, p) networkType = case normalised networkType of
   _ -> compilerDeveloperError "Invalid network type should have been caught by the main type system"
 
 assertUnquantifiedPolarity ::
-  (MonadTypeChecker PolarityType m) =>
+  (MonadTypeChecker PolarityBuiltin m) =>
   DeclProvenance ->
-  GluedType PolarityType ->
-  m (NormalisableType PolarityType)
+  GluedType PolarityBuiltin ->
+  m (Type Ix PolarityBuiltin)
 assertUnquantifiedPolarity (_, p) t = do
   createFreshUnificationConstraint p mempty CheckingAuxiliary (PolarityExpr p Unquantified) (unnormalised t)
   return $ unnormalised t

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Core.hs
@@ -129,30 +129,32 @@ instance Pretty PolarityTypeClass where
 -- Type synonyms
 
 -- Constraint
-type PolarityConstraintProgress = ConstraintProgress PolarityType
+type PolarityConstraintProgress = ConstraintProgress PolarityBuiltin
 
-type PolarityTypeClassConstraint = TypeClassConstraint PolarityType
+type PolarityTypeClassConstraint = TypeClassConstraint PolarityBuiltin
 
-type PolarityUnificationConstraint = UnificationConstraint PolarityType
+type PolarityUnificationConstraint = UnificationConstraint PolarityBuiltin
 
-type PolarityConstraintContext = ConstraintContext PolarityType
+type PolarityConstraintContext = ConstraintContext PolarityBuiltin
 
-type PolarityConstraint = Constraint PolarityType
+type PolarityConstraint = Constraint PolarityBuiltin
 
 -- Value
-type PolarityNormExpr = Value PolarityType
+type PolarityNormExpr = Value PolarityBuiltin
 
-type PolarityNormBinder = VBinder PolarityType
+type PolarityNormBinder = VBinder PolarityBuiltin
 
-type PolarityNormArg = VArg PolarityType
+type PolarityNormArg = VArg PolarityBuiltin
 
-type PolarityNormType = VType PolarityType
+type PolarityNormType = VType PolarityBuiltin
 
-type PolaritySpine = Spine PolarityType
+type PolaritySpine = Spine PolarityBuiltin
 
-type PolarityEnv = Env PolarityType
+type PolarityExplicitSpine = ExplicitSpine PolarityBuiltin
 
-pattern PolarityExpr :: Provenance -> Polarity -> Expr var (NormalisableBuiltin PolarityType)
+type PolarityEnv = Env PolarityBuiltin
+
+pattern PolarityExpr :: Provenance -> Polarity -> Expr var PolarityBuiltin
 pattern PolarityExpr p pol = Builtin p (CType (Polarity pol))
 
 pattern VPolarityExpr :: Polarity -> PolarityNormExpr

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Polarity/Type.hs
@@ -15,12 +15,13 @@ import Vehicle.Compile.Type.Monad.Class (MonadTypeChecker, freshMeta)
 import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.DSL
+import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalisable
 import Vehicle.Expr.Normalised
 import Prelude hiding (pi)
 
 -- | Return the type of the provided builtin.
-typePolarityBuiltin :: Provenance -> PolarityBuiltin -> NormalisableType PolarityType
+typePolarityBuiltin :: Provenance -> PolarityBuiltin -> Type Ix PolarityBuiltin
 typePolarityBuiltin p b = fromDSL p $ case b of
   CConstructor c -> typeOfConstructor c
   CFunction f -> typeOfBuiltinFunction f
@@ -141,43 +142,43 @@ typeOfVecLiteral n = go n unquantified
                 ~~~> li
                 ~> go (i - 1) newMax
 
-handlePolarityTypingError :: (MonadCompile m) => TypingError PolarityType -> m a
+handlePolarityTypingError :: (MonadCompile m) => TypingError PolarityBuiltin -> m a
 handlePolarityTypingError b =
   compilerDeveloperError $ "Polarity type system should not be throwing error:" <+> pretty b
 
 relevanceOfTypeClass :: (MonadCompile m) => PolarityType -> m Relevance
 relevanceOfTypeClass _b = return Relevant
 
-freshPolarityMeta :: (MonadTypeChecker PolarityType m) => Provenance -> m (GluedExpr PolarityType)
+freshPolarityMeta :: (MonadTypeChecker PolarityBuiltin m) => Provenance -> m (GluedExpr PolarityBuiltin)
 freshPolarityMeta p = snd <$> freshMeta p (TypeUniverse p 0) mempty
 
 convertToPolarityTypes ::
   forall m.
-  (MonadTypeChecker PolarityType m) =>
-  Provenance ->
-  StandardBuiltinType ->
-  [NormalisableArg PolarityType] ->
-  m (NormalisableExpr PolarityType)
-convertToPolarityTypes p b args = case b of
-  StandardBuiltinType s -> case s of
-    Unit -> return $ PolarityExpr p Unquantified
-    Bool -> unnormalised <$> freshPolarityMeta p
-    Index -> return $ PolarityExpr p Unquantified
-    Nat -> return $ PolarityExpr p Unquantified
-    Int -> return $ PolarityExpr p Unquantified
-    Rat -> unnormalised <$> freshPolarityMeta p
-    List -> case args of
-      [tElem] -> return $ argExpr tElem
-      _ -> monomorphisationError "List"
-    Vector -> case args of
-      [tElem, _] -> return $ argExpr tElem
-      _ -> monomorphisationError "Vector"
-  StandardTypeClass {} ->
-    monomorphisationError "TypeClass"
-  StandardTypeClassOp {} ->
-    compilerDeveloperError "Type class operations should have been resolved before converting to other type systems"
-  where
-    monomorphisationError :: Doc () -> m a
-    monomorphisationError name =
-      compilerDeveloperError $
-        "Monomorphisation should have got rid of partially applied" <+> name <+> "types."
+  (MonadTypeChecker PolarityBuiltin m) =>
+  BuiltinUpdate m Ix StandardBuiltin PolarityBuiltin
+convertToPolarityTypes p1 p2 b args = case b of
+  CConstructor c -> return $ normAppList p1 (Builtin p2 (CConstructor c)) args
+  CFunction f -> return $ normAppList p1 (Builtin p2 (CFunction f)) args
+  CType t -> case t of
+    StandardBuiltinType s -> case s of
+      Unit -> return $ PolarityExpr p2 Unquantified
+      Bool -> unnormalised <$> freshPolarityMeta p2
+      Index -> return $ PolarityExpr p2 Unquantified
+      Nat -> return $ PolarityExpr p2 Unquantified
+      Int -> return $ PolarityExpr p2 Unquantified
+      Rat -> unnormalised <$> freshPolarityMeta p2
+      List -> case args of
+        [tElem] -> return $ argExpr tElem
+        _ -> monomorphisationError "List"
+      Vector -> case args of
+        [tElem, _] -> return $ argExpr tElem
+        _ -> monomorphisationError "Vector"
+    StandardTypeClass {} ->
+      monomorphisationError "TypeClass"
+    StandardTypeClassOp {} ->
+      compilerDeveloperError "Type class operations should have been resolved before converting to other type systems"
+    where
+      monomorphisationError :: Doc () -> m a
+      monomorphisationError name =
+        compilerDeveloperError $
+          "Monomorphisation should have got rid of partially applied" <+> name <+> "types."

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
@@ -5,6 +5,7 @@ module Vehicle.Compile.Type.Subsystem.Standard
   )
 where
 
+import Vehicle.Compile.Normalise.Builtin
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Standard.AnnotationRestrictions
@@ -13,15 +14,23 @@ import Vehicle.Compile.Type.Subsystem.Standard.Constraint.TypeClassDefaults
 import Vehicle.Compile.Type.Subsystem.Standard.Core as Core
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
 import Vehicle.Compile.Type.Subsystem.Standard.Type
-import Vehicle.Expr.Normalisable
+import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Sugar
 
 -----------------------------------------------------------------------------
 -- Standard builtins
 -----------------------------------------------------------------------------
 
-instance TypableBuiltin StandardBuiltinType where
-  convertFromStandardTypes p t args = return $ normAppList p (Builtin p (CType t)) args
+instance Normalisable StandardBuiltinType where
+  evalBuiltin _ l spine = return $ VBuiltin l spine
+  isValue = return True
+  isTypeClassOp = \case
+    StandardTypeClassOp {} -> True
+    _ -> False
+  forceBuiltin _ _ _ _ = return (Nothing, mempty)
+
+instance TypableBuiltin StandardBuiltin where
+  convertFromStandardTypes p1 p2 t args = return $ normAppList p1 (Builtin p2 t) args
   useDependentMetas _ = True
   typeBuiltin = typeStandardBuiltin
   restrictNetworkType = restrictStandardNetworkType

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/AnnotationRestrictions.hs
@@ -18,13 +18,13 @@ import Vehicle.Expr.Normalised
 
 restrictStandardPropertyType ::
   forall m.
-  (MonadTypeChecker StandardBuiltinType m) =>
+  (MonadTypeChecker StandardBuiltin m) =>
   DeclProvenance ->
   StandardGluedType ->
   m ()
 restrictStandardPropertyType decl parameterType = go (normalised parameterType)
   where
-    go :: VType StandardBuiltinType -> m ()
+    go :: VType StandardBuiltin -> m ()
     go = \case
       VBoolType {} -> return ()
       VVectorType tElem _ -> go tElem
@@ -34,7 +34,7 @@ restrictStandardPropertyType decl parameterType = go (normalised parameterType)
 -- Parameters
 
 restrictStandardParameterType ::
-  (MonadTypeChecker StandardBuiltinType m) =>
+  (MonadTypeChecker StandardBuiltin m) =>
   ParameterSort ->
   DeclProvenance ->
   StandardGluedType ->
@@ -44,7 +44,7 @@ restrictStandardParameterType sort = case sort of
   Inferable -> restrictStandardInferableParameterType
 
 restrictStandardNonInferableParameterType ::
-  (MonadTypeChecker StandardBuiltinType m) =>
+  (MonadTypeChecker StandardBuiltin m) =>
   DeclProvenance ->
   StandardGluedType ->
   m StandardType
@@ -60,7 +60,7 @@ restrictStandardNonInferableParameterType decl parameterType = do
   return $ unnormalised parameterType
 
 restrictStandardInferableParameterType ::
-  (MonadTypeChecker StandardBuiltinType m) =>
+  (MonadTypeChecker StandardBuiltin m) =>
   DeclProvenance ->
   StandardGluedType ->
   m StandardType
@@ -74,7 +74,7 @@ restrictStandardInferableParameterType decl parameterType =
 
 restrictStandardDatasetType ::
   forall m.
-  (MonadTypeChecker StandardBuiltinType m) =>
+  (MonadTypeChecker StandardBuiltin m) =>
   DeclProvenance ->
   StandardGluedType ->
   m StandardType
@@ -105,7 +105,7 @@ restrictStandardDatasetType decl datasetType = do
 
 restrictStandardNetworkType ::
   forall m.
-  (MonadTypeChecker StandardBuiltinType m) =>
+  (MonadTypeChecker StandardBuiltin m) =>
   DeclProvenance ->
   StandardGluedType ->
   m StandardType

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Constraint/Core.hs
@@ -6,13 +6,15 @@ import Vehicle.Compile.Error (MonadCompile, compilerDeveloperError)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Standard.Core
+import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
+import Vehicle.Expr.Normalised (Value (..))
 
 --------------------------------------------------------------------------------
 -- Instance constraints
 
-type MonadInstance m = TCM StandardBuiltinType m
+type MonadInstance m = TCM StandardBuiltin m
 
-getTypeClass :: (MonadCompile m) => StandardBuiltinType -> m TypeClass
+getTypeClass :: (MonadCompile m) => StandardNormExpr -> m (TypeClass, StandardExplicitSpine)
 getTypeClass = \case
-  StandardTypeClass tc -> return tc
+  (VBuiltin (CType (StandardTypeClass tc)) args) -> return (tc, args)
   _ -> compilerDeveloperError "Unexpected non-type-class instance argument found."

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Core.hs
@@ -28,16 +28,6 @@ instance Pretty StandardBuiltinType where
     StandardTypeClass t -> pretty t
     StandardTypeClassOp t -> pretty t
 
-instance PrintableBuiltin StandardBuiltinType where
-  convertBuiltin p b = Builtin p $ case b of
-    StandardBuiltinType t -> BuiltinType t
-    StandardTypeClass t -> TypeClass t
-    StandardTypeClassOp t -> TypeClassOp t
-
-  isTypeClassOp = \case
-    StandardTypeClassOp {} -> True
-    _ -> False
-
 instance Hashable StandardBuiltinType
 
 instance Serialize StandardBuiltinType
@@ -60,47 +50,47 @@ convertToNormalisableBuiltins = traverseBuiltins $ \p1 p2 b args -> do
 
 type StandardBuiltin = NormalisableBuiltin StandardBuiltinType
 
-type StandardExpr = NormalisableExpr StandardBuiltinType
+type StandardExpr = Expr Ix StandardBuiltin
 
-type StandardBinder = NormalisableBinder StandardBuiltinType
+type StandardBinder = Binder Ix StandardBuiltin
 
-type StandardArg = NormalisableArg StandardBuiltinType
+type StandardArg = Arg Ix StandardBuiltin
 
-type StandardDecl = NormalisableDecl StandardBuiltinType
+type StandardDecl = Decl Ix StandardBuiltin
 
-type StandardProg = NormalisableProg StandardBuiltinType
+type StandardProg = Prog Ix StandardBuiltin
 
 type StandardType = StandardExpr
 
-type StandardTelescope = NormalisableTelescope StandardBuiltinType
+type StandardTelescope = Telescope Ix StandardBuiltin
 
-type StandardTypingBoundCtx = TypingBoundCtx StandardBuiltinType
+type StandardTypingBoundCtx = TypingBoundCtx StandardBuiltin
 
 -----------------------------------------------------------------------------
 -- Norm expressions
 
-type StandardNormExpr = Value StandardBuiltinType
+type StandardNormExpr = Value StandardBuiltin
 
-type StandardNormBinder = VBinder StandardBuiltinType
+type StandardNormBinder = VBinder StandardBuiltin
 
-type StandardNormArg = VArg StandardBuiltinType
+type StandardNormArg = VArg StandardBuiltin
 
-type StandardNormType = VType StandardBuiltinType
+type StandardNormType = VType StandardBuiltin
 
-type StandardSpine = Spine StandardBuiltinType
+type StandardSpine = Spine StandardBuiltin
 
-type StandardExplicitSpine = ExplicitSpine StandardBuiltinType
+type StandardExplicitSpine = ExplicitSpine StandardBuiltin
 
-type StandardEnv = Env StandardBuiltinType
+type StandardEnv = Env StandardBuiltin
 
-type StandardNormDeclCtx = NormDeclCtx StandardBuiltinType
+type StandardNormDeclCtx = NormDeclCtx StandardBuiltin
 
 -----------------------------------------------------------------------------
 -- Glued expressions
 
-type StandardGluedExpr = GluedExpr StandardBuiltinType
+type StandardGluedExpr = GluedExpr StandardBuiltin
 
-type StandardGluedType = GluedType StandardBuiltinType
+type StandardGluedType = GluedType StandardBuiltin
 
 type StandardGluedProg = GenericProg StandardGluedExpr
 
@@ -111,15 +101,15 @@ type ImportedModules = [StandardGluedProg]
 -----------------------------------------------------------------------------
 -- Constraints
 
-type StandardConstraintProgress = ConstraintProgress StandardBuiltinType
+type StandardConstraintProgress = ConstraintProgress StandardBuiltin
 
-type StandardTypeClassConstraint = TypeClassConstraint StandardBuiltinType
+type StandardTypeClassConstraint = TypeClassConstraint StandardBuiltin
 
-type StandardUnificationConstraint = UnificationConstraint StandardBuiltinType
+type StandardUnificationConstraint = UnificationConstraint StandardBuiltin
 
-type StandardConstraintContext = ConstraintContext StandardBuiltinType
+type StandardConstraintContext = ConstraintContext StandardBuiltin
 
-type StandardConstraint = Constraint StandardBuiltinType
+type StandardConstraint = Constraint StandardBuiltin
 
 -----------------------------------------------------------------------------
 -- Normalised patterns

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Patterns.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Patterns.hs
@@ -466,14 +466,14 @@ pattern AppConsExpr p tElem x xs <-
 pattern NullaryBuiltinFunctionExpr ::
   Provenance ->
   BuiltinFunction ->
-  Expr var (NormalisableBuiltin types)
+  Expr var StandardBuiltin
 pattern NullaryBuiltinFunctionExpr p b = Builtin p (CFunction b)
 
 pattern BuiltinFunctionExpr ::
   Provenance ->
   BuiltinFunction ->
-  NonEmpty (Arg var (NormalisableBuiltin types)) ->
-  Expr var (NormalisableBuiltin types)
+  NonEmpty (Arg var StandardBuiltin) ->
+  Expr var StandardBuiltin
 pattern BuiltinFunctionExpr p b args = BuiltinExpr p (CFunction b) args
 
 pattern QuantifierExpr ::

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Type.hs
@@ -246,7 +246,7 @@ typeOfVectorLiteral n = do
   forAll "A" type0 $ \tElem ->
     naryFunc n tElem (tVector tElem (natLit n))
 
-handleStandardTypingError :: (MonadCompile m) => TypingError StandardBuiltinType -> m a
+handleStandardTypingError :: (MonadCompile m) => TypingError StandardBuiltin -> m a
 handleStandardTypingError = \case
   MissingExplicitArgument boundCtx expectedBinder actualArg ->
     throwError $ MissingExplicitArg (boundContextOf boundCtx) actualArg (typeOf expectedBinder)
@@ -264,7 +264,7 @@ handleStandardTypingError = \case
   UnsolvableConstraints constraints ->
     throwError $ UnsolvedConstraints constraints
 
-relevanceOfTypeClass :: (MonadCompile m) => StandardBuiltinType -> m Relevance
-relevanceOfTypeClass b = do
-  tc <- getTypeClass b
+relevanceOfTypeClass :: (MonadCompile m) => StandardNormType -> m Relevance
+relevanceOfTypeClass t = do
+  (tc, _) <- getTypeClass t
   return $ relevanceOf tc

--- a/vehicle/src/Vehicle/Expr/DSL.hs
+++ b/vehicle/src/Vehicle/Expr/DSL.hs
@@ -108,14 +108,14 @@ class DSL expr where
   lam :: Name -> Visibility -> Relevance -> expr -> (expr -> expr) -> expr
   free :: StdLibFunction -> expr
 
-newtype DSLExpr types = DSL
-  { unDSL :: Provenance -> Lv -> NormalisableExpr types
+newtype DSLExpr builtin = DSL
+  { unDSL :: Provenance -> Lv -> Expr Ix builtin
   }
 
-fromDSL :: Provenance -> DSLExpr types -> NormalisableExpr types
+fromDSL :: Provenance -> DSLExpr builtin -> Expr Ix builtin
 fromDSL p e = unDSL e p 0
 
-boundVar :: Lv -> DSLExpr types
+boundVar :: Lv -> DSLExpr builtin
 boundVar i = DSL $ \p j -> BoundVar p (dbLevelToIndex j i)
 
 approxPiForm :: Maybe Name -> Visibility -> BinderDisplayForm
@@ -124,7 +124,7 @@ approxPiForm name = \case
   Implicit {} -> BinderDisplayForm (OnlyName $ fromMaybe "_" name) True
   Instance {} -> BinderDisplayForm OnlyType False
 
-instance DSL (DSLExpr types) where
+instance DSL (DSLExpr builtin) where
   hole = DSL $ \p _i ->
     Hole p "_"
 
@@ -158,37 +158,37 @@ instance DSL (DSLExpr types) where
 -- | Explicit function type
 infixr 4 ~>
 
-(~>) :: DSLExpr types -> DSLExpr types -> DSLExpr types
+(~>) :: DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin
 x ~> y = pi Nothing Explicit Relevant x (const y)
 
 -- | Implicit function type
 infixr 4 ~~>
 
-(~~>) :: DSLExpr types -> DSLExpr types -> DSLExpr types
+(~~>) :: DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin
 x ~~> y = pi Nothing (Implicit False) Relevant x (const y)
 
 -- | Instance function type
 infixr 4 ~~~>
 
-(~~~>) :: DSLExpr types -> DSLExpr types -> DSLExpr types
+(~~~>) :: DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin
 x ~~~> y = pi Nothing (Instance False) Relevant x (const y)
 
 -- | Irrelevant instance function type
 infixr 4 .~~~>
 
-(.~~~>) :: DSLExpr types -> DSLExpr types -> DSLExpr types
+(.~~~>) :: DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin
 x .~~~> y = pi Nothing (Instance False) Irrelevant x (const y)
 
-explLam :: Name -> DSLExpr types -> (DSLExpr types -> DSLExpr types) -> DSLExpr types
+explLam :: Name -> DSLExpr builtin -> (DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 explLam n = lam n Explicit Relevant
 
-implLam :: Name -> DSLExpr types -> (DSLExpr types -> DSLExpr types) -> DSLExpr types
+implLam :: Name -> DSLExpr builtin -> (DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 implLam n = lam n (Implicit False) Relevant
 
-instLam :: Name -> DSLExpr types -> (DSLExpr types -> DSLExpr types) -> DSLExpr types
+instLam :: Name -> DSLExpr builtin -> (DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 instLam n = lam n (Instance False) Relevant
 
-implTypeTripleLam :: (DSLExpr types -> DSLExpr types -> DSLExpr types -> DSLExpr types) -> DSLExpr types
+implTypeTripleLam :: (DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 implTypeTripleLam f =
   implLam "t1" type0 $ \t1 ->
     implLam "t2" type0 $ \t2 ->
@@ -197,62 +197,62 @@ implTypeTripleLam f =
 
 infixl 6 @@
 
-(@@) :: DSLExpr types -> NonEmpty (DSLExpr types) -> DSLExpr types
+(@@) :: DSLExpr builtin -> NonEmpty (DSLExpr builtin) -> DSLExpr builtin
 (@@) f args = app f (fmap (Explicit,Relevant,) args)
 
 infixl 6 @@@
 
-(@@@) :: DSLExpr types -> NonEmpty (DSLExpr types) -> DSLExpr types
+(@@@) :: DSLExpr builtin -> NonEmpty (DSLExpr builtin) -> DSLExpr builtin
 (@@@) f args = app f (fmap (Implicit True,Relevant,) args)
 
 infixl 6 @@@@
 
-(@@@@) :: DSLExpr types -> NonEmpty (DSLExpr types) -> DSLExpr types
+(@@@@) :: DSLExpr builtin -> NonEmpty (DSLExpr builtin) -> DSLExpr builtin
 (@@@@) f args = app f (fmap (Instance True,Relevant,) args)
 
 infixl 6 .@@@@
 
-(.@@@@) :: DSLExpr types -> NonEmpty (DSLExpr types) -> DSLExpr types
+(.@@@@) :: DSLExpr builtin -> NonEmpty (DSLExpr builtin) -> DSLExpr builtin
 (.@@@@) f args = app f (fmap (Instance True,Irrelevant,) args)
 
-naryFunc :: Int -> DSLExpr types -> DSLExpr types -> DSLExpr types
+naryFunc :: Int -> DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin
 naryFunc n a b = foldr (\_ r -> a ~> r) b ([0 .. n - 1] :: [Int])
 
-forAllExpl :: Name -> DSLExpr types -> (DSLExpr types -> DSLExpr types) -> DSLExpr types
+forAllExpl :: Name -> DSLExpr builtin -> (DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 forAllExpl name = pi (Just name) Explicit Relevant
 
-forAll :: Name -> DSLExpr types -> (DSLExpr types -> DSLExpr types) -> DSLExpr types
+forAll :: Name -> DSLExpr builtin -> (DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 forAll name = pi (Just name) (Implicit False) Relevant
 
-forAllInstance :: Name -> DSLExpr types -> (DSLExpr types -> DSLExpr types) -> DSLExpr types
+forAllInstance :: Name -> DSLExpr builtin -> (DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 forAllInstance name = pi (Just name) (Instance False) Relevant
 
-universe :: UniverseLevel -> DSLExpr types
+universe :: UniverseLevel -> DSLExpr builtin
 universe u = DSL $ \p _ -> Universe p u
 
-type0 :: DSLExpr types
+type0 :: DSLExpr builtin
 type0 = universe $ UniverseLevel 0
 
-forAllTypeTriples :: (DSLExpr types -> DSLExpr types -> DSLExpr types -> DSLExpr types) -> DSLExpr types
+forAllTypeTriples :: (DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin -> DSLExpr builtin) -> DSLExpr builtin
 forAllTypeTriples f =
   forAll "t1" type0 $ \t1 ->
     forAll "t2" type0 $ \t2 ->
       forAll "t3" type0 $ \t3 -> f t1 t2 t3
 
-builtin :: NormalisableBuiltin types -> DSLExpr types
+builtin :: builtin -> DSLExpr builtin
 builtin b = DSL $ \p _ -> Builtin p b
 
-builtinFunction :: BuiltinFunction -> DSLExpr types
+--------------------------------------------------------------------------------
+-- Standard builtin
+--------------------------------------------------------------------------------
+
+type StandardDSLExpr = DSLExpr StandardBuiltin
+
+builtinFunction :: BuiltinFunction -> StandardDSLExpr
 builtinFunction b = DSL $ \p _ -> Builtin p (CFunction b)
 
-builtinConstructor :: BuiltinConstructor -> DSLExpr types
+builtinConstructor :: BuiltinConstructor -> StandardDSLExpr
 builtinConstructor = builtin . CConstructor
-
---------------------------------------------------------------------------------
--- Standard types
---------------------------------------------------------------------------------
-
-type StandardDSLExpr = DSLExpr StandardBuiltinType
 
 builtinType :: BuiltinType -> StandardDSLExpr
 builtinType = builtin . CType . StandardBuiltinType
@@ -368,7 +368,7 @@ addNat x y = builtinFunction (Add AddNat) @@ [x, y]
 --------------------------------------------------------------------------------
 -- Linearity
 
-type LinearityDSLExpr = DSLExpr LinearityType
+type LinearityDSLExpr = DSLExpr LinearityBuiltin
 
 forAllLinearities :: (LinearityDSLExpr -> LinearityDSLExpr) -> LinearityDSLExpr
 forAllLinearities f = forAll "l" tLin $ \l -> f l
@@ -405,7 +405,7 @@ tLin = type0
 --------------------------------------------------------------------------------
 -- Polarities
 
-type PolarityDSLExpr = DSLExpr PolarityType
+type PolarityDSLExpr = DSLExpr PolarityBuiltin
 
 forAllPolarities :: (PolarityDSLExpr -> PolarityDSLExpr) -> PolarityDSLExpr
 forAllPolarities f = forAll "p" tPol $ \p -> f p

--- a/vehicle/src/Vehicle/Expr/Normalisable.hs
+++ b/vehicle/src/Vehicle/Expr/Normalisable.hs
@@ -4,7 +4,7 @@ import Data.Aeson (ToJSON)
 import Data.Hashable (Hashable)
 import Data.Serialize
 import GHC.Generics
-import Vehicle.Expr.DeBruijn
+import Vehicle.Expr.Normalised
 import Vehicle.Prelude
 import Vehicle.Syntax.AST
 
@@ -29,19 +29,64 @@ instance (Hashable types) => Hashable (NormalisableBuiltin types)
 
 instance (ToJSON types) => ToJSON (NormalisableBuiltin types)
 
------------------------------------------------------------------------------
--- Expressions
+-------------------------------------------------------------------------------
+-- Patterns
 
-type NormalisableExpr types = Expr Ix (NormalisableBuiltin types)
+pattern VBuiltinFunction :: BuiltinFunction -> ExplicitSpine (NormalisableBuiltin builtin) -> Value (NormalisableBuiltin builtin)
+pattern VBuiltinFunction f spine = VBuiltin (CFunction f) spine
 
-type NormalisableBinder types = Binder Ix (NormalisableBuiltin types)
+pattern VConstructor :: BuiltinConstructor -> ExplicitSpine (NormalisableBuiltin builtin) -> Value (NormalisableBuiltin builtin)
+pattern VConstructor c args = VBuiltin (CConstructor c) args
 
-type NormalisableArg types = Arg Ix (NormalisableBuiltin types)
+pattern VNullaryConstructor :: BuiltinConstructor -> Value (NormalisableBuiltin builtin)
+pattern VNullaryConstructor c <- VConstructor c []
+  where
+    VNullaryConstructor c = VConstructor c []
 
-type NormalisableType types = NormalisableExpr types
+pattern VUnitLiteral :: Value (NormalisableBuiltin builtin)
+pattern VUnitLiteral = VNullaryConstructor LUnit
 
-type NormalisableDecl types = Decl Ix (NormalisableBuiltin types)
+pattern VBoolLiteral :: Bool -> Value (NormalisableBuiltin builtin)
+pattern VBoolLiteral x = VNullaryConstructor (LBool x)
 
-type NormalisableProg types = Prog Ix (NormalisableBuiltin types)
+pattern VIndexLiteral :: Int -> Value (NormalisableBuiltin builtin)
+pattern VIndexLiteral x = VNullaryConstructor (LIndex x)
 
-type NormalisableTelescope types = Telescope Ix (NormalisableBuiltin types)
+pattern VNatLiteral :: Int -> Value (NormalisableBuiltin builtin)
+pattern VNatLiteral x = VNullaryConstructor (LNat x)
+
+pattern VIntLiteral :: Int -> Value (NormalisableBuiltin builtin)
+pattern VIntLiteral x = VNullaryConstructor (LInt x)
+
+pattern VRatLiteral :: Rational -> Value (NormalisableBuiltin builtin)
+pattern VRatLiteral x = VNullaryConstructor (LRat x)
+
+pattern VVecLiteral :: [Value (NormalisableBuiltin builtin)] -> Value (NormalisableBuiltin builtin)
+pattern VVecLiteral xs <- VConstructor (LVec _) xs
+  where
+    VVecLiteral xs = VConstructor (LVec (length xs)) xs
+
+pattern VNil :: Value (NormalisableBuiltin builtin)
+pattern VNil = VNullaryConstructor Nil
+
+pattern VCons :: [Value (NormalisableBuiltin builtin)] -> Value (NormalisableBuiltin builtin)
+pattern VCons xs = VConstructor Cons xs
+
+mkVList :: [Value (NormalisableBuiltin builtin)] -> Value (NormalisableBuiltin builtin)
+mkVList = foldr cons nil
+  where
+    nil = VConstructor Nil []
+    cons y ys = VConstructor Cons [y, ys]
+
+mkVLVec :: [Value (NormalisableBuiltin builtin)] -> Value (NormalisableBuiltin builtin)
+mkVLVec xs = VConstructor (LVec (length xs)) xs
+
+getNatLiteral :: Value (NormalisableBuiltin builtin) -> Maybe Int
+getNatLiteral = \case
+  VNatLiteral d -> Just d
+  _ -> Nothing
+
+getRatLiteral :: Value (NormalisableBuiltin builtin) -> Maybe Rational
+getRatLiteral = \case
+  VRatLiteral d -> Just d
+  _ -> Nothing

--- a/vehicle/src/Vehicle/Expr/Normalised.hs
+++ b/vehicle/src/Vehicle/Expr/Normalised.hs
@@ -4,7 +4,6 @@ import Data.Serialize (Serialize)
 import GHC.Generics (Generic)
 import Vehicle.Compile.Prelude.Contexts (BoundCtx)
 import Vehicle.Expr.DeBruijn
-import Vehicle.Expr.Normalisable
 import Vehicle.Syntax.AST
 
 -----------------------------------------------------------------------------
@@ -12,43 +11,30 @@ import Vehicle.Syntax.AST
 
 -- | A normalised expression. Internal invariant is that it should always be
 -- well-typed.
-data Value types
+data Value builtin
   = VUniverse UniverseLevel
-  | VLam (VBinder types) (Env types) (NormalisableExpr types)
-  | VPi (VBinder types) (Value types)
-  | VMeta MetaID (Spine types)
-  | VFreeVar Identifier (Spine types)
-  | VBoundVar Lv (Spine types)
-  | VBuiltin (NormalisableBuiltin types) (ExplicitSpine types)
+  | VLam (VBinder builtin) (Env builtin) (Expr Ix builtin)
+  | VPi (VBinder builtin) (Value builtin)
+  | VMeta MetaID (Spine builtin)
+  | VFreeVar Identifier (Spine builtin)
+  | VBoundVar Lv (Spine builtin)
+  | VBuiltin builtin (ExplicitSpine builtin)
   deriving (Eq, Show, Generic)
 
-instance (Serialize types) => Serialize (Value types)
+instance (Serialize builtin) => Serialize (Value builtin)
 
-type VArg types = GenericArg (Value types)
+type VArg builtin = GenericArg (Value builtin)
 
-type VBinder types = GenericBinder (VType types)
+type VBinder builtin = GenericBinder (VType builtin)
 
-type VDecl types = GenericDecl (Value types)
+type VDecl builtin = GenericDecl (Value builtin)
 
-type VProg types = GenericDecl types
+type VProg builtin = GenericDecl builtin
 
 -- | A normalised type
-type VType types = Value types
+type VType builtin = Value builtin
 
-isValue :: Value types -> Bool
-isValue = \case
-  VUniverse {} -> True
-  VLam {} -> True
-  VPi {} -> True
-  VMeta {} -> False
-  VFreeVar {} -> False
-  VBoundVar {} -> False
-  VBuiltin b _ -> case b of
-    CConstructor {} -> True
-    CType {} -> True
-    CFunction {} -> False
-
-arity :: VType types -> Int
+arity :: VType builtin -> Int
 arity = \case
   VPi _ r -> 1 + arity r
   _ -> 0
@@ -57,123 +43,61 @@ arity = \case
 -- Spines and environments
 
 -- | A list of arguments for an application that cannot be normalised.
-type Spine types = [VArg types]
+type Spine builtin = [VArg builtin]
 
 -- | A spine type for builtins which enforces the invariant that they should
 -- only ever depend computationally on their explicit arguments.
-type ExplicitSpine types = [Value types]
+type ExplicitSpine builtin = [Value builtin]
 
-type Env types = BoundCtx (Maybe Name, Value types)
+type Env builtin = BoundCtx (Maybe Name, Value builtin)
 
-extendEnv :: GenericBinder expr -> Value types -> Env types -> Env types
+extendEnv :: GenericBinder expr -> Value builtin -> Env builtin -> Env builtin
 extendEnv binder value = ((nameOf binder, value) :)
 
-extendEnvOverBinder :: GenericBinder expr -> Env types -> Env types
+extendEnvOverBinder :: GenericBinder expr -> Env builtin -> Env builtin
 extendEnvOverBinder binder env =
   extendEnv binder (VBoundVar (Lv $ length env) []) env
 
 -----------------------------------------------------------------------------
 -- Patterns
 
-pattern VTypeUniverse :: UniverseLevel -> VType types
-pattern VTypeUniverse l = VUniverse l
-
-pattern VBuiltinFunction :: BuiltinFunction -> ExplicitSpine types -> Value types
-pattern VBuiltinFunction f spine = VBuiltin (CFunction f) spine
-
-pattern VConstructor :: BuiltinConstructor -> ExplicitSpine types -> Value types
-pattern VConstructor c args = VBuiltin (CConstructor c) args
-
-pattern VNullaryConstructor :: BuiltinConstructor -> Value types
-pattern VNullaryConstructor c <- VConstructor c []
-  where
-    VNullaryConstructor c = VConstructor c []
-
-pattern VUnitLiteral :: Value types
-pattern VUnitLiteral = VNullaryConstructor LUnit
-
-pattern VBoolLiteral :: Bool -> Value types
-pattern VBoolLiteral x = VNullaryConstructor (LBool x)
-
-pattern VIndexLiteral :: Int -> Value types
-pattern VIndexLiteral x = VNullaryConstructor (LIndex x)
-
-pattern VNatLiteral :: Int -> Value types
-pattern VNatLiteral x = VNullaryConstructor (LNat x)
-
-pattern VIntLiteral :: Int -> Value types
-pattern VIntLiteral x = VNullaryConstructor (LInt x)
-
-pattern VRatLiteral :: Rational -> Value types
-pattern VRatLiteral x = VNullaryConstructor (LRat x)
-
-pattern VVecLiteral :: [Value types] -> Value types
-pattern VVecLiteral xs <- VConstructor (LVec _) xs
-  where
-    VVecLiteral xs = VConstructor (LVec (length xs)) xs
-
-pattern VNil :: Value types
-pattern VNil = VNullaryConstructor Nil
-
-pattern VCons :: [Value types] -> Value types
-pattern VCons xs = VConstructor Cons xs
-
-mkVList :: [Value types] -> Value types
-mkVList = foldr cons nil
-  where
-    nil = VConstructor Nil []
-    cons y ys = VConstructor Cons [y, ys]
-
-mkVLVec :: [Value types] -> Value types
-mkVLVec xs = VConstructor (LVec (length xs)) xs
-
-isNTypeUniverse :: Value types -> Bool
+isNTypeUniverse :: Value builtin -> Bool
 isNTypeUniverse VUniverse {} = True
 isNTypeUniverse _ = False
 
-isNMeta :: Value types -> Bool
+isNMeta :: Value builtin -> Bool
 isNMeta VMeta {} = True
 isNMeta _ = False
 
-getNMeta :: Value types -> Maybe MetaID
+getNMeta :: Value builtin -> Maybe MetaID
 getNMeta (VMeta m _) = Just m
 getNMeta _ = Nothing
-
-getNatLiteral :: Value types -> Maybe Int
-getNatLiteral = \case
-  VNatLiteral d -> Just d
-  _ -> Nothing
-
-getRatLiteral :: Value types -> Maybe Rational
-getRatLiteral = \case
-  VRatLiteral d -> Just d
-  _ -> Nothing
 
 -----------------------------------------------------------------------------
 -- Glued expressions
 
 -- | A pair of an unnormalised and normalised expression.
-data GluedExpr types = Glued
-  { unnormalised :: NormalisableExpr types,
-    normalised :: Value types
+data GluedExpr builtin = Glued
+  { unnormalised :: Expr Ix builtin,
+    normalised :: Value builtin
   }
   deriving (Show, Generic)
 
-instance (Serialize types) => Serialize (GluedExpr types)
+instance (Serialize builtin) => Serialize (GluedExpr builtin)
 
-instance HasProvenance (GluedExpr types) where
+instance HasProvenance (GluedExpr builtin) where
   provenanceOf = provenanceOf . unnormalised
 
-type GluedArg types = GenericArg (GluedExpr types)
+type GluedArg builtin = GenericArg (GluedExpr builtin)
 
-type GluedType types = GluedExpr types
+type GluedType builtin = GluedExpr builtin
 
-type GluedProg types = GenericProg (GluedExpr types)
+type GluedProg builtin = GenericProg (GluedExpr builtin)
 
-type GluedDecl types = GenericDecl (GluedExpr types)
+type GluedDecl builtin = GenericDecl (GluedExpr builtin)
 
-traverseNormalised :: (Monad m) => (Value types -> m (Value types)) -> GluedExpr types -> m (GluedExpr types)
+traverseNormalised :: (Monad m) => (Value builtin -> m (Value builtin)) -> GluedExpr builtin -> m (GluedExpr builtin)
 traverseNormalised f (Glued u n) = Glued u <$> f n
 
-traverseUnnormalised :: (Monad m) => (NormalisableExpr types -> m (NormalisableExpr types)) -> GluedExpr types -> m (GluedExpr types)
+traverseUnnormalised :: (Monad m) => (Expr Ix builtin -> m (Expr Ix builtin)) -> GluedExpr builtin -> m (GluedExpr builtin)
 traverseUnnormalised f (Glued u n) = Glued <$> f u <*> pure n

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -21,9 +21,8 @@ import Vehicle.Compile.Print
 import Vehicle.Compile.Queries.LinearityAndPolarityErrors (typeCheckWithSubsystem)
 import Vehicle.Compile.Scope (scopeCheck, scopeCheckClosedExpr)
 import Vehicle.Compile.Type (typeCheckExpr, typeCheckProg)
-import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Subsystem.Linearity.Core (LinearityType)
-import Vehicle.Compile.Type.Subsystem.Polarity.Core (PolarityType)
+import Vehicle.Compile.Type.Subsystem.Linearity.Core (LinearityBuiltin)
+import Vehicle.Compile.Type.Subsystem.Polarity.Core (PolarityBuiltin)
 import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries (Library (..), LibraryInfo (..), findLibraryContentFile)
@@ -42,8 +41,8 @@ typeCheck loggingSettings options@TypeCheckOptions {..} = runCompileMonad loggin
   (_, typedProg) <- typeCheckUserProg options
   case typingSystem of
     Standard -> return ()
-    Linearity -> printPropertyTypes =<< typeCheckWithSubsystem @LinearityType typedProg
-    Polarity -> printPropertyTypes =<< typeCheckWithSubsystem @PolarityType typedProg
+    Linearity -> printPropertyTypes =<< typeCheckWithSubsystem @LinearityBuiltin typedProg
+    Polarity -> printPropertyTypes =<< typeCheckWithSubsystem @PolarityBuiltin typedProg
 
 --------------------------------------------------------------------------------
 -- Useful functions that apply to multiple compiler passes

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -9,7 +9,7 @@ import Vehicle.Compile.Normalise.NBE (runEmptyNormT, whnf)
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
-import Vehicle.Compile.Type.Subsystem.Standard (StandardBinder, StandardBuiltinType (..), StandardExpr, StandardType)
+import Vehicle.Compile.Type.Subsystem.Standard (StandardBinder, StandardBuiltin, StandardBuiltinType (..), StandardExpr, StandardType)
 import Vehicle.Compile.Type.Subsystem.Standard.Patterns
 import Vehicle.Expr.DeBruijn (Lv)
 import Vehicle.Expr.Normalisable (NormalisableBuiltin (..))
@@ -66,7 +66,7 @@ data NBETest = NBETest
 normalisationTest :: NBETest -> TestTree
 normalisationTest NBETest {..} =
   unitTestCase ("normalise" <> name) $ do
-    normInput <- runEmptyNormT @StandardBuiltinType $ whnf (mkNoOpEnv dbLevel) input
+    normInput <- runEmptyNormT @StandardBuiltin $ whnf (mkNoOpEnv dbLevel) input
     actual <- quote mempty dbLevel normInput
 
     let errorMessage =

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -176,6 +176,8 @@ library
     Vehicle.Compile.ExpandResources.Dataset.IDX
     Vehicle.Compile.FunctionaliseResources
     Vehicle.Compile.Monomorphisation
+    Vehicle.Compile.Normalise.Builtin
+    Vehicle.Compile.Normalise.Monad
     Vehicle.Compile.ObjectFile
     Vehicle.Compile.Prelude.Contexts
     Vehicle.Compile.Prelude.Utils


### PR DESCRIPTION
The first half of @wenkokke's proposed refactor to eliminate `NormalisableBuiltin`. Type-checking and normalisation no longer assume it's presence, but it still exists on the outside.