### PR TITLE
Refactor some Haskell module locations

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
@@ -25,12 +25,12 @@ instance NoThunks OrderOp
 instance NoThunks OrderDomain
 instance NoThunks Quantifier
 
--- Now Vehicle.Compile.Type.Subsystem.Linearity.Core
+-- Now Vehicle.Backend.Queries.Error.Linearity.Core
 -- instance NoThunks LinearityProvenance
 -- instance NoThunks Linearity
 -- instance NoThunks LinearityTypeClass
 
--- Now Vehicle.Compile.Type.Subsystem.Polarity.Core
+-- Now Vehicle.Backend.Queries.Error.Polarity.Core
 -- instance NoThunks PolarityProvenance
 -- instance NoThunks Polarity
 -- instance NoThunks PolarityTypeClass

--- a/vehicle/app/NewTest.hs
+++ b/vehicle/app/NewTest.hs
@@ -76,7 +76,7 @@ import Vehicle.Verify qualified as VerifyOptions
   ( VerifyOptions (..),
     verifierID,
   )
-import Vehicle.Verify.Core (QueryFormatID (MarabouQueries))
+import Vehicle.Verify.QueryFormat (QueryFormatID (MarabouQueries))
 
 main :: IO ()
 main = getArgs >>= newTestSpec

--- a/vehicle/src/Vehicle/Backend/Agda/CapitaliseTypeNames.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/CapitaliseTypeNames.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.CapitaliseTypeNames
+module Vehicle.Backend.Agda.CapitaliseTypeNames
   ( capitaliseTypeNames,
   )
 where
@@ -54,7 +54,7 @@ instance CapitaliseTypes TypeCheckedExpr where
     Meta p m -> return $ Meta p m
     Builtin p op -> return $ Builtin p op
     Ann p e t -> Ann p <$> cap e <*> cap t
-    App p fun args -> App p <$> cap fun <*> traverse cap args -- traverse cap args
+    App p fun args -> App p <$> cap fun <*> traverse cap args
     Pi p binder result -> Pi p <$> cap binder <*> cap result
     Let p bound binder body -> Let p <$> cap bound <*> cap binder <*> cap body
     Lam p binder body -> Lam p <$> cap binder <*> cap body

--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -19,8 +19,8 @@ import Data.Text qualified as Text
 import GHC.Real (denominator, numerator)
 import Prettyprinter hiding (hcat, hsep, vcat, vsep)
 import System.FilePath (takeBaseName)
+import Vehicle.Backend.Agda.CapitaliseTypeNames (capitaliseTypeNames)
 import Vehicle.Backend.Prelude
-import Vehicle.Compile.CapitaliseTypeNames (capitaliseTypeNames)
 import Vehicle.Compile.Descope (descopeNamed)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Monomorphisation

--- a/vehicle/src/Vehicle/Backend/Prelude.hs
+++ b/vehicle/src/Vehicle/Backend/Prelude.hs
@@ -6,7 +6,7 @@ import Data.Text.IO qualified as TIO
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
 import Vehicle.Prelude
-import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat.Core
 
 --------------------------------------------------------------------------------
 -- Differentiable logics

--- a/vehicle/src/Vehicle/Backend/Queries.hs
+++ b/vehicle/src/Vehicle/Backend/Queries.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Queries
+module Vehicle.Backend.Queries
   ( compileToQueries,
   )
 where
@@ -13,17 +13,17 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Traversable (for)
 import System.Directory (createDirectoryIfMissing)
+import Vehicle.Backend.Queries.Error
+import Vehicle.Backend.Queries.IfElimination (unfoldIf)
+import Vehicle.Backend.Queries.NetworkElimination
+import Vehicle.Backend.Queries.QuerySetStructure
+import Vehicle.Backend.Queries.UserVariableElimination (catchableUnsupportedNonLinearConstraint, eliminateUserVariables)
+import Vehicle.Backend.Queries.Variable (MixedVariables (MixedVariables), UserVariable (..), pattern VInfiniteQuantifier)
 import Vehicle.Compile.Error
 import Vehicle.Compile.ExpandResources (expandResources)
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly, prettyVerbose)
-import Vehicle.Compile.Queries.IfElimination (unfoldIf)
-import Vehicle.Compile.Queries.LinearityAndPolarityErrors
-import Vehicle.Compile.Queries.NetworkElimination
-import Vehicle.Compile.Queries.QuerySetStructure
-import Vehicle.Compile.Queries.UserVariableElimination (catchableUnsupportedNonLinearConstraint, eliminateUserVariables)
-import Vehicle.Compile.Queries.Variable (MixedVariables (MixedVariables), UserVariable (..), pattern VInfiniteQuantifier)
 import Vehicle.Compile.Resource
 import Vehicle.Compile.Type.Core (TypingDeclCtxEntry (..))
 import Vehicle.Compile.Type.Subsystem.Standard
@@ -33,6 +33,7 @@ import Vehicle.Expr.Boolean
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries.StandardLibrary (StdLibFunction (StdEqualsVector))
 import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat
 import Vehicle.Verify.Specification
 import Vehicle.Verify.Specification.IO
 

--- a/vehicle/src/Vehicle/Backend/Queries/Error.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error.hs
@@ -1,18 +1,18 @@
-module Vehicle.Compile.Queries.LinearityAndPolarityErrors
+module Vehicle.Backend.Queries.Error
   ( diagnoseNonLinearity,
     diagnoseAlternatingQuantifiers,
   )
 where
 
 import Control.Monad.Except (MonadError (..))
+import Vehicle.Backend.Queries.Error.Linearity
+import Vehicle.Backend.Queries.Error.Polarity
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Subsystem (typeCheckWithSubsystem)
-import Vehicle.Compile.Type.Subsystem.Linearity
-import Vehicle.Compile.Type.Subsystem.Polarity
 import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.Normalised (GluedExpr (..))
-import Vehicle.Verify.Core (QueryFormatID)
+import Vehicle.Verify.QueryFormat.Core (QueryFormatID)
 
 diagnoseNonLinearity ::
   forall m.

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity.hs
@@ -1,20 +1,20 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Vehicle.Compile.Type.Subsystem.Linearity
+module Vehicle.Backend.Queries.Error.Linearity
   ( module Core,
   )
 where
 
+import Vehicle.Backend.Queries.Error.Linearity.AnnotationRestrictions (assertConstantLinearity, checkNetworkType)
+import Vehicle.Backend.Queries.Error.Linearity.Core as Core
+import Vehicle.Backend.Queries.Error.Linearity.LinearitySolver
+import Vehicle.Backend.Queries.Error.Linearity.Type
 import Vehicle.Compile.Error (compilerDeveloperError)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Monad.Class (freshMeta)
 import Vehicle.Compile.Type.Subsystem.InputOutputInsertion
-import Vehicle.Compile.Type.Subsystem.Linearity.AnnotationRestrictions (assertConstantLinearity, checkNetworkType)
-import Vehicle.Compile.Type.Subsystem.Linearity.Core as Core
-import Vehicle.Compile.Type.Subsystem.Linearity.LinearitySolver
-import Vehicle.Compile.Type.Subsystem.Linearity.Type
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Builtin hiding (Builtin (..))

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/AnnotationRestrictions.hs
@@ -1,15 +1,15 @@
-module Vehicle.Compile.Type.Subsystem.Linearity.AnnotationRestrictions
+module Vehicle.Backend.Queries.Error.Linearity.AnnotationRestrictions
   ( assertConstantLinearity,
     checkNetworkType,
   )
 where
 
+import Vehicle.Backend.Queries.Error.Linearity.Core
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
-import Vehicle.Compile.Type.Subsystem.Linearity.Core
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/Core.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/Core.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Type.Subsystem.Linearity.Core where
+module Vehicle.Backend.Queries.Error.Linearity.Core where
 
 import Control.DeepSeq (NFData (..))
 import Data.Hashable (Hashable (..))

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/LinearitySolver.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/LinearitySolver.hs
@@ -1,12 +1,13 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {-# HLINT ignore "Use max" #-}
-module Vehicle.Compile.Type.Subsystem.Linearity.LinearitySolver
+module Vehicle.Backend.Queries.Error.Linearity.LinearitySolver
   ( solveLinearityConstraint,
   )
 where
 
 import Data.Maybe (mapMaybe)
+import Vehicle.Backend.Queries.Error.Linearity.Core
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Monad (MonadNorm)
 import Vehicle.Compile.Prelude
@@ -15,7 +16,6 @@ import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad (MonadTypeChecker)
 import Vehicle.Compile.Type.Monad.Class (addConstraints, solveMeta)
-import Vehicle.Compile.Type.Subsystem.Linearity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Interface
 import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Builtin

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/Type.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/Type.hs
@@ -1,11 +1,11 @@
-module Vehicle.Compile.Type.Subsystem.Linearity.Type
+module Vehicle.Backend.Queries.Error.Linearity.Type
   ( typeLinearityBuiltin,
   )
 where
 
 import Data.Text qualified as Text
+import Vehicle.Backend.Queries.Error.Linearity.Core
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Type.Subsystem.Linearity.Core
 import Vehicle.Expr.DSL
 import Vehicle.Expr.DeBruijn
 import Vehicle.Syntax.Builtin hiding (Builtin (..))

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity.hs
@@ -1,21 +1,21 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Vehicle.Compile.Type.Subsystem.Polarity
+module Vehicle.Backend.Queries.Error.Polarity
   ( module Core,
   )
 where
 
+import Vehicle.Backend.Queries.Error.Polarity.AnnotationRestrictions (assertUnquantifiedPolarity, checkNetworkType)
+import Vehicle.Backend.Queries.Error.Polarity.Core
+import Vehicle.Backend.Queries.Error.Polarity.Core as Core hiding (BuiltinFunction)
+import Vehicle.Backend.Queries.Error.Polarity.PolaritySolver
+import Vehicle.Backend.Queries.Error.Polarity.Type
 import Vehicle.Compile.Error (compilerDeveloperError)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Monad.Class (freshMeta)
 import Vehicle.Compile.Type.Subsystem.InputOutputInsertion
-import Vehicle.Compile.Type.Subsystem.Polarity.AnnotationRestrictions (assertUnquantifiedPolarity, checkNetworkType)
-import Vehicle.Compile.Type.Subsystem.Polarity.Core
-import Vehicle.Compile.Type.Subsystem.Polarity.Core as Core hiding (BuiltinFunction)
-import Vehicle.Compile.Type.Subsystem.Polarity.PolaritySolver
-import Vehicle.Compile.Type.Subsystem.Polarity.Type
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Builtin hiding (Builtin (..))

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/AnnotationRestrictions.hs
@@ -1,15 +1,15 @@
-module Vehicle.Compile.Type.Subsystem.Polarity.AnnotationRestrictions
+module Vehicle.Backend.Queries.Error.Polarity.AnnotationRestrictions
   ( assertUnquantifiedPolarity,
     checkNetworkType,
   )
 where
 
+import Vehicle.Backend.Queries.Error.Polarity.Core
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
-import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Expr.DeBruijn
 import Vehicle.Expr.Normalised
 

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/Core.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/Core.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Type.Subsystem.Polarity.Core where
+module Vehicle.Backend.Queries.Error.Polarity.Core where
 
 import Control.DeepSeq (NFData (..))
 import Data.Hashable (Hashable (..))

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/PolaritySolver.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/PolaritySolver.hs
@@ -1,17 +1,17 @@
-module Vehicle.Compile.Type.Subsystem.Polarity.PolaritySolver
+module Vehicle.Backend.Queries.Error.Polarity.PolaritySolver
   ( solvePolarityConstraint,
   )
 where
 
 import Control.Monad.Except (MonadError (..))
 import Data.Maybe (mapMaybe)
+import Vehicle.Backend.Queries.Error.Polarity.Core
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
-import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Interface
 import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Builtin

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/Type.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/Type.hs
@@ -1,10 +1,10 @@
-module Vehicle.Compile.Type.Subsystem.Polarity.Type
+module Vehicle.Backend.Queries.Error.Polarity.Type
   ( typePolarityBuiltin,
   )
 where
 
 import Data.Text qualified as Text
-import Vehicle.Compile.Type.Subsystem.Polarity.Core
+import Vehicle.Backend.Queries.Error.Polarity.Core
 import Vehicle.Expr.DSL
 import Vehicle.Expr.DeBruijn
 import Vehicle.Prelude

--- a/vehicle/src/Vehicle/Backend/Queries/FourierMotzkinElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/FourierMotzkinElimination.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Queries.FourierMotzkinElimination
+module Vehicle.Backend.Queries.FourierMotzkinElimination
   ( FourierMotzkinVariableSolution,
     fourierMotzkinElimination,
     reconstructFourierMotzkinVariableValue,
@@ -9,10 +9,10 @@ import Control.Monad (foldM)
 import Data.Set (Set)
 import Data.Set qualified as Set (toList)
 import Data.Vector qualified as Vector
+import Vehicle.Backend.Queries.LinearExpr
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.LinearExpr
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Verify.Core
 
 -- | TODO If performance proves unnacceptably poor look into

--- a/vehicle/src/Vehicle/Backend/Queries/GaussianElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/GaussianElimination.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Queries.GaussianElimination
+module Vehicle.Backend.Queries.GaussianElimination
   ( GaussianVariableSolution,
     gaussianElimination,
     reconstructGaussianVariableValue,
@@ -12,10 +12,10 @@ import Data.Coerce (coerce)
 import Data.IntSet (IntSet)
 import Data.IntSet qualified as IntSet
 import Data.Maybe (fromMaybe)
+import Vehicle.Backend.Queries.LinearExpr
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.LinearExpr
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Verify.Core
 
 -- | Performs Gaussian elimination. Returns a list of solved variables, the remaining

--- a/vehicle/src/Vehicle/Backend/Queries/IfElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/IfElimination.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {-# HLINT ignore "Avoid lambda using `infix`" #-}
-module Vehicle.Compile.Queries.IfElimination
+module Vehicle.Backend.Queries.IfElimination
   ( eliminateIfs,
     unfoldIf,
   )

--- a/vehicle/src/Vehicle/Backend/Queries/LinearExpr.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/LinearExpr.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Queries.LinearExpr
+module Vehicle.Backend.Queries.LinearExpr
   ( Relation (..),
     Assertion (..),
     UnreducedAssertion (..),
@@ -39,8 +39,8 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Vector qualified as Vector
 import GHC.Generics (Generic)
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Backend/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/NetworkElimination.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
-module Vehicle.Compile.Queries.NetworkElimination
+module Vehicle.Backend.Queries.NetworkElimination
   ( MetaNetworkPartition (..),
     replaceNetworkApplications,
   )
@@ -24,12 +24,12 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Traversable (for)
 import GHC.Generics (Generic)
+import Vehicle.Backend.Queries.LinearExpr (VectorEquality (..))
+import Vehicle.Backend.Queries.QuerySetStructure (UnreducedAssertion (..))
+import Vehicle.Backend.Queries.Variable (MixedVariable (..), MixedVariables (..), NetworkVariable (..), UserVariable (..), mixedVariableDBCtx, pattern VFiniteQuantifier)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly, prettyVerbose)
-import Vehicle.Compile.Queries.LinearExpr (VectorEquality (..))
-import Vehicle.Compile.Queries.QuerySetStructure (UnreducedAssertion (..))
-import Vehicle.Compile.Queries.Variable (MixedVariable (..), MixedVariables (..), NetworkVariable (..), UserVariable (..), mixedVariableDBCtx, pattern VFiniteQuantifier)
 import Vehicle.Compile.Resource
 import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Compile.Type.Subsystem.Standard.Interface

--- a/vehicle/src/Vehicle/Backend/Queries/QuerySetStructure.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/QuerySetStructure.hs
@@ -1,4 +1,4 @@
-module Vehicle.Compile.Queries.QuerySetStructure
+module Vehicle.Backend.Queries.QuerySetStructure
   ( SeriousPropertyError (..),
     PropertyError (..),
     UnreducedAssertion (..),
@@ -20,13 +20,13 @@ import Data.Map qualified as Map (keysSet, lookup)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set (intersection, map, null, singleton)
+import Vehicle.Backend.Queries.IfElimination (eliminateIfs, unfoldIf)
+import Vehicle.Backend.Queries.LinearExpr (UnreducedAssertion (..), VectorEquality (..))
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly, prettyVerbose)
-import Vehicle.Compile.Queries.IfElimination (eliminateIfs, unfoldIf)
-import Vehicle.Compile.Queries.LinearExpr (UnreducedAssertion (..), VectorEquality (..))
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Compile.Resource (NetworkContext)
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Subsystem.Standard

--- a/vehicle/src/Vehicle/Backend/Queries/UserVariableElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/UserVariableElimination.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
-module Vehicle.Compile.Queries.UserVariableElimination
+module Vehicle.Backend.Queries.UserVariableElimination
   ( eliminateUserVariables,
     catchableUnsupportedNonLinearConstraint,
   )
@@ -22,19 +22,19 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Traversable (for)
 import Data.Vector qualified as Vector
+import Vehicle.Backend.Queries.FourierMotzkinElimination (fourierMotzkinElimination)
+import Vehicle.Backend.Queries.GaussianElimination
+  ( gaussianElimination,
+  )
+import Vehicle.Backend.Queries.IfElimination (eliminateIfs, unfoldIf)
+import Vehicle.Backend.Queries.LinearExpr
+import Vehicle.Backend.Queries.QuerySetStructure (eliminateNot)
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Builtin (evalMul)
 import Vehicle.Compile.Normalise.NBE (defaultEvalOptions, reeval, runNormT)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
-import Vehicle.Compile.Queries.FourierMotzkinElimination (fourierMotzkinElimination)
-import Vehicle.Compile.Queries.GaussianElimination
-  ( gaussianElimination,
-  )
-import Vehicle.Compile.Queries.IfElimination (eliminateIfs, unfoldIf)
-import Vehicle.Compile.Queries.LinearExpr
-import Vehicle.Compile.Queries.QuerySetStructure (eliminateNot)
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Compile.Type.Subsystem.Standard.Interface
 import Vehicle.Compile.Warning (CompileWarning (ResortingtoFMElimination))

--- a/vehicle/src/Vehicle/Backend/Queries/Variable.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Variable.hs
@@ -2,7 +2,7 @@
 
 {-# HLINT ignore "Avoid lambda using `infix`" #-}
 {-# HLINT ignore "Eta reduce" #-}
-module Vehicle.Compile.Queries.Variable
+module Vehicle.Backend.Queries.Variable
   ( Variable (..),
     variableCtxToNormEnv,
     UserVariable (..),

--- a/vehicle/src/Vehicle/Backend/Queries/VariableReconstruction.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/VariableReconstruction.hs
@@ -1,12 +1,12 @@
-module Vehicle.Compile.Queries.VariableReconstruction where
+module Vehicle.Backend.Queries.VariableReconstruction where
 
 import Data.Foldable (foldlM)
 import Data.Map qualified as Map
 import Data.Vector qualified as Vector
+import Vehicle.Backend.Queries.FourierMotzkinElimination
+import Vehicle.Backend.Queries.GaussianElimination
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.FourierMotzkinElimination
-import Vehicle.Compile.Queries.GaussianElimination
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Verify.Core
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -60,7 +60,7 @@ import Vehicle.Prelude
 import Vehicle.TypeCheck (TypeCheckOptions (..))
 import Vehicle.Validate (ValidateOptions (..))
 import Vehicle.Verify (VerifierID, VerifyOptions (..))
-import Vehicle.Verify.Core (QueryFormatID)
+import Vehicle.Verify.QueryFormat
 
 --------------------------------------------------------------------------------
 -- Options objects

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -10,6 +10,7 @@ import Vehicle.Backend.Agda
 import Vehicle.Backend.JSON (ToJBuiltin, compileProgToJSON)
 import Vehicle.Backend.LossFunction qualified as LossFunction
 import Vehicle.Backend.Prelude
+import Vehicle.Backend.Queries
 import Vehicle.Compile.Dependency (analyseDependenciesAndPrune)
 import Vehicle.Compile.Error
 import Vehicle.Compile.EtaConversion (etaExpandProg)
@@ -17,7 +18,6 @@ import Vehicle.Compile.FunctionaliseResources (functionaliseResources)
 import Vehicle.Compile.Monomorphisation (hoistInferableParameters, monomorphise, removeLiteralCoercions)
 import Vehicle.Compile.Prelude as CompilePrelude
 import Vehicle.Compile.Print (prettyFriendly)
-import Vehicle.Compile.Queries
 import Vehicle.Compile.Type.Irrelevance (removeIrrelevantCodeFromProg)
 import Vehicle.Compile.Type.Monad (TypableBuiltin)
 import Vehicle.Compile.Type.Subsystem (resolveInstanceArguments)
@@ -25,8 +25,7 @@ import Vehicle.Compile.Type.Subsystem.Standard
 import Vehicle.Expr.DeBruijn (Ix)
 import Vehicle.Expr.Normalised (GluedExpr (..))
 import Vehicle.TypeCheck (TypeCheckOptions (..), runCompileMonad, typeCheckUserProg)
-import Vehicle.Verify.Core
-import Vehicle.Verify.Verifier (queryFormats)
+import Vehicle.Verify.QueryFormat
 
 --------------------------------------------------------------------------------
 -- Interface

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -9,15 +9,15 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as Map
 import Prettyprinter (list)
 import Vehicle.Backend.Prelude
+import Vehicle.Backend.Queries.Error.Linearity.Core
+import Vehicle.Backend.Queries.Error.Polarity.Core
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Subsystem.Linearity.Core
-import Vehicle.Compile.Type.Subsystem.Polarity.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Interface (HasStandardData, PrintableBuiltin)
 import Vehicle.Expr.DeBruijn
 import Vehicle.Syntax.Parse (ParseError)
-import Vehicle.Verify.Core (QueryFormatID)
+import Vehicle.Verify.QueryFormat.Core
 
 --------------------------------------------------------------------------------
 -- Compilation monad

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -12,13 +12,13 @@ import Data.Monoid (Endo (..))
 import Data.Text (Text, pack)
 import Prettyprinter (list)
 import System.FilePath
+import Vehicle.Backend.Queries.Error.Linearity
+import Vehicle.Backend.Queries.Error.Polarity
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Quote (unnormalise)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Subsystem.Linearity
-import Vehicle.Compile.Type.Subsystem.Polarity
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Interface
 import Vehicle.Expr.DSL

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -24,10 +24,10 @@ import Data.IntMap qualified as IntMap (assocs)
 import Data.Text (Text)
 import GHC.TypeLits (ErrorMessage (..), TypeError)
 import Prettyprinter (list)
+import Vehicle.Backend.Queries.LinearExpr (UnreducedAssertion (..), VectorEquality (..))
 import Vehicle.Compile.Descope
 import Vehicle.Compile.Normalise.Quote (unnormalise)
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.LinearExpr (UnreducedAssertion (..), VectorEquality (..))
 import Vehicle.Compile.Simplify
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta.Map (MetaMap (..))

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard.hs
@@ -13,8 +13,8 @@ import Vehicle.Compile.Type.Constraint.InstanceSolver
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Subsystem.Standard.AnnotationRestrictions
-import Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceDefaults ()
 import Vehicle.Compile.Type.Subsystem.Standard.Core as Core
+import Vehicle.Compile.Type.Subsystem.Standard.InstanceDefaults ()
 import Vehicle.Compile.Type.Subsystem.Standard.Type
 import Vehicle.Expr.Normalised
 import Prelude hiding (pi)

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/InstanceBuiltins.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/InstanceBuiltins.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
-module Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceBuiltins
+module Vehicle.Compile.Type.Subsystem.Standard.InstanceBuiltins
   ( standardBuiltinInstances,
   )
 where

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/InstanceDefaults.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/InstanceDefaults.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceDefaults where
+module Vehicle.Compile.Type.Subsystem.Standard.InstanceDefaults where
 
 import Data.Maybe (fromMaybe)
 import Vehicle.Compile.Error

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Patterns.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Patterns.hs
@@ -390,21 +390,6 @@ pattern FromRatExpr ::
   Expr var StandardBuiltin
 pattern FromRatExpr p dom args <- BuiltinFunctionExpr p (FromRat dom) args
 
-{-
-pattern FromVecExpr ::
-  Provenance ->
-  FromVecDomain ->
-  [Arg var StandardBuiltin] ->
-  Expr var StandardBuiltin
-pattern FromVecExpr p dom explicitArgs <-
-  FreeVar
-    p
-    (FromVec dom)
-    ( ImplicitArg _ _
-        :| ImplicitArg _ _
-        : explicitArgs
-      )
--}
 --------------------------------------------------------------------------------
 -- Boolean operations
 

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Patterns.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem/Standard/Patterns.hs
@@ -489,23 +489,3 @@ pattern AtExpr p tElem tDim explicitArgs <-
         :| IrrelevantImplicitArg _ tDim
         : explicitArgs
       )
-
---------------------------------------------------------------------------------
--- Vector
-
-pattern FoldVectorExpr ::
-  Provenance ->
-  Expr var StandardBuiltin ->
-  Expr var StandardBuiltin ->
-  Expr var StandardBuiltin ->
-  [Arg var StandardBuiltin] ->
-  Expr var StandardBuiltin
-pattern FoldVectorExpr p tElem size tRes explicitArgs <-
-  BuiltinFunctionExpr
-    p
-    (Fold FoldVector)
-    ( RelevantImplicitArg _ tElem
-        :| IrrelevantImplicitArg _ size
-        : RelevantImplicitArg _ tRes
-        : explicitArgs
-      )

--- a/vehicle/src/Vehicle/Compile/Warning.hs
+++ b/vehicle/src/Vehicle/Compile/Warning.hs
@@ -2,7 +2,7 @@ module Vehicle.Compile.Warning where
 
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Vehicle.Compile.Queries.Variable
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Prelude
 import Vehicle.Resource (ExternalResource)
 import Vehicle.Syntax.AST

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -13,6 +13,8 @@ import Control.Monad.Except (ExceptT, MonadError (..), runExcept)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Text as T (Text)
 import Vehicle.Backend.Prelude
+import Vehicle.Backend.Queries.Error.Linearity.Core (LinearityBuiltin)
+import Vehicle.Backend.Queries.Error.Polarity.Core (PolarityBuiltin)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Error.Message
 import Vehicle.Compile.ObjectFile
@@ -21,10 +23,8 @@ import Vehicle.Compile.Print
 import Vehicle.Compile.Scope (scopeCheck, scopeCheckClosedExpr)
 import Vehicle.Compile.Type (typeCheckExpr, typeCheckProg)
 import Vehicle.Compile.Type.Subsystem
-import Vehicle.Compile.Type.Subsystem.Linearity.Core (LinearityBuiltin)
-import Vehicle.Compile.Type.Subsystem.Polarity.Core (PolarityBuiltin)
 import Vehicle.Compile.Type.Subsystem.Standard
-import Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceBuiltins
+import Vehicle.Compile.Type.Subsystem.Standard.InstanceBuiltins
 import Vehicle.Expr.Normalised
 import Vehicle.Libraries (Library (..), LibraryInfo (..), findLibraryContentFile)
 import Vehicle.Libraries.StandardLibrary (standardLibrary)

--- a/vehicle/src/Vehicle/Verify.hs
+++ b/vehicle/src/Vehicle/Verify.hs
@@ -13,9 +13,8 @@ import Vehicle.Backend.Prelude (Target (..))
 import Vehicle.Compile (CompileOptions (..), compile)
 import Vehicle.Compile.Prelude (DatasetLocations, NetworkLocations, ParameterValues)
 import Vehicle.Prelude
-import Vehicle.Verify.Core
 import Vehicle.Verify.Specification.IO
-import Vehicle.Verify.Verifier (verifiers)
+import Vehicle.Verify.Verifier
 
 data VerifyOptions = VerifyOptions
   { specification :: FilePath,

--- a/vehicle/src/Vehicle/Verify/Core.hs
+++ b/vehicle/src/Vehicle/Verify/Core.hs
@@ -1,6 +1,5 @@
 module Vehicle.Verify.Core where
 
-import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -9,9 +8,9 @@ import Data.Vector (Vector)
 import Data.Vector qualified as Vector (toList)
 import GHC.Generics (Generic)
 import System.FilePath ((<.>))
+import Vehicle.Backend.Queries.LinearExpr (Assertion, SparseLinearExpr)
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Prelude (Name)
-import Vehicle.Compile.Queries.LinearExpr (Assertion, CLSTProblem, SparseLinearExpr)
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Compile.Resource
 import Vehicle.Prelude
 
@@ -49,40 +48,6 @@ instance Pretty UserVariableAssignment where
         let name = pretty $ userVarName var
         let valueDoc = prettyConstant True (userVarDimensions var) value
         name <> ":" <+> valueDoc
-
---------------------------------------------------------------------------------
--- Verifiers
-
-data VerifierID
-  = Marabou
-  deriving (Eq, Ord, Show, Read, Bounded, Enum)
-
-instance Pretty VerifierID where
-  pretty = pretty . show
-
--- | Location of the verifier executable file
-type VerifierExecutable = FilePath
-
--- | The type of methods to call a verifier on a query
-type VerifierInvocation =
-  forall m.
-  (MonadIO m) =>
-  VerifierExecutable ->
-  MetaNetwork ->
-  QueryFile ->
-  m (Either Text (QueryResult NetworkVariableAssignment))
-
--- | A complete verifier implementation
-data Verifier = Verifier
-  { -- | The identifier for the verifier within Vehicle itself
-    verifierIdentifier :: VerifierID,
-    -- | The query format that the verifier accepts
-    verifierQueryFormat :: QueryFormatID,
-    -- | The name of the executable for the verifier
-    verifierExecutableName :: String,
-    -- | The command to invoke the verifier
-    invokeVerifier :: VerifierInvocation
-  }
 
 --------------------------------------------------------------------------------
 -- Addresses
@@ -191,27 +156,6 @@ metaNetworkVariables :: Bool -> MetaNetwork -> [NetworkVariable]
 metaNetworkVariables reduced metaNetwork = do
   let (_, result) = foldr (metaNetworkEntryVariables reduced) (mempty, mempty) metaNetwork
   concat (reverse result)
-
---------------------------------------------------------------------------------
--- Query formats
-
-data QueryFormatID
-  = MarabouQueries
-  | VNNLibQueries
-  deriving (Show, Eq, Bounded, Enum)
-
-instance Pretty QueryFormatID where
-  pretty = \case
-    MarabouQueries -> "Marabou query format"
-    VNNLibQueries -> "VNNLib query format"
-
--- | A format for an output query that verifiers can parse.
-data QueryFormat = QueryFormat
-  { queryFormatID :: QueryFormatID,
-    queryOutputFormat :: ExternalOutputFormat,
-    -- | The command to compile an individual query
-    compileQuery :: forall m. (MonadLogger m) => CLSTProblem -> m QueryText
-  }
 
 --------------------------------------------------------------------------------
 -- Query results

--- a/vehicle/src/Vehicle/Verify/QueryFormat.hs
+++ b/vehicle/src/Vehicle/Verify/QueryFormat.hs
@@ -1,7 +1,9 @@
 module Vehicle.Verify.QueryFormat
-  ( QueryFormat (..),
-    QueryFormatID,
+  ( QueryFormatID (..),
+    QueryFormat (..),
     queryFormats,
+    marabouQueryFormat,
+    vnnlibQueryFormat,
   )
 where
 

--- a/vehicle/src/Vehicle/Verify/QueryFormat.hs
+++ b/vehicle/src/Vehicle/Verify/QueryFormat.hs
@@ -1,0 +1,15 @@
+module Vehicle.Verify.QueryFormat
+  ( QueryFormat (..),
+    QueryFormatID,
+    queryFormats,
+  )
+where
+
+import Vehicle.Verify.QueryFormat.Core
+import Vehicle.Verify.QueryFormat.Marabou (marabouQueryFormat)
+import Vehicle.Verify.QueryFormat.VNNLib (vnnlibQueryFormat)
+
+queryFormats :: QueryFormatID -> QueryFormat
+queryFormats = \case
+  MarabouQueries -> marabouQueryFormat
+  VNNLibQueries -> vnnlibQueryFormat

--- a/vehicle/src/Vehicle/Verify/QueryFormat/Core.hs
+++ b/vehicle/src/Vehicle/Verify/QueryFormat/Core.hs
@@ -1,0 +1,26 @@
+module Vehicle.Verify.QueryFormat.Core where
+
+import Data.Text (Text)
+import Vehicle.Backend.Queries.LinearExpr
+import Vehicle.Prelude
+
+--------------------------------------------------------------------------------
+-- Query formats
+
+data QueryFormatID
+  = MarabouQueries
+  | VNNLibQueries
+  deriving (Show, Eq, Bounded, Enum)
+
+instance Pretty QueryFormatID where
+  pretty = \case
+    MarabouQueries -> "Marabou query format"
+    VNNLibQueries -> "VNNLib query format"
+
+-- | A format for an output query that verifiers can parse.
+data QueryFormat = QueryFormat
+  { queryFormatID :: QueryFormatID,
+    queryOutputFormat :: ExternalOutputFormat,
+    -- | The command to compile an individual query
+    compileQuery :: forall m. (MonadLogger m) => CLSTProblem -> m Text
+  }

--- a/vehicle/src/Vehicle/Verify/QueryFormat/Marabou.hs
+++ b/vehicle/src/Vehicle/Verify/QueryFormat/Marabou.hs
@@ -8,11 +8,12 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Vehicle.Backend.Queries.LinearExpr
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.LinearExpr
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Syntax.Builtin
 import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat.Core
 
 --------------------------------------------------------------------------------
 -- Marabou query format

--- a/vehicle/src/Vehicle/Verify/QueryFormat/VNNLib.hs
+++ b/vehicle/src/Vehicle/Verify/QueryFormat/VNNLib.hs
@@ -4,11 +4,12 @@ import Control.Monad (forM)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Vehicle.Backend.Queries.LinearExpr
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.LinearExpr
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Syntax.Builtin
 import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat.Core
 
 --------------------------------------------------------------------------------
 -- Marabou query format

--- a/vehicle/src/Vehicle/Verify/Specification/IO.hs
+++ b/vehicle/src/Vehicle/Verify/Specification/IO.hs
@@ -34,13 +34,15 @@ import System.FilePath (takeExtension, (<.>), (</>))
 import System.IO (stderr, stdout)
 import System.ProgressBar
 import Vehicle.Backend.Prelude (writeResultToFile)
+import Vehicle.Backend.Queries.Variable (UserVariable (..))
+import Vehicle.Backend.Queries.VariableReconstruction (reconstructUserVars)
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Queries.Variable (UserVariable (..))
-import Vehicle.Compile.Queries.VariableReconstruction (reconstructUserVars)
 import Vehicle.Expr.Boolean
 import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat
 import Vehicle.Verify.Specification
 import Vehicle.Verify.Specification.Status
+import Vehicle.Verify.Verifier
 
 --------------------------------------------------------------------------------
 -- Specification

--- a/vehicle/src/Vehicle/Verify/Specification/Status.hs
+++ b/vehicle/src/Vehicle/Verify/Specification/Status.hs
@@ -6,9 +6,9 @@ import Data.Text (Text, pack)
 import Data.Vector qualified as Vector
 import GHC.Generics (Generic)
 import System.Console.ANSI (Color (..))
+import Vehicle.Backend.Queries.Variable
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly)
-import Vehicle.Compile.Queries.Variable
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Compile.Type.Subsystem.Standard.Interface
 import Vehicle.Expr.Boolean (MaybeTrivial (..))

--- a/vehicle/src/Vehicle/Verify/Verifier.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier.hs
@@ -1,18 +1,13 @@
 module Vehicle.Verify.Verifier
-  ( verifiers,
-    queryFormats,
+  ( Verifier (..),
+    VerifierID,
+    verifiers,
+    VerifierExecutable,
   )
 where
 
-import Vehicle.Verify.Core
-import Vehicle.Verify.QueryFormat.Marabou (marabouQueryFormat)
-import Vehicle.Verify.QueryFormat.VNNLib (vnnlibQueryFormat)
+import Vehicle.Verify.Verifier.Core
 import Vehicle.Verify.Verifier.Marabou (marabouVerifier)
-
-queryFormats :: QueryFormatID -> QueryFormat
-queryFormats = \case
-  MarabouQueries -> marabouQueryFormat
-  VNNLibQueries -> vnnlibQueryFormat
 
 verifiers :: VerifierID -> Verifier
 verifiers = \case

--- a/vehicle/src/Vehicle/Verify/Verifier.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier.hs
@@ -1,7 +1,8 @@
 module Vehicle.Verify.Verifier
-  ( Verifier (..),
-    VerifierID,
+  ( VerifierID (..),
+    Verifier (..),
     verifiers,
+    marabouVerifier,
     VerifierExecutable,
   )
 where

--- a/vehicle/src/Vehicle/Verify/Verifier/Core.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier/Core.hs
@@ -1,0 +1,41 @@
+module Vehicle.Verify.Verifier.Core where
+
+import Control.Monad.IO.Class (MonadIO)
+import Data.Text (Text)
+import Vehicle.Compile.Prelude
+import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat.Core
+
+--------------------------------------------------------------------------------
+-- Verifiers
+
+data VerifierID
+  = Marabou
+  deriving (Eq, Ord, Show, Read, Bounded, Enum)
+
+instance Pretty VerifierID where
+  pretty = pretty . show
+
+-- | Location of the verifier executable file
+type VerifierExecutable = FilePath
+
+-- | The type of methods to call a verifier on a query
+type VerifierInvocation =
+  forall m.
+  (MonadIO m) =>
+  VerifierExecutable ->
+  MetaNetwork ->
+  QueryFile ->
+  m (Either Text (QueryResult NetworkVariableAssignment))
+
+-- | A complete verifier implementation
+data Verifier = Verifier
+  { -- | The identifier for the verifier within Vehicle itself
+    verifierIdentifier :: VerifierID,
+    -- | The query format that the verifier accepts
+    verifierQueryFormat :: QueryFormatID,
+    -- | The name of the executable for the verifier
+    verifierExecutableName :: String,
+    -- | The command to invoke the verifier
+    invokeVerifier :: VerifierInvocation
+  }

--- a/vehicle/src/Vehicle/Verify/Verifier/Marabou.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier/Marabou.hs
@@ -14,6 +14,8 @@ import System.IO (stderr)
 import System.Process (readProcessWithExitCode)
 import Vehicle.Compile.Prelude
 import Vehicle.Verify.Core
+import Vehicle.Verify.QueryFormat.Core
+import Vehicle.Verify.Verifier.Core
 
 --------------------------------------------------------------------------------
 -- The main interface

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
@@ -25,7 +25,7 @@ import Vehicle.Prelude
 import Vehicle.TypeCheck (TypeCheckOptions (..))
 import Vehicle.Validate (ValidateOptions (..))
 import Vehicle.Verify (VerifyOptions (..))
-import Vehicle.Verify.Core (VerifierID (..))
+import Vehicle.Verify.Verifier (VerifierID (..))
 
 commandLineParserTests :: TestTree
 commandLineParserTests =

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -162,12 +162,8 @@ library
     Vehicle.TypeCheck
     Vehicle.Validate
     Vehicle.Verify
-    Vehicle.Verify.Core
-    Vehicle.Verify.QueryFormat.Marabou
-    Vehicle.Verify.QueryFormat.VNNLib
-    Vehicle.Verify.Specification
-    Vehicle.Verify.Specification.IO
-    Vehicle.Verify.Specification.Status
+    Vehicle.Verify.QueryFormat
+    Vehicle.Verify.Verifier
 
   other-modules:
     Paths_vehicle
@@ -241,9 +237,13 @@ library
     Vehicle.Prelude.Prettyprinter
     Vehicle.Prelude.Supply
     Vehicle.Prelude.Version
-    Vehicle.Verify.QueryFormat
+    Vehicle.Verify.Core
     Vehicle.Verify.QueryFormat.Core
-    Vehicle.Verify.Verifier
+    Vehicle.Verify.QueryFormat.Marabou
+    Vehicle.Verify.QueryFormat.VNNLib
+    Vehicle.Verify.Specification
+    Vehicle.Verify.Specification.IO
+    Vehicle.Verify.Specification.Status
     Vehicle.Verify.Verifier.Core
     Vehicle.Verify.Verifier.Marabou
 

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -117,6 +117,16 @@ library
     Vehicle.Backend.Agda
     Vehicle.Backend.LossFunction
     Vehicle.Backend.Prelude
+    Vehicle.Backend.Queries.Error
+    Vehicle.Backend.Queries.FourierMotzkinElimination
+    Vehicle.Backend.Queries.GaussianElimination
+    Vehicle.Backend.Queries.IfElimination
+    Vehicle.Backend.Queries.LinearExpr
+    Vehicle.Backend.Queries.NetworkElimination
+    Vehicle.Backend.Queries.QuerySetStructure
+    Vehicle.Backend.Queries.UserVariableElimination
+    Vehicle.Backend.Queries.Variable
+    Vehicle.Backend.Queries.VariableReconstruction
     Vehicle.CommandLine
     Vehicle.Compile
     Vehicle.Compile.Descope
@@ -132,16 +142,6 @@ library
     Vehicle.Compile.Normalise.Quote
     Vehicle.Compile.Prelude
     Vehicle.Compile.Print
-    Vehicle.Compile.Queries.FourierMotzkinElimination
-    Vehicle.Compile.Queries.GaussianElimination
-    Vehicle.Compile.Queries.IfElimination
-    Vehicle.Compile.Queries.LinearExpr
-    Vehicle.Compile.Queries.LinearityAndPolarityErrors
-    Vehicle.Compile.Queries.NetworkElimination
-    Vehicle.Compile.Queries.QuerySetStructure
-    Vehicle.Compile.Queries.UserVariableElimination
-    Vehicle.Compile.Queries.Variable
-    Vehicle.Compile.Queries.VariableReconstruction
     Vehicle.Compile.Resource
     Vehicle.Compile.Scope
     Vehicle.Compile.Simplify
@@ -171,6 +171,7 @@ library
 
   other-modules:
     Paths_vehicle
+    Vehicle.Backend.Agda.CapitaliseTypeNames
     Vehicle.Backend.Agda.Compile
     Vehicle.Backend.Agda.Interact
     Vehicle.Backend.JSON
@@ -181,8 +182,18 @@ library
     Vehicle.Backend.LossFunction.TypeSystem.InstanceBuiltins
     Vehicle.Backend.LossFunction.TypeSystem.InstanceDefaults
     Vehicle.Backend.LossFunction.TypeSystem.Type
+    Vehicle.Backend.Queries
+    Vehicle.Backend.Queries.Error.Linearity
+    Vehicle.Backend.Queries.Error.Linearity.AnnotationRestrictions
+    Vehicle.Backend.Queries.Error.Linearity.Core
+    Vehicle.Backend.Queries.Error.Linearity.LinearitySolver
+    Vehicle.Backend.Queries.Error.Linearity.Type
+    Vehicle.Backend.Queries.Error.Polarity
+    Vehicle.Backend.Queries.Error.Polarity.AnnotationRestrictions
+    Vehicle.Backend.Queries.Error.Polarity.Core
+    Vehicle.Backend.Queries.Error.Polarity.PolaritySolver
+    Vehicle.Backend.Queries.Error.Polarity.Type
     Vehicle.Compile.Arity
-    Vehicle.Compile.CapitaliseTypeNames
     Vehicle.Compile.Dependency
     Vehicle.Compile.EtaConversion
     Vehicle.Compile.ExpandResources.Dataset.IDX
@@ -193,7 +204,6 @@ library
     Vehicle.Compile.Prelude.Contexts
     Vehicle.Compile.Prelude.MonadContext
     Vehicle.Compile.Prelude.Utils
-    Vehicle.Compile.Queries
     Vehicle.Compile.Type.Bidirectional
     Vehicle.Compile.Type.Constraint.Core
     Vehicle.Compile.Type.Constraint.IndexSolver
@@ -214,20 +224,10 @@ library
     Vehicle.Compile.Type.Monad.Instance
     Vehicle.Compile.Type.Subsystem
     Vehicle.Compile.Type.Subsystem.InputOutputInsertion
-    Vehicle.Compile.Type.Subsystem.Linearity
-    Vehicle.Compile.Type.Subsystem.Linearity.AnnotationRestrictions
-    Vehicle.Compile.Type.Subsystem.Linearity.Core
-    Vehicle.Compile.Type.Subsystem.Linearity.LinearitySolver
-    Vehicle.Compile.Type.Subsystem.Linearity.Type
-    Vehicle.Compile.Type.Subsystem.Polarity
-    Vehicle.Compile.Type.Subsystem.Polarity.AnnotationRestrictions
-    Vehicle.Compile.Type.Subsystem.Polarity.Core
-    Vehicle.Compile.Type.Subsystem.Polarity.PolaritySolver
-    Vehicle.Compile.Type.Subsystem.Polarity.Type
     Vehicle.Compile.Type.Subsystem.Standard.AnnotationRestrictions
-    Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceBuiltins
-    Vehicle.Compile.Type.Subsystem.Standard.Constraint.InstanceDefaults
     Vehicle.Compile.Type.Subsystem.Standard.Core
+    Vehicle.Compile.Type.Subsystem.Standard.InstanceBuiltins
+    Vehicle.Compile.Type.Subsystem.Standard.InstanceDefaults
     Vehicle.Compile.Type.Subsystem.Standard.Type
     Vehicle.Compile.Warning
     Vehicle.Debug
@@ -241,7 +241,10 @@ library
     Vehicle.Prelude.Prettyprinter
     Vehicle.Prelude.Supply
     Vehicle.Prelude.Version
+    Vehicle.Verify.QueryFormat
+    Vehicle.Verify.QueryFormat.Core
     Vehicle.Verify.Verifier
+    Vehicle.Verify.Verifier.Core
     Vehicle.Verify.Verifier.Marabou
 
   autogen-modules: Paths_vehicle


### PR DESCRIPTION
This is a no-op rearrangement of the location of modules in the compiler, as over the past year there's been lots of changes that mean some module's locations no longer make much sense. Done as the first part of documenting the compiler in preparation for wrapping up the project.