### PR TITLE
Remove higher order declarations before exporting to JSON

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Vehicle.Syntax.AST.Binder where
 
 import Control.DeepSeq (NFData)
@@ -68,13 +70,6 @@ instance HasName BinderDisplayForm (Maybe Name) where
   nameOf = nameOf . namingForm
 
 instance Serialize BinderDisplayForm
-
-mapBinderFormName :: (Name -> Name) -> BinderDisplayForm -> BinderDisplayForm
-mapBinderFormName f binderDisplayForm =
-  BinderDisplayForm
-    { namingForm = mapBindingNamingFormName f $ namingForm binderDisplayForm,
-      foldingForm = foldingForm binderDisplayForm
-    }
 
 --------------------------------------------------------------------------------
 -- Binders
@@ -154,3 +149,14 @@ binderNamingForm = namingForm . binderDisplayForm
 
 setBinderRelevance :: GenericBinder expr -> Relevance -> GenericBinder expr
 setBinderRelevance (Binder p u v _r x) r = Binder p u v r x
+
+mapBinderNamingForm :: (BinderNamingForm -> BinderNamingForm) -> GenericBinder expr -> GenericBinder expr
+mapBinderNamingForm f Binder {..} =
+  Binder
+    { binderDisplayForm =
+        BinderDisplayForm
+          { namingForm = f $ namingForm binderDisplayForm,
+            foldingForm = foldingForm binderDisplayForm
+          },
+      ..
+    }

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -192,7 +192,9 @@ type Telescope var builtin = [Binder var builtin]
 mkHole :: Provenance -> Name -> Expr var builtin
 mkHole p name = Hole p ("_" <> name)
 
-isTypeSynonym :: Expr var builtin -> Bool
+-- | Tests if a definition's type indicates that the definition is a type
+-- synonym.
+isTypeSynonym :: Type var builtin -> Bool
 isTypeSynonym = \case
   Universe {} -> True
   Pi _ _ res -> isTypeSynonym res

--- a/vehicle/lib/std.vcl
+++ b/vehicle/lib/std.vcl
@@ -52,10 +52,10 @@ notEqualsVector xs ys = bigOr (zipWith (\x y -> x != y) xs ys)
 --------------------------------------------------------------------------------
 
 existsIndex : forallT n . (Index n -> Bool) -> Bool
-existsIndex n f = bigOr (foreach i . f i)
+existsIndex n f = bigOr (map f (indices n))
 
 forallIndex : forallT n . (Index n -> Bool) -> Bool
-forallIndex n f = bigAnd (foreach i . f i)
+forallIndex n f = bigAnd (map f (indices n))
 
 --------------------------------------------------------------------------------
 -- Tensor

--- a/vehicle/src/Vehicle/Backend/Tensors/Clean.hs
+++ b/vehicle/src/Vehicle/Backend/Tensors/Clean.hs
@@ -1,0 +1,104 @@
+module Vehicle.Backend.Tensors.Clean
+  ( cleanUpHigherOrderStuff,
+  )
+where
+
+import Control.Monad.State (MonadState, evalStateT, gets, modify)
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (maybeToList)
+import Data.Proxy (Proxy (..))
+import Vehicle.Compile.Error
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Prelude.MonadContext (MonadContext (addDeclToContext), normalise, runContextT, unnormalise)
+import Vehicle.Expr.BuiltinInterface
+
+cleanUpHigherOrderStuff ::
+  forall m builtin.
+  (MonadCompile m, HasStandardData builtin, PrintableBuiltin builtin) =>
+  Prog Ix builtin ->
+  m (Prog Ix builtin)
+cleanUpHigherOrderStuff (Main ds) =
+  Main <$> runContextT (Proxy @builtin) (evalStateT (cleanDecls ds) mempty) mempty
+
+type MonadClean m builtin =
+  ( MonadCompile m,
+    MonadState (Map Identifier (Bool, Expr Ix builtin)) m,
+    MonadContext builtin m,
+    PrintableBuiltin builtin
+  )
+
+cleanDecls :: forall m builtin. (MonadClean m builtin) => [Decl Ix builtin] -> m [Decl Ix builtin]
+cleanDecls = \case
+  [] -> return []
+  decl : decls -> do
+    cleanedDecl <- traverse cleanExpr decl
+    addDeclToContext cleanedDecl $ do
+      let ident = identifierOf decl
+      let declType = typeOf decl
+      maybeNewDecl <- case cleanedDecl of
+        DefAbstract {} -> return $ Just cleanedDecl
+        DefFunction _ _ _ _ e -> do
+          if isTypeSynonym declType
+            then do
+              modify (Map.insert ident (True, e))
+              return Nothing
+            else
+              if hasHigherOrderFunctions declType
+                then do
+                  modify (Map.insert ident (False, e))
+                  return Nothing
+                else return $ Just cleanedDecl
+
+      cleanedDecls <- cleanDecls decls
+      return $ maybeToList maybeNewDecl <> cleanedDecls
+
+hasHigherOrderFunctions :: Type Ix builtin -> Bool
+hasHigherOrderFunctions = \case
+  Pi _ binder body -> case typeOf binder of
+    Pi {} -> True
+    _ -> hasHigherOrderFunctions body
+  _ -> False
+
+cleanExpr :: (MonadClean m builtin) => Expr Ix builtin -> m (Expr Ix builtin)
+cleanExpr expr = case expr of
+  -- Free variables test to see if they should be eliminated
+  FreeVar p v -> cleanFreeVar p p v []
+  App p1 fun args -> do
+    args' <- traverse (traverse cleanExpr) args
+    case fun of
+      FreeVar p2 v -> cleanFreeVar p1 p2 v (NonEmpty.toList args')
+      Lam {} -> substArgs p1 <$> cleanExpr fun <*> pure (NonEmpty.toList args')
+      _ -> App p1 <$> cleanExpr fun <*> pure args'
+
+  -- Pi binders should have the binder form changed so as to only display the
+  -- type as we no longer have dependently typed-indices.
+  Pi p binder body -> do
+    let typeOnlyBinder = mapBinderNamingForm (const OnlyType) binder
+    Pi p <$> traverse cleanExpr typeOnlyBinder <*> cleanExpr body
+  BoundVar {} -> return expr
+  Universe {} -> return expr
+  Meta {} -> return expr
+  Hole {} -> return expr
+  Builtin {} -> return expr
+  Ann _p e _t -> cleanExpr e
+  Let p e1 binder e2 -> Let p <$> cleanExpr e1 <*> traverse cleanExpr binder <*> cleanExpr e2
+  Lam p binder e -> Lam p <$> traverse cleanExpr binder <*> cleanExpr e
+
+cleanFreeVar ::
+  (MonadClean m builtin) =>
+  Provenance ->
+  Provenance ->
+  Identifier ->
+  [Arg Ix builtin] ->
+  m (Expr Ix builtin)
+cleanFreeVar p1 p2 ident args = do
+  maybeSubstitution <- gets (Map.lookup ident)
+  case maybeSubstitution of
+    Nothing -> return $ normAppList p1 (FreeVar p2 ident) args
+    Just (shouldNormalise, value) -> do
+      let newValue = substArgs p1 value args
+      if shouldNormalise
+        then unnormalise =<< normalise newValue
+        else return newValue

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -130,9 +130,7 @@ compileToTensors prog outputFile outputAsJSON = do
   let monomorphiseIf = isPropertyDecl
   monomorphiseProg <- monomorphise monomorphiseIf "_" relevantProg
   literalFreeProg <- removeLiteralCoercions "_" monomorphiseProg
-  logDebug MinDetail $ prettyFriendly literalFreeProg
   cleanedProg <- cleanUpHigherOrderStuff literalFreeProg
-  logDebug MinDetail $ prettyFriendly cleanedProg
 
   hoistedProg <- hoistInferableParameters cleanedProg
   functionalisedProg <- functionaliseResources hoistedProg

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -91,8 +91,6 @@ instance (MonadNorm builtin m) => MetaSubstitutable m (Value builtin) where
           case args of
             [] -> return substValue
             (a : as) -> evalApp substValue (a : as)
-    -- logDebug MaxDetail $ prettyVerbose substValue -- <+> prettyVerbose (fmap argExpr (a : as))
-
     VUniverse {} -> return expr
     VFreeVar v spine -> VFreeVar v <$> traverse subst spine
     VBoundVar v spine -> VBoundVar v <$> traverse subst spine

--- a/vehicle/tests/golden/compile/acasXu/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/acasXu/Explicit.vcl.golden
@@ -1,19 +1,8 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
-
-foreachVector__Rat : forallT n . (Index -> Rat) -> Vector Rat;
-foreachVector__Rat n f = map f (indices n)
-
-foreachVector__Bool : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector__Bool n f = map f (indices n)
-
-forallIndex : forallT n . (Index -> Bool) -> Bool;
-forallIndex n f = bigAnd (foreachVector__Bool n (\ i -> f i))
 
 pi : Rat;
 pi = 3.141592
-
-type InputVector = Vector Rat
 
 distanceToIntruder : Index;
 distanceToIntruder = 0
@@ -30,8 +19,6 @@ speed = 3
 intruderSpeed : Index;
 intruderSpeed = 4
 
-type OutputVector = Vector Rat
-
 clearOfConflict : Index;
 clearOfConflict = 0
 
@@ -44,101 +31,99 @@ strongLeft = 3
 strongRight : Index;
 strongRight = 4
 
-type UnnormalisedInputVector = Vector Rat
-
-minimumInputValues : UnnormalisedInputVector;
+minimumInputValues : Vector Rat;
 minimumInputValues = [0.0, - pi, - pi, 100.0, 0.0]
 
-maximumInputValues : UnnormalisedInputVector;
+maximumInputValues : Vector Rat;
 maximumInputValues = [60261.0, pi, pi, 1200.0, 1200.0]
 
-validInput : UnnormalisedInputVector -> Bool;
-validInput x = forallIndex 5 (\ i -> minimumInputValues ! i <= x ! i and x ! i <= maximumInputValues ! i)
+validInput : Vector Rat -> Bool;
+validInput x = bigAnd (map (\ i -> minimumInputValues ! i <= x ! i and x ! i <= maximumInputValues ! i) (indices 5))
 
-meanScalingValues : UnnormalisedInputVector;
+meanScalingValues : Vector Rat;
 meanScalingValues = [19791.091, 0.0, 0.0, 650.0, 600.0]
 
-normalise : UnnormalisedInputVector -> InputVector;
-normalise x = foreachVector__Rat 5 (\ i -> (x ! i - meanScalingValues ! i) - (maximumInputValues ! i - minimumInputValues ! i))
+normalise : Vector Rat -> Vector Rat;
+normalise x = map (\ i -> (x ! i - meanScalingValues ! i) - (maximumInputValues ! i - minimumInputValues ! i)) (indices 5)
 
-normAcasXu : forallT (acasXu : InputVector -> OutputVector) . UnnormalisedInputVector -> OutputVector;
+normAcasXu : forallT (acasXu : Vector Rat -> Vector Rat) . Vector Rat -> Vector Rat;
 normAcasXu acasXu x = acasXu (normalise x)
 
-minimalScore : forallT (acasXu : InputVector -> OutputVector) . Index -> UnnormalisedInputVector -> Bool;
-minimalScore acasXu i x = forallIndex 5 (\ j -> i != j => normAcasXu acasXu x ! i < normAcasXu acasXu x ! j)
+minimalScore : forallT (acasXu : Vector Rat -> Vector Rat) . Index -> Vector Rat -> Bool;
+minimalScore acasXu i x = bigAnd (map (\ j -> i != j => normAcasXu acasXu x ! i < normAcasXu acasXu x ! j) (indices 5))
 
-maximalScore : forallT (acasXu : InputVector -> OutputVector) . Index -> UnnormalisedInputVector -> Bool;
-maximalScore acasXu i x = forallIndex 5 (\ j -> i != j => normAcasXu acasXu x ! i > normAcasXu acasXu x ! j)
+maximalScore : forallT (acasXu : Vector Rat -> Vector Rat) . Index -> Vector Rat -> Bool;
+maximalScore acasXu i x = bigAnd (map (\ j -> i != j => normAcasXu acasXu x ! i > normAcasXu acasXu x ! j) (indices 5))
 
 scaleCOCOutput : Rat -> Rat;
 scaleCOCOutput x = (x - 7.518884) - 373.94992
 
-intruderDistantAndSlower : UnnormalisedInputVector -> Bool;
+intruderDistantAndSlower : Vector Rat -> Bool;
 intruderDistantAndSlower x = x ! distanceToIntruder >= 55947.691 and x ! speed >= 1145.0 and x ! intruderSpeed <= 60.0
 
 @property;
-property1 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property1 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property1 acasXu = forall x . validInput x and intruderDistantAndSlower x => normAcasXu acasXu x ! clearOfConflict <= scaleCOCOutput 1500.0
 
 @property;
-property2 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property2 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property2 acasXu = forall x . validInput x and intruderDistantAndSlower x => not maximalScore acasXu clearOfConflict x
 
-directlyAhead : UnnormalisedInputVector -> Bool;
+directlyAhead : Vector Rat -> Bool;
 directlyAhead x = (1500.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 1800.0) and - 6.0e-2 <= x ! angleToIntruder and x ! angleToIntruder <= 6.0e-2
 
-movingTowards : UnnormalisedInputVector -> Bool;
+movingTowards : Vector Rat -> Bool;
 movingTowards x = x ! intruderHeading >= 3.1 and x ! speed >= 980.0 and x ! intruderSpeed >= 960.0
 
 @property;
-property3 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property3 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property3 acasXu = forall x . validInput x and directlyAhead x and movingTowards x => not minimalScore acasXu clearOfConflict x
 
-movingAway : UnnormalisedInputVector -> Bool;
+movingAway : Vector Rat -> Bool;
 movingAway x = x ! intruderHeading == 0.0 and 1000.0 <= x ! speed and 700.0 <= x ! intruderSpeed and x ! intruderSpeed <= 800.0
 
 @property;
-property4 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property4 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property4 acasXu = forall x . validInput x and directlyAhead x and movingAway x => not minimalScore acasXu clearOfConflict x
 
-nearAndApproachingFromLeft : UnnormalisedInputVector -> Bool;
+nearAndApproachingFromLeft : Vector Rat -> Bool;
 nearAndApproachingFromLeft x = (250.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 400.0) and (0.2 <= x ! angleToIntruder and x ! angleToIntruder <= 0.4) and (- pi <= x ! intruderHeading and x ! intruderHeading <= - pi + 5.0e-3) and (100.0 <= x ! speed and x ! speed <= 400.0) and 0.0 <= x ! intruderSpeed and x ! intruderSpeed <= 400.0
 
 @property;
-property5 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property5 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property5 acasXu = forall x . validInput x and nearAndApproachingFromLeft x => minimalScore acasXu strongRight x
 
-intruderFarAway : UnnormalisedInputVector -> Bool;
+intruderFarAway : Vector Rat -> Bool;
 intruderFarAway x = (12000.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 62000.0) and ((- pi <= x ! angleToIntruder and x ! angleToIntruder <= - 0.7) or 0.7 <= x ! angleToIntruder and x ! angleToIntruder <= pi) and (- pi <= x ! intruderHeading and x ! intruderHeading <= - pi + 5.0e-3) and (100.0 <= x ! speed and x ! speed <= 1200.0) and 0.0 <= x ! intruderSpeed and x ! intruderSpeed <= 1200.0
 
 @property;
-property6 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property6 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property6 acasXu = forall x . validInput x and intruderFarAway x => minimalScore acasXu clearOfConflict x
 
-largeVerticalSeparation : UnnormalisedInputVector -> Bool;
+largeVerticalSeparation : Vector Rat -> Bool;
 largeVerticalSeparation x = (0.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 60760.0) and (- pi <= x ! angleToIntruder and x ! angleToIntruder <= pi) and (- pi <= x ! intruderHeading and x ! intruderHeading <= pi) and (100.0 <= x ! speed and x ! speed <= 1200.0) and 0.0 <= x ! intruderSpeed and x ! intruderSpeed <= 1200.0
 
 @property;
-property7 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property7 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property7 acasXu = forall x . validInput x and largeVerticalSeparation x => not minimalScore acasXu strongLeft x and not minimalScore acasXu strongRight x
 
-largeVerticalSeparationAndPreviousWeakLeft : UnnormalisedInputVector -> Bool;
+largeVerticalSeparationAndPreviousWeakLeft : Vector Rat -> Bool;
 largeVerticalSeparationAndPreviousWeakLeft x = (0.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 60760.0) and (- pi <= x ! angleToIntruder and x ! angleToIntruder <= - 0.75 * pi) and (- 0.1 <= x ! intruderHeading and x ! intruderHeading <= 0.1) and (600.0 <= x ! speed and x ! speed <= 1200.0) and 600.0 <= x ! intruderSpeed and x ! intruderSpeed <= 1200.0
 
 @property;
-property8 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property8 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property8 acasXu = forall x . validInput x and largeVerticalSeparationAndPreviousWeakLeft x => minimalScore acasXu clearOfConflict x or minimalScore acasXu weakLeft x
 
-previousWeakRightAndNearbyIntruder : UnnormalisedInputVector -> Bool;
+previousWeakRightAndNearbyIntruder : Vector Rat -> Bool;
 previousWeakRightAndNearbyIntruder x = (2000.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 7000.0) and (- 0.4 <= x ! angleToIntruder and x ! angleToIntruder <= - 0.14) and (- pi <= x ! intruderHeading and x ! intruderHeading <= - pi + 1.0e-2) and (100.0 <= x ! speed and x ! speed <= 150.0) and 0.0 <= x ! intruderSpeed and x ! intruderSpeed <= 150.0
 
 @property;
-property9 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property9 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property9 acasXu = forall x . validInput x and previousWeakRightAndNearbyIntruder x => minimalScore acasXu strongLeft x
 
-intruderFarAway2 : UnnormalisedInputVector -> Bool;
+intruderFarAway2 : Vector Rat -> Bool;
 intruderFarAway2 x = (36000.0 <= x ! distanceToIntruder and x ! distanceToIntruder <= 60760.0) and (0.7 <= x ! angleToIntruder and x ! angleToIntruder <= pi) and (- pi <= x ! intruderHeading and x ! intruderHeading <= - pi + 1.0e-2) and (900.0 <= x ! speed and x ! speed <= 1200.0) and 600.0 <= x ! intruderSpeed and x ! intruderSpeed <= 1200.0
 
 @property;
-property10 : forallT (acasXu : InputVector -> OutputVector) . Bool;
+property10 : forallT (acasXu : Vector Rat -> Vector Rat) . Bool;
 property10 acasXu = forall x . validInput x and intruderFarAway2 x => minimalScore acasXu clearOfConflict x

--- a/vehicle/tests/golden/compile/andGate/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/andGate/DL2Loss.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 truthy : Rat -> Rat;
 truthy x = max 0.0 (0.5 - x) + (if 0.5 == x then 1.0 else 0.0)
 
@@ -9,9 +7,9 @@ falsey x = max 0.0 (x - 0.5) + (if x == 0.5 then 1.0 else 0.0)
 validInput : Rat -> Rat;
 validInput x = max 0.0 (0.0 - x) + (if 0.0 == x then 1.0 else 0.0) + (max 0.0 (x - 1.0) + (if x == 1.0 then 1.0 else 0.0))
 
-correctOutput : forallT (andGate : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat -> Rat -> Rat;
+correctOutput : forallT (andGate : Vector Rat -> Vector Rat) . Rat -> Rat -> Rat;
 correctOutput andGate x1 x2 = let y = andGate [x1, x2] ! 0 in max 0.0 ((truthy x1 + truthy x2) * truthy y) + (max 0.0 ((truthy x1 + falsey x2) * falsey y) + (max 0.0 ((falsey x1 + truthy x2) * falsey y) + max 0.0 ((falsey x1 + falsey x2) * falsey y)))
 
 @property;
-andGateCorrect : forallT (andGate : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+andGateCorrect : forallT (andGate : Vector Rat -> Vector Rat) . Rat;
 andGateCorrect andGate = Optimise[min] (+) (\ x1 -> Optimise[min] (+) (\ x2 -> max 0.0 ((validInput x1 + validInput x2) * correctOutput andGate x1 x2)))

--- a/vehicle/tests/golden/compile/andGate/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/andGate/Explicit.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 truthy : Rat -> Bool;
 truthy x = x >= 0.5
 
@@ -9,9 +7,9 @@ falsey x = x <= 0.5
 validInput : Rat -> Bool;
 validInput x = 0.0 <= x and x <= 1.0
 
-correctOutput : forallT (andGate : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat -> Rat -> Bool;
+correctOutput : forallT (andGate : Vector Rat -> Vector Rat) . Rat -> Rat -> Bool;
 correctOutput andGate x1 x2 = let y = andGate [x1, x2] ! 0 in (truthy x1 and truthy x2 => truthy y) and (truthy x1 and falsey x2 => falsey y) and (falsey x1 and truthy x2 => falsey y) and (falsey x1 and falsey x2 => falsey y)
 
 @property;
-andGateCorrect : forallT (andGate : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+andGateCorrect : forallT (andGate : Vector Rat -> Vector Rat) . Bool;
 andGateCorrect andGate = forall x1 . forall x2 . validInput x1 and validInput x2 => correctOutput andGate x1 x2

--- a/vehicle/tests/golden/compile/autoencoderError/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Explicit.vcl.golden
@@ -1,11 +1,5 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
-
-foreachVector__Rat : forallT n . (Index -> Rat) -> Vector Rat;
-foreachVector__Rat n f = map f (indices n)
-
-foreachVector__Bool : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector__Bool n f = map f (indices n)
 
 @noinline;
 addVector : Vector Rat -> Vector Rat -> Vector Rat;
@@ -15,14 +9,9 @@ addVector _x0 _x1 = zipWith (\ x -> \ y -> x + y) _x0 _x1
 subVector : Vector Rat -> Vector Rat -> Vector Rat;
 subVector _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 
-forallIndex : forallT n . (Index -> Bool) -> Bool;
-forallIndex n f = bigAnd (foreachVector__Bool n (\ i -> f i))
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
-epsilon : Tensor Rat (5 :: nil);
-epsilon = foreachVector__Rat 5 (\ i -> 0.1)
+epsilon : Vector Rat;
+epsilon = map (\ i -> 0.1) (indices 5)
 
 @property;
-identity : forallT (encode : Tensor Rat (5 :: nil) -> Tensor Rat (2 :: nil)) . forallT (decode : Tensor Rat (2 :: nil) -> Tensor Rat (5 :: nil)) . Bool;
-identity encode decode = forall x . forallIndex 5 (\ i -> subVector x epsilon ! i <= decode (encode x) ! i and decode (encode x) ! i <= addVector x epsilon ! i)
+identity : forallT (encode : Vector Rat -> Vector Rat) . forallT (decode : Vector Rat -> Vector Rat) . Bool;
+identity encode decode = forall x . bigAnd (map (\ i -> subVector x epsilon ! i <= decode (encode x) ! i and decode (encode x) ! i <= addVector x epsilon ! i) (indices 5))

--- a/vehicle/tests/golden/compile/bounded/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/bounded/DL2Loss.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-bounded : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+bounded : forallT (f : Vector Rat -> Vector Rat) . Rat;
 bounded f = Optimise[min] (+) (\ x -> max 0.0 ((max 0.0 (0.0 - x) + max 0.0 (x - 1.0)) * (max 0.0 (0.0 - f [x] ! 0) + max 0.0 (f [x] ! 0 - 1.0))))

--- a/vehicle/tests/golden/compile/bounded/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/bounded/Explicit.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-bounded : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+bounded : forallT (f : Vector Rat -> Vector Rat) . Bool;
 bounded f = forall x . 0.0 < x and x < 1.0 => 0.0 < f [x] ! 0 and f [x] ! 0 < 1.0

--- a/vehicle/tests/golden/compile/dogsHierarchy/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/dogsHierarchy/Explicit.vcl.golden
@@ -1,27 +1,11 @@
-bigAnd__lam_A__Vector_A : (\ A -> Vector A) Bool -> Bool;
+bigAnd__lam_A__Vector_A : Vector Bool -> Bool;
 bigAnd__lam_A__Vector_A _x0 = fold (\ x -> \ y -> x and y) True _x0
 
 bigAnd__List : List Bool -> Bool;
 bigAnd__List _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-bigOr : (\ A -> Vector A) Bool -> Bool;
+bigOr : Vector Bool -> Bool;
 bigOr _x0 = fold (\ x -> \ y -> x or y) False _x0
-
-forallIn : (Index -> Bool) -> List (Index) -> Bool;
-forallIn f xs = bigAnd__List (map f xs)
-
-foreachVector : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector n f = map f (indices n)
-
-existsIndex : forallT n . (Index -> Bool) -> Bool;
-existsIndex n f = bigOr (foreachVector n (\ i -> f i))
-
-forallIndex : forallT n . (Index -> Bool) -> Bool;
-forallIndex n f = bigAnd__lam_A__Vector_A (foreachVector n (\ i -> f i))
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
-type Dog = Index
 
 greatDane : Index;
 greatDane = 1
@@ -35,31 +19,27 @@ chihuahua = 4
 pekinese : Index;
 pekinese = 5
 
-smallDogs : List Dog;
+smallDogs : List (Index);
 smallDogs = chihuahua :: pekinese :: nil
 
-bigDogs : List Dog;
+bigDogs : List (Index);
 bigDogs = greatDane :: germanShepherd :: nil
-
-type Image = Tensor Rat (4 :: 4 :: nil)
-
-type Score = Rat
 
 validPixel : Rat -> Bool;
 validPixel p = 0.0 <= p and p <= 1.0
 
-validImage : Image -> Bool;
-validImage x = forallIndex 4 (\ i -> forallIndex 4 (\ j -> validPixel (x ! i ! j)))
+validImage : Vector (Vector Rat) -> Bool;
+validImage x = bigAnd__lam_A__Vector_A (map (\ i -> bigAnd__lam_A__Vector_A (map (\ j -> validPixel (x ! i ! j)) (indices 4))) (indices 4))
 
-isFirstChoice : forallT (score : Image -> Vector Score) . Image -> Dog -> Bool;
-isFirstChoice score x dog1 = let scores = score x in forallIndex 6 (\ d -> d != dog1 => scores ! dog1 > scores ! d)
+isFirstChoice : forallT (score : Vector (Vector Rat) -> Vector Rat) . Vector (Vector Rat) -> Index -> Bool;
+isFirstChoice score x dog1 = let scores = score x in bigAnd__lam_A__Vector_A (map (\ d -> d != dog1 => scores ! dog1 > scores ! d) (indices 6))
 
-isSecondChoice : forallT (score : Image -> Vector Score) . Image -> Dog -> Bool;
-isSecondChoice score x dog2 = let scores = score x in existsIndex 6 (\ dog1 -> isFirstChoice score x dog1 and forallIndex 6 (\ d -> d != dog1 and d != dog2 => scores ! dog2 > scores ! d))
+isSecondChoice : forallT (score : Vector (Vector Rat) -> Vector Rat) . Vector (Vector Rat) -> Index -> Bool;
+isSecondChoice score x dog2 = let scores = score x in bigOr (map (\ dog1 -> isFirstChoice score x dog1 and bigAnd__lam_A__Vector_A (map (\ d -> d != dog1 and d != dog2 => scores ! dog2 > scores ! d) (indices 6))) (indices 6))
 
-noConfusionWith : forallT (score : Image -> Vector Score) . Image -> List Dog -> List Dog -> Bool;
-noConfusionWith score x dogs1 dogs2 = forallIn (\ dog1 -> forallIn (\ dog2 -> not (isFirstChoice score x dog1 and isSecondChoice score x dog2)) dogs2) dogs1
+noConfusionWith : forallT (score : Vector (Vector Rat) -> Vector Rat) . Vector (Vector Rat) -> List (Index) -> List (Index) -> Bool;
+noConfusionWith score x dogs1 dogs2 = bigAnd__List (map (\ dog1 -> bigAnd__List (map (\ dog2 -> not (isFirstChoice score x dog1 and isSecondChoice score x dog2)) dogs2)) dogs1)
 
 @property;
-doesNotConfuseBigAndSmall : forallT (score : Image -> Vector Score) . Bool;
+doesNotConfuseBigAndSmall : forallT (score : Vector (Vector Rat) -> Vector Rat) . Bool;
 doesNotConfuseBigAndSmall score = forall x . validImage x => noConfusionWith score x bigDogs smallDogs

--- a/vehicle/tests/golden/compile/increasing/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/increasing/Explicit.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-increasing : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+increasing : forallT (f : Vector Rat -> Vector Rat) . Bool;
 increasing f = forall x . x <= f [x] ! 0

--- a/vehicle/tests/golden/compile/logic-and-comparisons/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/DL2Loss.vcl.golden
@@ -1,20 +1,18 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
+bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
 @noinline;
 equalsVector--Rat--Rat : Vector Rat -> Vector Rat -> Rat;
 equalsVector--Rat--Rat xs ys = bigAnd (zipWith (\ x -> \ y -> max 0.0 (x - y) + max 0.0 (y - x)) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 test1 f = Optimise[min] (*) (\ a -> (max 0.0 (a - 0.0) + (if a == 0.0 then 1.0 else 0.0)) * equalsVector--Rat--Rat (f [a + 2.0]) [0.0])
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test2 g = Optimise[min] (*) (\ a -> Optimise[min] (*) (\ b -> max 0.0 (1.0 - a) + (if 1.0 == a then 1.0 else 0.0) + (max 0.0 (b - a) + (if b == a then 1.0 else 0.0) + equalsVector--Rat--Rat (g [a + b, a + 2.0 * b]) [0.0])))
 
 @property;
-test3 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test3 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test3 g = Optimise[min] (+) (\ a -> Optimise[min] (+) (\ b -> (max 0.0 (0.0 - a) + (if 0.0 == a then 1.0 else 0.0)) * (max 0.0 (b - 0.0) + max 0.0 (0.0 - b)) + equalsVector--Rat--Rat (g [a, b]) [0.0]))

--- a/vehicle/tests/golden/compile/logic-and-comparisons/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/Explicit.vcl.golden
@@ -1,7 +1,7 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-bigOr : (\ A -> Vector A) Bool -> Bool;
+bigOr : Vector Bool -> Bool;
 bigOr _x0 = fold (\ x -> \ y -> x or y) False _x0
 
 @noinline;
@@ -12,16 +12,14 @@ equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 notEqualsVector : Vector Rat -> Vector Rat -> Bool;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> x != y) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 test1 f = exists a . a <= 0.0 or equalsVector (f [a + 2.0]) [0.0]
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Bool;
 test2 g = exists a . exists b . a >= 1.0 and not (b > a) and equalsVector (g [a + b, a + 2.0 * b]) [0.0]
 
 @property;
-test3 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+test3 : forallT (g : Vector Rat -> Vector Rat) . Bool;
 test3 g = forall a . forall b . not ((a < 0.0 and b != 0.0) or notEqualsVector (g [a, b]) [0.0])

--- a/vehicle/tests/golden/compile/logic-and-comparisons/GodelLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/GodelLoss.vcl.golden
@@ -1,8 +1,8 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
-bigAnd _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - min x y) x y) 0.0 _x0
+bigAnd : Vector Rat -> Rat;
+bigAnd _x0 = fold (\ x -> \ y -> 1.0 - min x y) 0.0 _x0
 
-bigOr : (\ A -> Vector A) Rat -> Rat;
-bigOr _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - max x y) x y) 1.0 _x0
+bigOr : Vector Rat -> Rat;
+bigOr _x0 = fold (\ x -> \ y -> 1.0 - max x y) 1.0 _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
@@ -12,16 +12,14 @@ equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 el
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 test1 f = Optimise[min] (\ x -> \ y -> 1.0 - max x y) (\ a -> 1.0 - max (max 0.0 (a - 0.0)) (equalsVector (f [a + 2.0]) [0.0]))
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test2 g = Optimise[min] (\ x -> \ y -> 1.0 - max x y) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - max x y) (\ b -> 1.0 - min (max 0.0 (1.0 - a)) (1.0 - min (1.0 - max 0.0 (a - b)) (equalsVector (g [a + b, a + 2.0 * b]) [0.0]))))
 
 @property;
-test3 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test3 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test3 g = Optimise[min] (\ x -> \ y -> 1.0 - min x y) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - min x y) (\ b -> 1.0 - (1.0 - max (1.0 - min (max 0.0 (a - 0.0)) (if b == 0.0 then 1.0 else 0.0)) (notEqualsVector (g [a, b]) [0.0]))))

--- a/vehicle/tests/golden/compile/logic-and-comparisons/LukasiewiczLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/LukasiewiczLoss.vcl.golden
@@ -1,8 +1,8 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
-bigAnd _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - max 0.0 (x + y - 1.0)) x y) 0.0 _x0
+bigAnd : Vector Rat -> Rat;
+bigAnd _x0 = fold (\ x -> \ y -> 1.0 - max 0.0 (x + y - 1.0)) 0.0 _x0
 
-bigOr : (\ A -> Vector A) Rat -> Rat;
-bigOr _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - min (x + y) 1.0) x y) 1.0 _x0
+bigOr : Vector Rat -> Rat;
+bigOr _x0 = fold (\ x -> \ y -> 1.0 - min (x + y) 1.0) 1.0 _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
@@ -12,16 +12,14 @@ equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 el
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 test1 f = Optimise[min] (\ x -> \ y -> 1.0 - min (x + y) 1.0) (\ a -> 1.0 - min (max 0.0 (a - 0.0) + equalsVector (f [a + 2.0]) [0.0]) 1.0)
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test2 g = Optimise[min] (\ x -> \ y -> 1.0 - min (x + y) 1.0) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - min (x + y) 1.0) (\ b -> 1.0 - max 0.0 (max 0.0 (1.0 - a) + (1.0 - max 0.0 (1.0 - max 0.0 (a - b) + equalsVector (g [a + b, a + 2.0 * b]) [0.0] - 1.0)) - 1.0)))
 
 @property;
-test3 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test3 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test3 g = Optimise[min] (\ x -> \ y -> 1.0 - max 0.0 (x + y - 1.0)) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - max 0.0 (x + y - 1.0)) (\ b -> 1.0 - (1.0 - min (1.0 - max 0.0 (max 0.0 (a - 0.0) + (if b == 0.0 then 1.0 else 0.0) - 1.0) + notEqualsVector (g [a, b]) [0.0]) 1.0)))

--- a/vehicle/tests/golden/compile/logic-and-comparisons/ProductLoss.json.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/ProductLoss.json.golden
@@ -1,8 +1,8 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
-bigAnd _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - x * y) x y) 0.0 _x0
+bigAnd : Vector Rat -> Rat;
+bigAnd _x0 = fold (\ x -> \ y -> 1.0 - x * y) 0.0 _x0
 
-bigOr : (\ A -> Vector A) Rat -> Rat;
-bigOr _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - x * y) x y) 1.0 _x0
+bigOr : Vector Rat -> Rat;
+bigOr _x0 = fold (\ x -> \ y -> 1.0 - x * y) 1.0 _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
@@ -12,16 +12,14 @@ equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 el
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 test1 f = Optimise[min] (\ x -> \ y -> 1.0 - (x + y - x * y)) (\ a -> 1.0 - max 0.0 (a - 0.0) * equalsVector (f [a + 2.0]) [0.0])
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test2 g = Optimise[min] (\ x -> \ y -> 1.0 - (x + y - x * y)) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - (x + y - x * y)) (\ b -> 1.0 - max 0.0 (1.0 - a) * (1.0 - (1.0 - max 0.0 (a - b)) * equalsVector (g [a + b, a + 2.0 * b]) [0.0])))
 
 @property;
-test3 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test3 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test3 g = Optimise[min] (\ x -> \ y -> 1.0 - x * y) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - x * y) (\ b -> 1.0 - (1.0 - (1.0 - max 0.0 (a - 0.0) * (if b == 0.0 then 1.0 else 0.0)) * notEqualsVector (g [a, b]) [0.0])))

--- a/vehicle/tests/golden/compile/logic-and-comparisons/YagerLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/YagerLoss.vcl.golden
@@ -1,8 +1,8 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
-bigAnd _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - max (** (1.0 - (** (1.0 - x) 1.0 + ** (1.0 - y) 1.0)) 1.0) 0.0) x y) 0.0 _x0
+bigAnd : Vector Rat -> Rat;
+bigAnd _x0 = fold (\ x -> \ y -> 1.0 - max (** (1.0 - (** (1.0 - x) 1.0 + ** (1.0 - y) 1.0)) 1.0) 0.0) 0.0 _x0
 
-bigOr : (\ A -> Vector A) Rat -> Rat;
-bigOr _x0 = fold (\ x -> \ y -> (\ x -> \ y -> 1.0 - min (** (** x 1.0 + ** y 1.0) 1.0) 1.0) x y) 1.0 _x0
+bigOr : Vector Rat -> Rat;
+bigOr _x0 = fold (\ x -> \ y -> 1.0 - min (** (** x 1.0 + ** y 1.0) 1.0) 1.0) 1.0 _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
@@ -12,16 +12,14 @@ equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 el
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 test1 f = Optimise[min] (\ x -> \ y -> 1.0 - min (** (** x 1.0 + ** y 1.0) 1.0) 1.0) (\ a -> 1.0 - min (** (** (max 0.0 (a - 0.0)) 1.0 + ** (equalsVector (f [a + 2.0]) [0.0]) 1.0) 1.0) 1.0)
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test2 g = Optimise[min] (\ x -> \ y -> 1.0 - min (** (** x 1.0 + ** y 1.0) 1.0) 1.0) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - min (** (** x 1.0 + ** y 1.0) 1.0) 1.0) (\ b -> 1.0 - max (** (1.0 - (** (1.0 - max 0.0 (1.0 - a)) 1.0 + ** (1.0 - (1.0 - max (** (1.0 - (** (1.0 - (1.0 - max 0.0 (a - b))) 1.0 + ** (1.0 - equalsVector (g [a + b, a + 2.0 * b]) [0.0]) 1.0)) 1.0) 0.0)) 1.0)) 1.0) 0.0))
 
 @property;
-test3 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test3 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test3 g = Optimise[min] (\ x -> \ y -> 1.0 - max (** (1.0 - (** (1.0 - x) 1.0 + ** (1.0 - y) 1.0)) 1.0) 0.0) (\ a -> Optimise[min] (\ x -> \ y -> 1.0 - max (** (1.0 - (** (1.0 - x) 1.0 + ** (1.0 - y) 1.0)) 1.0) 0.0) (\ b -> 1.0 - (1.0 - min (** (** (1.0 - max (** (1.0 - (** (1.0 - max 0.0 (a - 0.0)) 1.0 + ** (1.0 - (if b == 0.0 then 1.0 else 0.0)) 1.0)) 1.0) 0.0) 1.0 + ** (notEqualsVector (g [a, b]) [0.0]) 1.0) 1.0) 1.0)))

--- a/vehicle/tests/golden/compile/mnist-robustness/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/DL2Loss.vcl.golden
@@ -1,8 +1,5 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
+bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
-
-foreachVector : forallT n . (Index -> Rat) -> Vector Rat;
-foreachVector n f = map f (indices n)
 
 @noinline;
 subVector--Rat--Rat--Rat : Vector Rat -> Vector Rat -> Vector Rat;
@@ -12,27 +9,18 @@ subVector--Rat--Rat--Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 subVector--Vector-Rat--Vector-Rat--Vector-Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector--Vector-Rat--Vector-Rat--Vector-Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector--Rat--Rat--Rat x y) _x0 _x1
 
-forallIndex : forallT n . (Index -> Rat) -> Rat;
-forallIndex n f = bigAnd (foreachVector n (\ i -> f i))
+validImage : Vector (Vector Rat) -> Rat;
+validImage x = bigAnd (map (\ i -> bigAnd (map (\ j -> max 0.0 (0.0 - x ! i ! j) + (if 0.0 == x ! i ! j then 1.0 else 0.0) + (max 0.0 (x ! i ! j - 1.0) + (if x ! i ! j == 1.0 then 1.0 else 0.0))) (indices 28))) (indices 28))
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
+advises : forallT (classifier : Vector (Vector Rat) -> Vector Rat) . Vector (Vector Rat) -> Index -> Rat;
+advises classifier x i = bigAnd (map (\ j -> max 0.0 ((if j != i then 0.0 else 1.0) * max 0.0 (classifier x ! j - classifier x ! i))) (indices 10))
 
-type Image = Tensor Rat (28 :: 28 :: nil)
+boundedByEpsilon : forallT (epsilon : Rat) . Vector (Vector Rat) -> Rat;
+boundedByEpsilon epsilon x = bigAnd (map (\ i -> bigAnd (map (\ j -> max 0.0 (- epsilon - x ! i ! j) + (if - epsilon == x ! i ! j then 1.0 else 0.0) + (max 0.0 (x ! i ! j - epsilon) + (if x ! i ! j == epsilon then 1.0 else 0.0))) (indices 28))) (indices 28))
 
-type Label = Index
-
-validImage : Image -> Rat;
-validImage x = forallIndex 28 (\ i -> forallIndex 28 (\ j -> max 0.0 (0.0 - x ! i ! j) + (if 0.0 == x ! i ! j then 1.0 else 0.0) + (max 0.0 (x ! i ! j - 1.0) + (if x ! i ! j == 1.0 then 1.0 else 0.0))))
-
-advises : forallT (classifier : Image -> Vector Rat) . Image -> Label -> Rat;
-advises classifier x i = forallIndex 10 (\ j -> (\ x -> \ y -> max 0.0 (x * y)) (if j != i then 0.0 else 1.0) (max 0.0 (classifier x ! j - classifier x ! i)))
-
-boundedByEpsilon : forallT (epsilon : Rat) . Image -> Rat;
-boundedByEpsilon epsilon x = forallIndex 28 (\ i -> forallIndex 28 (\ j -> max 0.0 (- epsilon - x ! i ! j) + (if - epsilon == x ! i ! j then 1.0 else 0.0) + (max 0.0 (x ! i ! j - epsilon) + (if x ! i ! j == epsilon then 1.0 else 0.0))))
-
-robustAround : forallT (classifier : Image -> Vector Rat) . forallT (epsilon : Rat) . Image -> Label -> Rat;
+robustAround : forallT (classifier : Vector (Vector Rat) -> Vector Rat) . forallT (epsilon : Rat) . Vector (Vector Rat) -> Index -> Rat;
 robustAround classifier epsilon image label = Optimise[min] (+) (\ pertubation -> let perturbedImage = subVector--Vector-Rat--Vector-Rat--Vector-Rat image pertubation in max 0.0 ((boundedByEpsilon epsilon pertubation + validImage perturbedImage) * advises classifier perturbedImage label))
 
 @property;
-robust : forallT (n : Nat) . forallT (classifier : Image -> Vector Rat) . forallT (epsilon : Rat) . forallT (trainingImages : Vector Image) . forallT (trainingLabels : Vector Label) . Vector Rat;
-robust n classifier epsilon trainingImages trainingLabels = foreachVector n (\ i -> robustAround classifier epsilon (trainingImages ! i) (trainingLabels ! i))
+robust : forallT (n : Nat) . forallT (classifier : Vector (Vector Rat) -> Vector Rat) . forallT (epsilon : Rat) . forallT (trainingImages : Vector (Vector (Vector Rat))) . forallT (trainingLabels : Vector (Index)) . Vector Rat;
+robust n classifier epsilon trainingImages trainingLabels = map (\ i -> robustAround classifier epsilon (trainingImages ! i) (trainingLabels ! i)) (indices n)

--- a/vehicle/tests/golden/compile/mnist-robustness/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Explicit.vcl.golden
@@ -1,8 +1,5 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
-
-foreachVector : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector n f = map f (indices n)
 
 @noinline;
 subVector__Rat__Rat__Rat : Vector Rat -> Vector Rat -> Vector Rat;
@@ -12,27 +9,18 @@ subVector__Rat__Rat__Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 subVector__Vector_Rat__Vector_Rat__Vector_Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector__Vector_Rat__Vector_Rat__Vector_Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector__Rat__Rat__Rat x y) _x0 _x1
 
-forallIndex : forallT n . (Index -> Bool) -> Bool;
-forallIndex n f = bigAnd (foreachVector n (\ i -> f i))
+validImage : Vector (Vector Rat) -> Bool;
+validImage x = bigAnd (map (\ i -> bigAnd (map (\ j -> 0.0 <= x ! i ! j and x ! i ! j <= 1.0) (indices 28))) (indices 28))
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
+advises : forallT (classifier : Vector (Vector Rat) -> Vector Rat) . Vector (Vector Rat) -> Index -> Bool;
+advises classifier x i = bigAnd (map (\ j -> j != i => classifier x ! i > classifier x ! j) (indices 10))
 
-type Image = Tensor Rat (28 :: 28 :: nil)
+boundedByEpsilon : forallT (epsilon : Rat) . Vector (Vector Rat) -> Bool;
+boundedByEpsilon epsilon x = bigAnd (map (\ i -> bigAnd (map (\ j -> - epsilon <= x ! i ! j and x ! i ! j <= epsilon) (indices 28))) (indices 28))
 
-type Label = Index
-
-validImage : Image -> Bool;
-validImage x = forallIndex 28 (\ i -> forallIndex 28 (\ j -> 0.0 <= x ! i ! j and x ! i ! j <= 1.0))
-
-advises : forallT (classifier : Image -> Vector Rat) . Image -> Label -> Bool;
-advises classifier x i = forallIndex 10 (\ j -> j != i => classifier x ! i > classifier x ! j)
-
-boundedByEpsilon : forallT (epsilon : Rat) . Image -> Bool;
-boundedByEpsilon epsilon x = forallIndex 28 (\ i -> forallIndex 28 (\ j -> - epsilon <= x ! i ! j and x ! i ! j <= epsilon))
-
-robustAround : forallT (classifier : Image -> Vector Rat) . forallT (epsilon : Rat) . Image -> Label -> Bool;
+robustAround : forallT (classifier : Vector (Vector Rat) -> Vector Rat) . forallT (epsilon : Rat) . Vector (Vector Rat) -> Index -> Bool;
 robustAround classifier epsilon image label = forall pertubation . let perturbedImage = subVector__Vector_Rat__Vector_Rat__Vector_Rat image pertubation in boundedByEpsilon epsilon pertubation and validImage perturbedImage => advises classifier perturbedImage label
 
 @property;
-robust : forallT (n : Nat) . forallT (classifier : Image -> Vector Rat) . forallT (epsilon : Rat) . forallT (trainingImages : Vector Image) . forallT (trainingLabels : Vector Label) . Vector Bool;
-robust n classifier epsilon trainingImages trainingLabels = foreachVector n (\ i -> robustAround classifier epsilon (trainingImages ! i) (trainingLabels ! i))
+robust : forallT (n : Nat) . forallT (classifier : Vector (Vector Rat) -> Vector Rat) . forallT (epsilon : Rat) . forallT (trainingImages : Vector (Vector (Vector Rat))) . forallT (trainingLabels : Vector (Index)) . Vector Bool;
+robust n classifier epsilon trainingImages trainingLabels = map (\ i -> robustAround classifier epsilon (trainingImages ! i) (trainingLabels ! i)) (indices n)

--- a/vehicle/tests/golden/compile/mnist-robustness/VehicleLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/VehicleLoss.vcl.golden
@@ -1,8 +1,5 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
+bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> max x y) -100000.0 _x0
-
-foreachVector : forallT n . (Index -> Rat) -> Vector Rat;
-foreachVector n f = map f (indices n)
 
 @noinline;
 subVector--Rat--Rat--Rat : Vector Rat -> Vector Rat -> Vector Rat;
@@ -12,27 +9,18 @@ subVector--Rat--Rat--Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 subVector--Vector-Rat--Vector-Rat--Vector-Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector--Vector-Rat--Vector-Rat--Vector-Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector--Rat--Rat--Rat x y) _x0 _x1
 
-forallIndex : forallT n . (Index -> Rat) -> Rat;
-forallIndex n f = bigAnd (foreachVector n (\ i -> f i))
+validImage : Vector (Vector Rat) -> Rat;
+validImage x = bigAnd (map (\ i -> bigAnd (map (\ j -> max (0.0 - x ! i ! j) (x ! i ! j - 1.0)) (indices 28))) (indices 28))
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
+advises : forallT (classifier : Vector (Vector Rat) -> Vector Rat) . Vector (Vector Rat) -> Index -> Rat;
+advises classifier x i = bigAnd (map (\ j -> max (- (if j != i then -100000.0 else 100000.0)) (classifier x ! j - classifier x ! i)) (indices 10))
 
-type Image = Tensor Rat (28 :: 28 :: nil)
+boundedByEpsilon : forallT (epsilon : Rat) . Vector (Vector Rat) -> Rat;
+boundedByEpsilon epsilon x = bigAnd (map (\ i -> bigAnd (map (\ j -> max (- epsilon - x ! i ! j) (x ! i ! j - epsilon)) (indices 28))) (indices 28))
 
-type Label = Index
-
-validImage : Image -> Rat;
-validImage x = forallIndex 28 (\ i -> forallIndex 28 (\ j -> max (0.0 - x ! i ! j) (x ! i ! j - 1.0)))
-
-advises : forallT (classifier : Image -> Vector Rat) . Image -> Label -> Rat;
-advises classifier x i = forallIndex 10 (\ j -> (\ x -> \ y -> max (- x) y) (if j != i then -100000.0 else 100000.0) (classifier x ! j - classifier x ! i))
-
-boundedByEpsilon : forallT (epsilon : Rat) . Image -> Rat;
-boundedByEpsilon epsilon x = forallIndex 28 (\ i -> forallIndex 28 (\ j -> max (- epsilon - x ! i ! j) (x ! i ! j - epsilon)))
-
-robustAround : forallT (classifier : Image -> Vector Rat) . forallT (epsilon : Rat) . Image -> Label -> Rat;
+robustAround : forallT (classifier : Vector (Vector Rat) -> Vector Rat) . forallT (epsilon : Rat) . Vector (Vector Rat) -> Index -> Rat;
 robustAround classifier epsilon image label = Optimise[min] max (\ pertubation -> let perturbedImage = subVector--Vector-Rat--Vector-Rat--Vector-Rat image pertubation in max (- max (boundedByEpsilon epsilon pertubation) (validImage perturbedImage)) (advises classifier perturbedImage label))
 
 @property;
-robust : forallT (n : Nat) . forallT (classifier : Image -> Vector Rat) . forallT (epsilon : Rat) . forallT (trainingImages : Vector Image) . forallT (trainingLabels : Vector Label) . Vector Rat;
-robust n classifier epsilon trainingImages trainingLabels = foreachVector n (\ i -> robustAround classifier epsilon (trainingImages ! i) (trainingLabels ! i))
+robust : forallT (n : Nat) . forallT (classifier : Vector (Vector Rat) -> Vector Rat) . forallT (epsilon : Rat) . forallT (trainingImages : Vector (Vector (Vector Rat))) . forallT (trainingLabels : Vector (Index)) . Vector Rat;
+robust n classifier epsilon trainingImages trainingLabels = map (\ i -> robustAround classifier epsilon (trainingImages ! i) (trainingLabels ! i)) (indices n)

--- a/vehicle/tests/golden/compile/monotonicity/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/monotonicity/DL2Loss.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-monotonic : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+monotonic : forallT (f : Vector Rat -> Vector Rat) . Rat;
 monotonic f = Optimise[min] (+) (\ x1 -> Optimise[min] (+) (\ x2 -> max 0.0 ((max 0.0 (x1 - x2) + (if x1 == x2 then 1.0 else 0.0)) * (max 0.0 (f [x1] ! 0 - f [x2] ! 0) + (if f [x1] ! 0 == f [x2] ! 0 then 1.0 else 0.0)))))

--- a/vehicle/tests/golden/compile/monotonicity/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/monotonicity/Explicit.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-monotonic : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+monotonic : forallT (f : Vector Rat -> Vector Rat) . Bool;
 monotonic f = forall x1 . forall x2 . x1 <= x2 => f [x1] ! 0 <= f [x2] ! 0

--- a/vehicle/tests/golden/compile/reachability/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/reachability/DL2Loss.vcl.golden
@@ -1,12 +1,10 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
+bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> max 0.0 (x - y) + max 0.0 (y - x)) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-reachable : forallT (f : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+reachable : forallT (f : Vector Rat -> Vector Rat) . Rat;
 reachable f = Optimise[min] (*) (\ x -> equalsVector (f x) [0.0])

--- a/vehicle/tests/golden/compile/reachability/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/reachability/Explicit.vcl.golden
@@ -1,12 +1,10 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-reachable : forallT (f : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+reachable : forallT (f : Vector Rat -> Vector Rat) . Bool;
 reachable f = exists x . equalsVector (f x) [0.0]

--- a/vehicle/tests/golden/compile/simple-constantInput/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-constantInput/DL2Loss.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-spec : forallT (f : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+spec : forallT (f : Vector Rat -> Vector Rat) . Rat;
 spec f = Optimise[min] (+) (\ x -> max 0.0 (0.0 - f [x, 0.0] ! 0) + (if 0.0 == f [x, 0.0] ! 0 then 1.0 else 0.0))

--- a/vehicle/tests/golden/compile/simple-constantInput/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-constantInput/Explicit.vcl.golden
@@ -1,5 +1,3 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-spec : forallT (f : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+spec : forallT (f : Vector Rat -> Vector Rat) . Bool;
 spec f = forall x . f [x, 0.0] ! 0 >= 0.0

--- a/vehicle/tests/golden/compile/simple-constantNetworkInput/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-constantNetworkInput/Explicit.vcl.golden
@@ -1,4 +1,4 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
 @noinline;

--- a/vehicle/tests/golden/compile/simple-foreach/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-foreach/DL2Loss.vcl.golden
@@ -1,8 +1,3 @@
-foreachVector : forallT n . (Index -> Rat) -> Vector Rat;
-foreachVector n f = map f (indices n)
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-index : forallT (f : Tensor Rat (2 :: nil) -> Tensor Rat (2 :: nil)) . Tensor Rat (2 :: nil);
-index f = foreachVector 2 (\ i -> max 0.0 (0.0 - f [0.0, 0.0] ! i) + (if 0.0 == f [0.0, 0.0] ! i then 1.0 else 0.0))
+index : forallT (f : Vector Rat -> Vector Rat) . Vector Rat;
+index f = map (\ i -> max 0.0 (0.0 - f [0.0, 0.0] ! i) + (if 0.0 == f [0.0, 0.0] ! i then 1.0 else 0.0)) (indices 2)

--- a/vehicle/tests/golden/compile/simple-foreach/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-foreach/Explicit.vcl.golden
@@ -1,8 +1,3 @@
-foreachVector : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector n f = map f (indices n)
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-index : forallT (f : Tensor Rat (2 :: nil) -> Tensor Rat (2 :: nil)) . Tensor Bool (2 :: nil);
-index f = foreachVector 2 (\ i -> f [0.0, 0.0] ! i >= 0.0)
+index : forallT (f : Vector Rat -> Vector Rat) . Vector Bool;
+index f = map (\ i -> f [0.0, 0.0] ! i >= 0.0) (indices 2)

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/DL2Loss.vcl.golden
@@ -1,17 +1,15 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-unusedVar : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+unusedVar : forallT (f : Vector Rat -> Vector Rat) . Rat;
 unusedVar f = Optimise[min] (*) (\ x -> Optimise[min] (*) (\ (y : Rat) -> max 0.0 (0.0 - f [x] ! 0) + (if 0.0 == f [x] ! 0 then 1.0 else 0.0)))
 
 @property;
-underConstrainedVar1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+underConstrainedVar1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 underConstrainedVar1 f = Optimise[min] (*) (\ x -> Optimise[min] (*) (\ y -> max 0.0 (1.0 - x) + (if 1.0 == x then 1.0 else 0.0) + (max 0.0 (2.0 - y) + (if 2.0 == y then 1.0 else 0.0) + (max 0.0 (0.0 - f [x + y] ! 0) + (if 0.0 == f [x + y] ! 0 then 1.0 else 0.0)))))
 
 @property;
-underConstrainedVar2 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+underConstrainedVar2 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 underConstrainedVar2 f = Optimise[min] (*) (\ x -> Optimise[min] (*) (\ y -> max 0.0 (1.0 - x) + (if 1.0 == x then 1.0 else 0.0) + (max 0.0 (2.0 - 2.0 * y) + (if 2.0 == 2.0 * y then 1.0 else 0.0) + (max 0.0 (0.0 - f [2.0 * x + y] ! 0) + (if 0.0 == f [2.0 * x + y] ! 0 then 1.0 else 0.0)))))
 
 @property;
-underConstrainedVars : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+underConstrainedVars : forallT (f : Vector Rat -> Vector Rat) . Rat;
 underConstrainedVars f = Optimise[min] (*) (\ (x : Vector Rat) -> max 0.0 (2.0 - x ! 3) + (if 2.0 == x ! 3 then 1.0 else 0.0) + (max 0.0 (1.0 - (x ! 2 + x ! 3)) + (if 1.0 == x ! 2 + x ! 3 then 1.0 else 0.0) + (max 0.0 (2.5 - (x ! 1 + x ! 0)) + (if 2.5 == x ! 1 + x ! 0 then 1.0 else 0.0) + (max 0.0 (2.0 - f [x ! 0 + x ! 1] ! 0) + (if 2.0 == f [x ! 0 + x ! 1] ! 0 then 1.0 else 0.0)))))

--- a/vehicle/tests/golden/compile/simple-fourierMotzkin/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-fourierMotzkin/Explicit.vcl.golden
@@ -1,17 +1,15 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-unusedVar : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+unusedVar : forallT (f : Vector Rat -> Vector Rat) . Bool;
 unusedVar f = exists x . exists (y : Rat) . f [x] ! 0 >= 0.0
 
 @property;
-underConstrainedVar1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+underConstrainedVar1 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 underConstrainedVar1 f = exists x . exists y . x >= 1.0 and y >= 2.0 and f [x + y] ! 0 >= 0.0
 
 @property;
-underConstrainedVar2 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+underConstrainedVar2 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 underConstrainedVar2 f = exists x . exists y . x >= 1.0 and 2.0 * y >= 2.0 and f [2.0 * x + y] ! 0 >= 0.0
 
 @property;
-underConstrainedVars : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+underConstrainedVars : forallT (f : Vector Rat -> Vector Rat) . Bool;
 underConstrainedVars f = exists (x : fold (\ d -> \ t -> Vector t) Rat (4 :: nil)) . x ! 3 >= 2.0 and x ! 2 + x ! 3 >= 1.0 and x ! 1 + x ! 0 >= 2.5 and f [x ! 0 + x ! 1] ! 0 >= 2.0

--- a/vehicle/tests/golden/compile/simple-gaussianElim/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/DL2Loss.vcl.golden
@@ -1,16 +1,14 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
+bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> max 0.0 (x - y) + max 0.0 (y - x)) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Rat;
 test1 f = Optimise[min] (*) (\ a -> max 0.0 (0.0 - a) + (if 0.0 == a then 1.0 else 0.0) + equalsVector (f [a + 2.0]) [0.0])
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Rat;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Rat;
 test2 g = Optimise[min] (*) (\ a -> Optimise[min] (*) (\ b -> max 0.0 (1.0 - a) + (if 1.0 == a then 1.0 else 0.0) + (max 0.0 (a - b) + (if a == b then 1.0 else 0.0) + equalsVector (g [a + b, a + 2.0 * b]) [0.0])))

--- a/vehicle/tests/golden/compile/simple-gaussianElim/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/Explicit.vcl.golden
@@ -1,16 +1,14 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-test1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+test1 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 test1 f = exists a . a >= 0.0 and equalsVector (f [a + 2.0]) [0.0]
 
 @property;
-test2 : forallT (g : Tensor Rat (2 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+test2 : forallT (g : Vector Rat -> Vector Rat) . Bool;
 test2 g = exists a . exists b . a >= 1.0 and b >= a and equalsVector (g [a + b, a + 2.0 * b]) [0.0]

--- a/vehicle/tests/golden/compile/simple-if/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-if/Explicit.vcl.golden
@@ -1,13 +1,11 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
-prop1 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+prop1 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 prop1 f = forall x . if x > 0.0 then f [x] ! 0 > 0.0 else f [x] ! 0 <= 0.0
 
 @property;
-prop2 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+prop2 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 prop2 f = exists x . f [if x > 0.0 then x else 0.2] ! 0 >= 0.0
 
 @property;
-prop3 : forallT (f : Tensor Rat (1 :: nil) -> Tensor Rat (1 :: nil)) . Bool;
+prop3 : forallT (f : Vector Rat -> Vector Rat) . Bool;
 prop3 f = exists x . if f [x] ! 0 > 0.0 then x >= 0.0 else x < 0.0

--- a/vehicle/tests/golden/compile/simple-let/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-let/Explicit.vcl.golden
@@ -1,9 +1,6 @@
 bigAnd : List Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-forallIn : (Nat -> Bool) -> List Nat -> Bool;
-forallIn f xs = bigAnd (map f xs)
-
 @property;
 e1 : Bool;
 e1 = let x = True in let y = False in x and y
@@ -22,11 +19,11 @@ letForall = let y = 1.0 in forall (x : Rat) . y == x
 
 @property;
 forallInLet : Bool;
-forallInLet = forallIn (\ x -> let y = x in y == 1) (1 :: nil)
+forallInLet = bigAnd (map (\ x -> let y = x in y == 1) (1 :: nil))
 
 @property;
 letForallIn : Bool;
-letForallIn = let y = 1 in forallIn (\ x -> y == x) (1 :: nil)
+letForallIn = let y = 1 in bigAnd (map (\ x -> y == x) (1 :: nil))
 
 falsey : Rat -> Bool;
 falsey x = x <= 0.5

--- a/vehicle/tests/golden/compile/simple-quantifierIn/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-quantifierIn/Explicit.vcl.golden
@@ -1,14 +1,11 @@
-bigAnd__lam_A__Vector_A : (\ A -> Vector A) Bool -> Bool;
+bigAnd__lam_A__Vector_A : Vector Bool -> Bool;
 bigAnd__lam_A__Vector_A _x0 = fold (\ x -> \ y -> x and y) True _x0
 
 bigAnd__List : List Bool -> Bool;
 bigAnd__List _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-bigOr : (\ A -> Vector A) Bool -> Bool;
+bigOr : Vector Bool -> Bool;
 bigOr _x0 = fold (\ x -> \ y -> x or y) False _x0
-
-forallIn : (Vector Rat -> Bool) -> List (Vector Rat) -> Bool;
-forallIn f xs = bigAnd__List (map f xs)
 
 @noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
@@ -23,16 +20,16 @@ dataset = [0.5, 1.0] :: nil
 
 @property;
 empty : Bool;
-empty = forallIn (\ x -> True) dataset
+empty = bigAnd__List (map (\ x -> True) dataset)
 
 @property;
 double : Bool;
-double = forallIn (\ x -> forallIn (\ y -> equalsVector x y) dataset) dataset
+double = bigAnd__List (map (\ x -> bigAnd__List (map (\ y -> equalsVector x y) dataset)) dataset)
 
 @property;
 forallForallIn : Bool;
-forallForallIn = forall x . forallIn (\ y -> equalsVector x y) dataset
+forallForallIn = forall x . bigAnd__List (map (\ y -> equalsVector x y) dataset)
 
 @property;
 forallInForall : forallT (f : Vector Rat -> Vector Rat) . Bool;
-forallInForall f = forallIn (\ x -> forall y . notEqualsVector (f x) y) dataset
+forallInForall f = bigAnd__List (map (\ x -> forall y . notEqualsVector (f x) y) dataset)

--- a/vehicle/tests/golden/compile/simple-tensor/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Explicit.vcl.golden
@@ -1,8 +1,5 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
-
-foreachVector : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector n f = map f (indices n)
 
 @noinline;
 addVector__Rat__Rat__Rat : Vector Rat -> Vector Rat -> Vector Rat;
@@ -20,26 +17,21 @@ subVector__Rat__Rat__Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 subVector__Vector_Rat__Vector_Rat__Vector_Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector__Vector_Rat__Vector_Rat__Vector_Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector__Rat__Rat__Rat x y) _x0 _x1
 
-forallIndex : forallT n . (Index -> Bool) -> Bool;
-forallIndex n f = bigAnd (foreachVector n (\ i -> f i))
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
-zeroD : Tensor Rat nil;
+zeroD : Rat;
 zeroD = 2.5
 
-oneD : Tensor Rat (2 :: nil);
+oneD : Vector Rat;
 oneD = [zeroD, 1.0]
 
-twoD : Tensor Rat (2 :: 2 :: nil);
+twoD : Vector (Vector Rat);
 twoD = [oneD, [2.0, 3.0]]
 
-addition : Tensor Rat (2 :: 2 :: nil);
+addition : Vector (Vector Rat);
 addition = addVector__Vector_Rat__Vector_Rat__Vector_Rat twoD twoD
 
-subtraction : Tensor Rat (2 :: 2 :: nil);
+subtraction : Vector (Vector Rat);
 subtraction = subVector__Vector_Rat__Vector_Rat__Vector_Rat twoD twoD
 
 @property;
-p : forallT (f : Tensor Rat (2 :: 2 :: nil) -> Tensor Rat (2 :: 2 :: nil)) . Bool;
-p f = forallIndex 2 (\ i -> forallIndex 2 (\ j -> addVector__Vector_Rat__Vector_Rat__Vector_Rat (f subtraction) addition ! i ! j >= 0.0))
+p : forallT (f : Vector (Vector Rat) -> Vector (Vector Rat)) . Bool;
+p f = bigAnd (map (\ i -> bigAnd (map (\ j -> addVector__Vector_Rat__Vector_Rat__Vector_Rat (f subtraction) addition ! i ! j >= 0.0) (indices 2))) (indices 2))

--- a/vehicle/tests/golden/compile/simple-triviallyTrue/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-triviallyTrue/DL2Loss.vcl.golden
@@ -1,9 +1,7 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
 p : forallT (f : Vector Rat -> Vector Rat) . Rat;
 p f = Optimise[min] (+) (\ x -> max 0.0 (0.0 - f x ! 0)) * (if True then 0.0 else 1.0)
 
 @property;
-multiProperty : Tensor Rat (2 :: 3 :: nil);
+multiProperty : Vector (Vector Rat);
 multiProperty = [[0.0, 0.0, 0.0], [1.0, 0.0, 1.0]]

--- a/vehicle/tests/golden/compile/simple-triviallyTrue/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-triviallyTrue/Explicit.vcl.golden
@@ -1,9 +1,7 @@
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
 @property;
 p : forallT (f : Vector Rat -> Vector Rat) . Bool;
 p f = (forall x . f x ! 0 > 0.0) or True
 
 @property;
-multiProperty : Tensor Bool (2 :: 3 :: nil);
+multiProperty : Vector (Vector Bool);
 multiProperty = [[True, True, True], [False, True, False]]

--- a/vehicle/tests/golden/compile/simple-vector/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-vector/DL2Loss.vcl.golden
@@ -1,4 +1,4 @@
-untyped : (\ A -> Vector A) Rat;
+untyped : Vector Rat;
 untyped = [0.0]
 
 @property;

--- a/vehicle/tests/golden/compile/simple-vector/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-vector/Explicit.vcl.golden
@@ -1,4 +1,4 @@
-untyped : (\ A -> Vector A) Rat;
+untyped : Vector Rat;
 untyped = [0.0]
 
 @property;

--- a/vehicle/tests/golden/compile/windController/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/windController/DL2Loss.vcl.golden
@@ -1,15 +1,5 @@
-bigAnd : (\ A -> Vector A) Rat -> Rat;
+bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
-
-foreachVector : forallT n . (Index -> Rat) -> Vector Rat;
-foreachVector n f = map f (indices n)
-
-forallIndex : forallT n . (Index -> Rat) -> Rat;
-forallIndex n f = bigAnd (foreachVector n (\ i -> f i))
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
-type InputVector = Tensor Rat (2 :: nil)
 
 currentSensor : Index;
 currentSensor = 0
@@ -17,12 +7,12 @@ currentSensor = 0
 previousSensor : Index;
 previousSensor = 1
 
-safeInput : InputVector -> Rat;
-safeInput x = forallIndex 2 (\ i -> max 0.0 (- 3.25 - x ! i) + (if - 3.25 == x ! i then 1.0 else 0.0) + (max 0.0 (x ! i - 3.25) + (if x ! i == 3.25 then 1.0 else 0.0)))
+safeInput : Vector Rat -> Rat;
+safeInput x = bigAnd (map (\ i -> max 0.0 (- 3.25 - x ! i) + (if - 3.25 == x ! i then 1.0 else 0.0) + (max 0.0 (x ! i - 3.25) + (if x ! i == 3.25 then 1.0 else 0.0))) (indices 2))
 
-safeOutput : forallT (controller : InputVector -> Tensor Rat (1 :: nil)) . InputVector -> Rat;
+safeOutput : forallT (controller : Vector Rat -> Vector Rat) . Vector Rat -> Rat;
 safeOutput controller x = max 0.0 (- 1.25 - (controller x ! 0 + 2.0 * x ! currentSensor - x ! previousSensor)) + max 0.0 (controller x ! 0 + 2.0 * x ! currentSensor - x ! previousSensor - 1.25)
 
 @property;
-safe : forallT (controller : InputVector -> Tensor Rat (1 :: nil)) . Rat;
+safe : forallT (controller : Vector Rat -> Vector Rat) . Rat;
 safe controller = Optimise[min] (+) (\ x -> max 0.0 (safeInput x * safeOutput controller x))

--- a/vehicle/tests/golden/compile/windController/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/windController/Explicit.vcl.golden
@@ -1,15 +1,5 @@
-bigAnd : (\ A -> Vector A) Bool -> Bool;
+bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
-
-foreachVector : forallT n . (Index -> Bool) -> Vector Bool;
-foreachVector n f = map f (indices n)
-
-forallIndex : forallT n . (Index -> Bool) -> Bool;
-forallIndex n f = bigAnd (foreachVector n (\ i -> f i))
-
-type Tensor A ds = fold (\ d -> \ t -> Vector t) A ds
-
-type InputVector = Tensor Rat (2 :: nil)
 
 currentSensor : Index;
 currentSensor = 0
@@ -17,12 +7,12 @@ currentSensor = 0
 previousSensor : Index;
 previousSensor = 1
 
-safeInput : InputVector -> Bool;
-safeInput x = forallIndex 2 (\ i -> - 3.25 <= x ! i and x ! i <= 3.25)
+safeInput : Vector Rat -> Bool;
+safeInput x = bigAnd (map (\ i -> - 3.25 <= x ! i and x ! i <= 3.25) (indices 2))
 
-safeOutput : forallT (controller : InputVector -> Tensor Rat (1 :: nil)) . InputVector -> Bool;
+safeOutput : forallT (controller : Vector Rat -> Vector Rat) . Vector Rat -> Bool;
 safeOutput controller x = - 1.25 < controller x ! 0 + 2.0 * x ! currentSensor - x ! previousSensor and controller x ! 0 + 2.0 * x ! currentSensor - x ! previousSensor < 1.25
 
 @property;
-safe : forallT (controller : InputVector -> Tensor Rat (1 :: nil)) . Bool;
+safe : forallT (controller : Vector Rat -> Vector Rat) . Bool;
 safe controller = forall x . safeInput x => safeOutput controller x

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -127,6 +127,7 @@ library
     Vehicle.Backend.Queries.UserVariableElimination
     Vehicle.Backend.Queries.Variable
     Vehicle.Backend.Queries.VariableReconstruction
+    Vehicle.Backend.Tensors.Clean
     Vehicle.CommandLine
     Vehicle.Compile
     Vehicle.Compile.Descope


### PR DESCRIPTION
Towards being able to compile to tensors this PR adds a pass before exporting to JSON:

- Fully normalises all types
- Substitutes through any declarations that take higher-order function arguments.

As well as cleaning up the generated code, this should make it much easier to perform the translation to tensors. 