### PR TITLE
Remove meta-substitution from `MonadNorm`

### DIFF
--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/LinearitySolver.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/LinearitySolver.hs
@@ -14,9 +14,8 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad (MonadTypeChecker)
-import Vehicle.Compile.Type.Monad.Class (addConstraints, solveMeta)
+import Vehicle.Compile.Type.Monad.Class (addConstraints, solveMeta, substMetas)
 import Vehicle.Expr.BuiltinInterface
 import Vehicle.Expr.Normalised
 import Vehicle.Syntax.Builtin

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/PolaritySolver.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/PolaritySolver.hs
@@ -11,7 +11,6 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.BuiltinInterface
 import Vehicle.Expr.Normalised

--- a/vehicle/src/Vehicle/Compile/Normalise/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Monad.hs
@@ -33,22 +33,18 @@ defaultEvalOptions =
 class (MonadCompile m, PrintableBuiltin builtin, HasStandardData builtin) => MonadNorm builtin m where
   getEvalOptions :: Proxy builtin -> m EvalOptions
   getDeclSubstitution :: m (NormDeclCtx builtin)
-  getMetaSubstitution :: m (MetaSubstitution builtin)
 
 instance (MonadNorm builtin m) => MonadNorm builtin (StateT s m) where
   getEvalOptions = lift . getEvalOptions
   getDeclSubstitution = lift getDeclSubstitution
-  getMetaSubstitution = lift getMetaSubstitution
 
 instance (Monoid s, MonadNorm builtin m) => MonadNorm builtin (WriterT s m) where
   getEvalOptions = lift . getEvalOptions
   getDeclSubstitution = lift getDeclSubstitution
-  getMetaSubstitution = lift getMetaSubstitution
 
 instance (MonadNorm builtin m) => MonadNorm builtin (ReaderT s m) where
   getEvalOptions = lift . getEvalOptions
   getDeclSubstitution = lift getDeclSubstitution
-  getMetaSubstitution = lift getMetaSubstitution
 
 newtype NormT builtin m a = NormT
   { unnormT :: ReaderT (EvalOptions, NormDeclCtx builtin, MetaSubstitution builtin) m a
@@ -79,4 +75,3 @@ instance (MonadError e m) => MonadError e (NormT builtin m) where
 instance (MonadCompile m, PrintableBuiltin builtin, HasStandardData builtin) => MonadNorm builtin (NormT builtin m) where
   getEvalOptions _ = NormT $ asks (\(opts, _, _) -> opts)
   getDeclSubstitution = NormT $ asks (\(_, declCtx, _) -> declCtx)
-  getMetaSubstitution = NormT $ asks (\(_, _, metaCtx) -> metaCtx)

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -12,7 +12,6 @@ import Data.List (partition)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.Monad (getMetaSubstitution)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Bidirectional
@@ -22,8 +21,8 @@ import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Generalise
 import Vehicle.Compile.Type.Meta
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
-import Vehicle.Compile.Type.Meta.Substitution
 import Vehicle.Compile.Type.Monad
+import Vehicle.Compile.Type.Monad.Class
 import Vehicle.Compile.Type.Subsystem.Standard.Core
 import Vehicle.Expr.Normalised
 
@@ -295,7 +294,7 @@ checkAllMetasSolved proxy = do
 logUnsolvedUnknowns :: forall builtin m. (TCM builtin m) => Maybe (Decl Ix builtin) -> Maybe MetaSet -> m ()
 logUnsolvedUnknowns maybeDecl maybeSolvedMetas = do
   logDebugM MaxDetail $ do
-    newSubstitution <- getMetaSubstitution @builtin
+    newSubstitution <- getMetaSubstitution (Proxy @builtin)
     updatedSubst <- substMetas newSubstitution
 
     unsolvedMetas <- getUnsolvedMetas (Proxy @builtin)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/IndexSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/IndexSolver.hs
@@ -9,7 +9,6 @@ import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
-import Vehicle.Compile.Type.Meta.Substitution
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.BuiltinInterface
 import Vehicle.Expr.Normalised

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
@@ -13,7 +13,6 @@ import Vehicle.Compile.Print (prettyVerbose)
 import Vehicle.Compile.Type.Constraint.Core (createInstanceUnification)
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
-import Vehicle.Compile.Type.Meta.Substitution
 import Vehicle.Compile.Type.Meta.Variable
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.BuiltinInterface

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
@@ -17,7 +17,6 @@ import Vehicle.Compile.Print (PrintableBuiltin, prettyExternal, prettyFriendly)
 import Vehicle.Compile.Type (runUnificationSolver)
 import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.DeBruijn (dbLevelToIndex, substDBInto)
 import Vehicle.Expr.Normalised

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -15,7 +15,6 @@ import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Meta
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
-import Vehicle.Compile.Type.Meta.Substitution (substMetas)
 import Vehicle.Compile.Type.Monad
 import Vehicle.Expr.DeBruijn
 

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -21,6 +21,7 @@ module Vehicle.Compile.Type.Monad
     trackSolvedMetas,
     prettyMeta,
     prettyMetas,
+    substMetas,
     -- Constraints
     copyContext,
     createFreshUnificationConstraint,

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
@@ -77,8 +77,6 @@ instance (PrintableBuiltin builtin, NormalisableBuiltin builtin, MonadCompile m)
 
   getDeclSubstitution = TypeCheckerT $ asks (typingDeclCtxToNormDeclCtx . fst)
 
-  getMetaSubstitution = TypeCheckerT (gets currentSubstitution)
-
 instance (PrintableBuiltin builtin, NormalisableBuiltin builtin, MonadCompile m) => MonadTypeChecker builtin (TypeCheckerT builtin m) where
   getDeclContext = TypeCheckerT (asks fst)
   addDeclContext d s = TypeCheckerT $ local (first (addToTypingDeclCtx d)) (unTypeCheckerT s)


### PR DESCRIPTION
Normalisation should be agnostic to the current meta-variable state. The meta-variables should be handled before hand by a more efficient forcing operation.