### PR TITLE
Internalise the @noinline annotation into the compiler

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -129,7 +129,6 @@ isExternalResourceSort = \case
 
 data Annotation
   = AnnProperty
-  | AnnNoInline
   deriving (Eq, Show, Generic)
 
 instance NFData Annotation
@@ -142,6 +141,3 @@ instance Pretty Annotation where
 
 isProperty :: [Annotation] -> Bool
 isProperty anns = AnnProperty `elem` anns
-
-isInlinable :: [Annotation] -> Bool
-isInlinable anns = AnnNoInline `notElem` anns

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -99,7 +99,6 @@ instance Delaborate (V.Binder V.Name V.Builtin) B.BasicBinder where
 instance Delaborate V.Annotation B.Decl where
   delabM = \case
     V.AnnProperty -> return $ delabAnn propertyAnn []
-    V.AnnNoInline -> return $ delabAnn noInlineAnn []
 
 -- | Used for things not in the user-syntax.
 cheatDelab :: Text -> B.Expr

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
@@ -194,7 +194,6 @@ parseAnnotation defName (name, opts) = case name of
   B.Parameter {} -> Left <$> elabParameterOptions opts
   B.Postulate {} -> do checkNoAnnotationOptions name opts; return $ Left V.PostulateDef
   B.Property {} -> do checkNoAnnotationOptions name opts; return $ Right V.AnnProperty
-  B.NoInline {} -> do checkNoAnnotationOptions name opts; return $ Right V.AnnNoInline
 
 elabParameterOptions :: (MonadElab m) => B.DeclAnnOpts -> m V.DefAbstractSort
 elabParameterOptions = \case

--- a/vehicle-syntax/src/Vehicle/Syntax/External.cf
+++ b/vehicle-syntax/src/Vehicle/Syntax/External.cf
@@ -15,7 +15,6 @@ position token TokDataset   {"@dataset"};
 position token TokParameter {"@parameter"};
 position token TokProperty  {"@property"};
 position token TokPostulate {"@postulate"};
-position token TokNoInline  {"@noinline"};
 
 position token TokArrow     {"->"};
 position token TokForallT   {"forallT"};
@@ -222,7 +221,6 @@ Dataset.   DeclAnnName ::= TokDataset;
 Parameter. DeclAnnName ::= TokParameter;
 Property.  DeclAnnName ::= TokProperty;
 Postulate. DeclAnnName ::= TokPostulate;
-NoInline.  DeclAnnName ::= TokNoInline;
 
 -- * Annotation options
 

--- a/vehicle/lib/std.vcl
+++ b/vehicle/lib/std.vcl
@@ -31,19 +31,15 @@ vectorToVector xs = xs
 foreachVector : forallT n . (Index n -> A) -> Vector A n
 foreachVector n f = map f (indices n)
 
-@noinline
 addVector : forallT {@0 n} . {{HasAdd A B C}} -> Vector A n -> Vector B n -> Vector C n
 addVector = zipWith (\x y -> x + y)
 
-@noinline
 subVector : forallT {@0 n} . {{HasSub A B C}} -> Vector A n -> Vector B n -> Vector C n
 subVector = zipWith (\x y -> x - y)
 
-@noinline
 equalsVector : forallT {@0 n} . {{HasEq A B}} -> Vector A n -> Vector B n -> Bool
 equalsVector xs ys = bigAnd (zipWith (\x y -> x == y) xs ys)
 
-@noinline
 notEqualsVector : forallT {@0 n} . {{HasNotEq A B}} -> Vector A n -> Vector B n -> Bool
 notEqualsVector xs ys = bigOr (zipWith (\x y -> x != y) xs ys)
 

--- a/vehicle/src/Vehicle/Backend/Queries.hs
+++ b/vehicle/src/Vehicle/Backend/Queries.hs
@@ -126,7 +126,7 @@ compilePropertyDecl ::
   m (Name, MultiProperty ())
 compilePropertyDecl prog queryFormat networkCtx queryFreeCtx p ident expr outputLocation = do
   logCompilerPass MinDetail ("property" <+> quotePretty ident) $ do
-    normalisedExpr <- eval defaultNBEOptions mempty expr
+    normalisedExpr <- eval (mkNBEOptions vectorStructureOperations) mempty expr
 
     let computeProperty = compileMultiProperty queryFormat networkCtx queryFreeCtx p ident outputLocation normalisedExpr
 

--- a/vehicle/src/Vehicle/Compile/Error/Message.hs
+++ b/vehicle/src/Vehicle/Compile/Error/Message.hs
@@ -141,16 +141,6 @@ instance MeaningfulError CompileError where
                   problem = "missing definition for property" <+> quotePretty name <> ".",
                   fix = Just $ "add a definition for" <+> quotePretty name <+> "."
                 }
-          AnnNoInline ->
-            UError $
-              UserError
-                { provenance = p,
-                  problem =
-                    "the annotation"
-                      <+> pretty AnnNoInline
-                      <> "must be attached to a declaration with a definition.",
-                  fix = Just $ "add a definition for" <+> quotePretty name <+> "."
-                }
       NonAbstractDefWithAbstractAnnotation p name resource ->
         UError $
           UserError

--- a/vehicle/src/Vehicle/Libraries/StandardLibrary/Definitions.hs
+++ b/vehicle/src/Vehicle/Libraries/StandardLibrary/Definitions.hs
@@ -28,7 +28,7 @@ data StdLibFunction
   | StdVectorToList
   | StdForeach
   | StdTensor
-  deriving (Eq, Enum, Bounded)
+  deriving (Eq, Ord, Enum, Bounded)
 
 instance Show StdLibFunction where
   show = \case

--- a/vehicle/tests/golden/compile/autoencoderError/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/autoencoderError/Explicit.vcl.golden
@@ -1,11 +1,9 @@
 bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-@noinline;
 addVector : Vector Rat -> Vector Rat -> Vector Rat;
 addVector _x0 _x1 = zipWith (\ x -> \ y -> x + y) _x0 _x1
 
-@noinline;
 subVector : Vector Rat -> Vector Rat -> Vector Rat;
 subVector _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 

--- a/vehicle/tests/golden/compile/logic-and-comparisons/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/DL2Loss.vcl.golden
@@ -1,7 +1,6 @@
 bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
-@noinline;
 equalsVector--Rat--Rat : Vector Rat -> Vector Rat -> Rat;
 equalsVector--Rat--Rat xs ys = bigAnd (zipWith (\ x -> \ y -> max 0.0 (x - y) + max 0.0 (y - x)) xs ys)
 

--- a/vehicle/tests/golden/compile/logic-and-comparisons/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/Explicit.vcl.golden
@@ -4,11 +4,9 @@ bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 bigOr : Vector Bool -> Bool;
 bigOr _x0 = fold (\ x -> \ y -> x or y) False _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 
-@noinline;
 notEqualsVector : Vector Rat -> Vector Rat -> Bool;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> x != y) xs ys)
 

--- a/vehicle/tests/golden/compile/logic-and-comparisons/GodelLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/GodelLoss.vcl.golden
@@ -4,11 +4,9 @@ bigAnd _x0 = fold (\ x -> \ y -> 1.0 - min x y) 0.0 _x0
 bigOr : Vector Rat -> Rat;
 bigOr _x0 = fold (\ x -> \ y -> 1.0 - max x y) 1.0 _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 else 0.0)) xs ys)
 
-@noinline;
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 

--- a/vehicle/tests/golden/compile/logic-and-comparisons/LukasiewiczLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/LukasiewiczLoss.vcl.golden
@@ -4,11 +4,9 @@ bigAnd _x0 = fold (\ x -> \ y -> 1.0 - max 0.0 (x + y - 1.0)) 0.0 _x0
 bigOr : Vector Rat -> Rat;
 bigOr _x0 = fold (\ x -> \ y -> 1.0 - min (x + y) 1.0) 1.0 _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 else 0.0)) xs ys)
 
-@noinline;
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 

--- a/vehicle/tests/golden/compile/logic-and-comparisons/ProductLoss.json.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/ProductLoss.json.golden
@@ -4,11 +4,9 @@ bigAnd _x0 = fold (\ x -> \ y -> 1.0 - x * y) 0.0 _x0
 bigOr : Vector Rat -> Rat;
 bigOr _x0 = fold (\ x -> \ y -> 1.0 - x * y) 1.0 _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 else 0.0)) xs ys)
 
-@noinline;
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 

--- a/vehicle/tests/golden/compile/logic-and-comparisons/YagerLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/logic-and-comparisons/YagerLoss.vcl.golden
@@ -4,11 +4,9 @@ bigAnd _x0 = fold (\ x -> \ y -> 1.0 - max (** (1.0 - (** (1.0 - x) 1.0 + ** (1.
 bigOr : Vector Rat -> Rat;
 bigOr _x0 = fold (\ x -> \ y -> 1.0 - min (** (** x 1.0 + ** y 1.0) 1.0) 1.0) 1.0 _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> 1.0 - (if x == y then 1.0 else 0.0)) xs ys)
 
-@noinline;
 notEqualsVector : Vector Rat -> Vector Rat -> Rat;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> if x == y then 1.0 else 0.0) xs ys)
 

--- a/vehicle/tests/golden/compile/mnist-robustness/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/DL2Loss.vcl.golden
@@ -1,11 +1,9 @@
 bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
-@noinline;
 subVector--Rat--Rat--Rat : Vector Rat -> Vector Rat -> Vector Rat;
 subVector--Rat--Rat--Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 
-@noinline;
 subVector--Vector-Rat--Vector-Rat--Vector-Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector--Vector-Rat--Vector-Rat--Vector-Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector--Rat--Rat--Rat x y) _x0 _x1
 

--- a/vehicle/tests/golden/compile/mnist-robustness/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/Explicit.vcl.golden
@@ -1,11 +1,9 @@
 bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-@noinline;
 subVector__Rat__Rat__Rat : Vector Rat -> Vector Rat -> Vector Rat;
 subVector__Rat__Rat__Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 
-@noinline;
 subVector__Vector_Rat__Vector_Rat__Vector_Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector__Vector_Rat__Vector_Rat__Vector_Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector__Rat__Rat__Rat x y) _x0 _x1
 

--- a/vehicle/tests/golden/compile/mnist-robustness/VehicleLoss.vcl.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/VehicleLoss.vcl.golden
@@ -1,11 +1,9 @@
 bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> max x y) -100000.0 _x0
 
-@noinline;
 subVector--Rat--Rat--Rat : Vector Rat -> Vector Rat -> Vector Rat;
 subVector--Rat--Rat--Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 
-@noinline;
 subVector--Vector-Rat--Vector-Rat--Vector-Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector--Vector-Rat--Vector-Rat--Vector-Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector--Rat--Rat--Rat x y) _x0 _x1
 

--- a/vehicle/tests/golden/compile/reachability/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/reachability/DL2Loss.vcl.golden
@@ -1,7 +1,6 @@
 bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> max 0.0 (x - y) + max 0.0 (y - x)) xs ys)
 

--- a/vehicle/tests/golden/compile/reachability/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/reachability/Explicit.vcl.golden
@@ -1,7 +1,6 @@
 bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 

--- a/vehicle/tests/golden/compile/simple-constantNetworkInput/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-constantNetworkInput/Explicit.vcl.golden
@@ -1,7 +1,6 @@
 bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 

--- a/vehicle/tests/golden/compile/simple-gaussianElim/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/DL2Loss.vcl.golden
@@ -1,7 +1,6 @@
 bigAnd : Vector Rat -> Rat;
 bigAnd _x0 = fold (\ x -> \ y -> x + y) 0.0 _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Rat;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> max 0.0 (x - y) + max 0.0 (y - x)) xs ys)
 

--- a/vehicle/tests/golden/compile/simple-gaussianElim/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-gaussianElim/Explicit.vcl.golden
@@ -1,7 +1,6 @@
 bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd (zipWith (\ x -> \ y -> x == y) xs ys)
 

--- a/vehicle/tests/golden/compile/simple-quantifierIn/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-quantifierIn/Explicit.vcl.golden
@@ -7,11 +7,9 @@ bigAnd__List _x0 = fold (\ x -> \ y -> x and y) True _x0
 bigOr : Vector Bool -> Bool;
 bigOr _x0 = fold (\ x -> \ y -> x or y) False _x0
 
-@noinline;
 equalsVector : Vector Rat -> Vector Rat -> Bool;
 equalsVector xs ys = bigAnd__lam_A__Vector_A (zipWith (\ x -> \ y -> x == y) xs ys)
 
-@noinline;
 notEqualsVector : Vector Rat -> Vector Rat -> Bool;
 notEqualsVector xs ys = bigOr (zipWith (\ x -> \ y -> x != y) xs ys)
 

--- a/vehicle/tests/golden/compile/simple-tensor/Explicit.vcl.golden
+++ b/vehicle/tests/golden/compile/simple-tensor/Explicit.vcl.golden
@@ -1,19 +1,15 @@
 bigAnd : Vector Bool -> Bool;
 bigAnd _x0 = fold (\ x -> \ y -> x and y) True _x0
 
-@noinline;
 addVector__Rat__Rat__Rat : Vector Rat -> Vector Rat -> Vector Rat;
 addVector__Rat__Rat__Rat _x0 _x1 = zipWith (\ x -> \ y -> x + y) _x0 _x1
 
-@noinline;
 addVector__Vector_Rat__Vector_Rat__Vector_Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 addVector__Vector_Rat__Vector_Rat__Vector_Rat _x0 _x1 = zipWith (\ x -> \ y -> addVector__Rat__Rat__Rat x y) _x0 _x1
 
-@noinline;
 subVector__Rat__Rat__Rat : Vector Rat -> Vector Rat -> Vector Rat;
 subVector__Rat__Rat__Rat _x0 _x1 = zipWith (\ x -> \ y -> x - y) _x0 _x1
 
-@noinline;
 subVector__Vector_Rat__Vector_Rat__Vector_Rat : Vector (Vector Rat) -> Vector (Vector Rat) -> Vector (Vector Rat);
 subVector__Vector_Rat__Vector_Rat__Vector_Rat _x0 _x1 = zipWith (\ x -> \ y -> subVector__Rat__Rat__Rat x y) _x0 _x1
 


### PR DESCRIPTION
Turns out when compiling to loss functions, we _don't_ want the `@noinline` annotations to work. Rather than specialising the annotations to Marabou, far easier to just make them configurable within the compiler itself. It's not like the user is ever going to be writing them on their own functions.