### PR TITLE
During NBE of DB indices calculate the level in the final context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -401,6 +401,16 @@ The compiler tests test the output of a successful run of the Vehicle compiler. 
 cabal run exe:vehicle -- --logging=MaxDetail ...
 ```
 
+##### Extra logging
+
+There is various useful debugging information that can be logged, but is not available even when the max logging
+level is set because its simply too verbose. This includes:
+
+1. If you want to see normalisation behaviour, in `Vehicle.Compile.Normalise.NBE`, there are various disabled logging functions (e.g. `showEntry`) that can be enabled.
+
+2. If you want to see the current contexts attached lambda `Value` constructors, in
+   `Vehicle.Compile.Descope.descopeNormExpr` there is some disabled code that attaches that information to `prettyVerbose`.
+
 #### Installing from source
 
 Ensure that [you have the source code](#getting-the-source) and that you have installed [GHC and Cabal](#installing-ghc-and-cabal).

--- a/vehicle/src/Vehicle/Backend/Queries.hs
+++ b/vehicle/src/Vehicle/Backend/Queries.hs
@@ -19,6 +19,7 @@ import Vehicle.Backend.Queries.IfElimination (unfoldIf)
 import Vehicle.Backend.Queries.LinearExpr
 import Vehicle.Backend.Queries.NetworkElimination
 import Vehicle.Backend.Queries.QuerySetStructure
+import Vehicle.Backend.Queries.UsedFunctions
 import Vehicle.Backend.Queries.UserVariableElimination (catchableUnsupportedNonLinearConstraint, eliminateUserVariables)
 import Vehicle.Backend.Queries.Variable (MixedVariables (MixedVariables), NetworkVariable (..), UserVariableCtx, pattern VInfiniteQuantifier)
 import Vehicle.Compile.Context.Free
@@ -126,7 +127,7 @@ compilePropertyDecl ::
   m (Name, MultiProperty ())
 compilePropertyDecl prog queryFormat networkCtx queryFreeCtx p ident expr outputLocation = do
   logCompilerPass MinDetail ("property" <+> quotePretty ident) $ do
-    normalisedExpr <- eval (mkNBEOptions vectorStructureOperations) mempty expr
+    normalisedExpr <- eval (mkNBEOptions vectorStructureOperations) emptyEnv expr
 
     let computeProperty = compileMultiProperty queryFormat networkCtx queryFreeCtx p ident outputLocation normalisedExpr
 

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Linearity/AnnotationRestrictions.hs
@@ -23,8 +23,8 @@ checkNetworkType (ident, p) networkType = case normalised networkType of
   -- binders are explicit and their types are equal. Returns a function that
   -- prepends the max linearity constraint.
   VPi binder result -> do
-    inputLin <- quote mempty 0 (typeOf binder)
-    outputLin <- quote mempty 0 result
+    let inputLin = quote mempty 0 (typeOf binder)
+    let outputLin = quote mempty 0 result
 
     -- The linearity of the output of a network is the max of 1) Linear (as outputs
     -- are also variables) and 2) the linearity of its input. So prepend this

--- a/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/AnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Error/Polarity/AnnotationRestrictions.hs
@@ -23,8 +23,8 @@ checkNetworkType (_, p) networkType = case normalised networkType of
   -- binders are explicit and their types are equal. Returns a function that
   -- prepends the max linearity constraint.
   VPi binder result -> do
-    inputPol <- quote mempty 0 (typeOf binder)
-    outputPol <- quote mempty 0 result
+    let inputPol = quote mempty 0 (typeOf binder)
+    let outputPol = quote mempty 0 result
 
     createFreshUnificationConstraint p mempty CheckingAuxiliary (PolarityExpr p Unquantified) inputPol
     createFreshUnificationConstraint p mempty CheckingAuxiliary (PolarityExpr p Unquantified) outputPol

--- a/vehicle/src/Vehicle/Backend/Queries/NetworkElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/NetworkElimination.hs
@@ -222,7 +222,7 @@ findApplicationsInSpine ::
   WHNFSpine Builtin ->
   m NetworkApplicationForest
 findApplicationsInSpine spine =
-  HashSet.unions <$> traverse findApplicationsInExpr (fmap argExpr spine)
+  HashSet.unions <$> traverse (findApplicationsInExpr . argExpr) spine
 
 --------------------------------------------------------------------------------
 -- Replace network applications.

--- a/vehicle/src/Vehicle/Backend/Queries/UsedFunctions.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/UsedFunctions.hs
@@ -1,0 +1,122 @@
+module Vehicle.Backend.Queries.UsedFunctions
+  ( UsedFunctionsCtx,
+    UsedFunctionsInfo,
+    getUsedFunctions,
+    getUsedFunctionsCtx,
+  )
+where
+
+import Data.HashSet (HashSet)
+import Data.HashSet qualified as HashSet (singleton)
+import Data.Map qualified as Map (lookup)
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set (singleton)
+import Vehicle.Compile.Context.Free
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Subsystem.Standard
+import Vehicle.Data.DeBruijn (dbLevelToIndex)
+import Vehicle.Data.NormalisedExpr
+
+--------------------------------------------------------------------------------
+-- Builtin and free variable tracking
+
+type UsedFunctionsCtx = GenericFreeCtx UsedFunctionsInfo
+
+type UsedFunctionsInfo = (HashSet BuiltinFunction, Set Identifier)
+
+getUsedFunctions ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  GenericBoundCtx UsedFunctionsInfo ->
+  Expr Ix Builtin ->
+  UsedFunctionsInfo
+getUsedFunctions freeCtx boundCtx expr = case expr of
+  Universe {} -> mempty
+  Meta {} -> mempty
+  Hole {} -> mempty
+  Pi {} -> mempty
+  BoundVar _ v -> getUsedVarsBoundVar boundCtx v
+  Builtin _ b -> getUsedFunctionsBuiltin b
+  FreeVar _ ident -> getUsedFunctionsFreeVar freeCtx ident
+  App _ fun args -> foldr ((<>) . getUsedFunctions freeCtx boundCtx . argExpr) (getUsedFunctions freeCtx boundCtx fun) args
+  Let _ e1 _binder e2 -> getUsedFunctions freeCtx boundCtx e1 <> getUsedFunctions freeCtx boundCtx e2
+  Lam _ _binder e -> getUsedFunctions freeCtx (mempty : boundCtx) e
+
+getUsedNormFunctions ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  GenericBoundCtx UsedFunctionsInfo ->
+  WHNFValue Builtin ->
+  UsedFunctionsInfo
+getUsedNormFunctions freeCtx boundCtx expr = case expr of
+  VPi {} -> mempty
+  VUniverse {} -> mempty
+  VMeta {} -> mempty
+  VLam _ (WHNFBody env body) -> do
+    let envInfo = getUsedFunctionsEnv freeCtx boundCtx env
+    let bodyInfo = getUsedFunctions freeCtx (mempty : boundCtx) body
+    envInfo <> bodyInfo
+  VBoundVar v spine -> do
+    let varInfo = getUsedVarsBoundVar boundCtx (dbLevelToIndex (Lv (length boundCtx)) v)
+    let spineInfo = getUsedFunctionsSpine freeCtx boundCtx spine
+    varInfo <> spineInfo
+  VFreeVar ident spine -> do
+    let identInfo = getUsedFunctionsFreeVar freeCtx ident
+    let spineInfo = getUsedFunctionsSpine freeCtx boundCtx spine
+    identInfo <> spineInfo
+  VBuiltin b spine -> do
+    let builtinInfo = getUsedFunctionsBuiltin b
+    let spineInfo = getUsedFunctionsSpine freeCtx boundCtx spine
+    builtinInfo <> spineInfo
+
+getUsedFunctionsBuiltin ::
+  Builtin ->
+  UsedFunctionsInfo
+getUsedFunctionsBuiltin = \case
+  BuiltinFunction f -> (HashSet.singleton f, mempty)
+  _ -> mempty
+
+getUsedFunctionsFreeVar ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  Identifier ->
+  UsedFunctionsInfo
+getUsedFunctionsFreeVar freeCtx ident =
+  (mempty, Set.singleton ident) <> fromMaybe mempty (Map.lookup ident freeCtx)
+
+getUsedVarsBoundVar ::
+  GenericBoundCtx UsedFunctionsInfo ->
+  Ix ->
+  UsedFunctionsInfo
+getUsedVarsBoundVar boundCtx ix =
+  fromMaybe mempty (lookupIx boundCtx ix)
+
+getUsedFunctionsSpine ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  GenericBoundCtx UsedFunctionsInfo ->
+  WHNFSpine Builtin ->
+  UsedFunctionsInfo
+getUsedFunctionsSpine freeCtx boundCtx =
+  foldMap (getUsedNormFunctions freeCtx boundCtx . argExpr)
+
+getUsedFunctionsEnv ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  GenericBoundCtx UsedFunctionsInfo ->
+  WHNFEnv Builtin ->
+  UsedFunctionsInfo
+getUsedFunctionsEnv freeCtx boundCtx =
+  foldMap (getUsedFunctionsEnvEntry freeCtx boundCtx)
+
+getUsedFunctionsEnvEntry ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  GenericBoundCtx UsedFunctionsInfo ->
+  EnvEntry 'WHNF Builtin ->
+  UsedFunctionsInfo
+getUsedFunctionsEnvEntry freeCtx boundCtx (_binder, value) = case value of
+  Bound {} -> mempty
+  Defined v -> getUsedNormFunctions freeCtx boundCtx v
+
+getUsedFunctionsCtx ::
+  GenericFreeCtx UsedFunctionsInfo ->
+  WHNFEnv Builtin ->
+  GenericBoundCtx UsedFunctionsInfo
+getUsedFunctionsCtx freeCtx =
+  foldr (\u v -> getUsedFunctionsEnvEntry freeCtx v u : v) mempty

--- a/vehicle/src/Vehicle/Backend/Queries/UserVariableElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/UserVariableElimination.hs
@@ -367,28 +367,26 @@ reduceVariables variables solvedUserVariables = do
       variable ->
       (Lv, GenericBoundCtx variable, VariableNormalisationSteps, WHNFEnv Builtin, Map variable Lv) ->
       m (Lv, GenericBoundCtx variable, VariableNormalisationSteps, WHNFEnv Builtin, Map variable Lv)
-    possiblyReduceVariable solvedVariables var (currentLv, reducedVariables, steps, subst, solvedIndices)
+    possiblyReduceVariable solvedVariables var (currentLv, reducedVariables, steps, env, solvedIndices)
       | var `Set.member` solvedVariables = do
           logDebug MaxDetail $
             "Variable"
               <+> quotePretty var
               <+> "not reduced as previously solved"
               <> line
-          let newExpr = VFreeVar (Identifier User (layoutAsText ("Should not appear - SOLVED" <+> pretty var))) []
-          let newEnv = mkDefaultBinder varName newExpr : subst
-          let newSolvedIndices = Map.insert var (Lv $ length subst) solvedIndices
+          let newEnv = extendEnvWithBound (mkDefaultBinder varName ()) env
+          let newSolvedIndices = Map.insert var (Lv $ length env) solvedIndices
           return (currentLv, reducedVariables, steps, newEnv, newSolvedIndices)
       | isRationalVariable var = do
           logDebug MaxDetail $ "Variable" <+> quotePretty var <+> "already fully reduced" <> line
           let newNormVariables = var : reducedVariables
-          let newExpr = VBoundVar (Lv $ length subst) []
-          let newEnv = mkDefaultBinder varName newExpr : subst
+          let newEnv = extendEnvWithBound (mkDefaultBinder varName ()) env
           return (currentLv + 1, newNormVariables, steps, newEnv, solvedIndices)
       | otherwise = do
           let (newVars, newExpr) = reduceVariable currentLv var
           logDebug MaxDetail $ "Variable" <+> quotePretty var <+> "reduced to" <> line <> indent 2 (pretty newVars) <> line
           let newNormVariables = newVars <> reducedVariables
-          let newEnv = mkDefaultBinder varName newExpr : subst
+          let newEnv = extendEnvWithDefined newExpr (mkDefaultBinder varName ()) env
           return (currentLv + Lv (length newVars), newNormVariables, Reduce (toMixedVariable var) : steps, newEnv, solvedIndices)
       where
         varName = layoutAsText $ pretty var
@@ -409,7 +407,8 @@ substituteReducedVariablesThroughSolutions partialEnv solutions solvedVariablePo
       normalisedSolution <- reeval defaultNBEOptions env solution
       let errorMsg = developerError $ "Environment index missing for solved variable" <+> quotePretty var
       let index = unIx $ fromMaybe errorMsg $ Map.lookup var solvedVariablePositions
-      let newEnv = take index env <> [mkDefaultBinder (layoutAsText $ pretty var) normalisedSolution] <> drop (index + 1) env
+      let newEntry = mkDefaultEnvEntry (layoutAsText $ pretty var) (Defined normalisedSolution)
+      let newEnv = take index env <> [newEntry] <> drop (index + 1) env
       return newEnv
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Backend/Queries/Variable.hs
+++ b/vehicle/src/Vehicle/Backend/Queries/Variable.hs
@@ -76,17 +76,14 @@ class
 isRationalVariable :: (Variable variable) => variable -> Bool
 isRationalVariable v = null (variableDimensions v)
 
-variableToEnvEntry :: (Variable variable) => Lv -> variable -> GenericBinder (Value strategy body)
-variableToEnvEntry lv var = mkDefaultBinder (layoutAsText $ pretty var) (VBoundVar lv [])
-
-variableCtxToEnv :: (Variable variable) => [variable] -> Env strategy body
-variableCtxToEnv ctx = zipWith variableToEnvEntry (reverse [0 .. Lv (length ctx - 1)]) ctx
-
 variableCtxToBoundCtxEntry :: (Variable variable) => Ix -> variable -> Binder Ix Builtin
 variableCtxToBoundCtxEntry ix var = mkDefaultBinder (layoutAsText $ pretty var) (BoundVar mempty ix)
 
 variableCtxToBoundCtx :: (Variable variable) => [variable] -> BoundCtx Builtin
 variableCtxToBoundCtx ctx = zipWith variableCtxToBoundCtxEntry [0 .. Ix (length ctx - 1)] ctx
+
+variableCtxToEnv :: (Variable variable) => [variable] -> Env strategy Builtin
+variableCtxToEnv ctx = boundContextToEnv (variableCtxToBoundCtx ctx)
 
 --------------------------------------------------------------------------------
 -- User variables

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -221,9 +221,9 @@ descopeNormExpr f e = case e of
   VLam binder (WHNFBody _env body) -> do
     let binder' = descopeNormBinder f binder
     let body' = descopeNaive body
-    -- let env' = fmap (descopeNormExpr f) env
-    -- let envExpr = normAppList p (BoundVar p "ENV") $ fmap (ExplicitArg p) env'
-    -- Lam p binder' (App p envExpr [ExplicitArg p body'])
+    -- let env' = fmap (descopeNormExpr f) (cheatEnvToValues env)
+    -- let envExpr = normAppList p (BoundVar p "ENV") $ fmap (Arg p Explicit Relevant) env'
+    -- Lam p binder' (App p envExpr [Arg p Explicit Relevant body'])
     Lam p binder' body'
   where
     p = mempty

--- a/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
@@ -1,6 +1,5 @@
 module Vehicle.Compile.Normalise.Quote where
 
-import Vehicle.Compile.Error (MonadCompile, runCompileMonadSilently)
 import Vehicle.Compile.Prelude
 import Vehicle.Data.DeBruijn
 import Vehicle.Data.NormalisedExpr
@@ -9,7 +8,7 @@ import Vehicle.Data.NormalisedExpr
 -- Do not call except for logging and debug purposes, very expensive with nested
 -- lambdas.
 unnormalise :: forall a b. (Quote a b) => Lv -> a -> b
-unnormalise level e = runCompileMonadSilently "unquoting" (quote mempty level e)
+unnormalise = quote mempty
 
 -----------------------------------------------------------------------------
 -- Quoting
@@ -17,48 +16,51 @@ unnormalise level e = runCompileMonadSilently "unquoting" (quote mempty level e)
 -- i.e. converting back to unnormalised expressions
 
 class Quote a b where
-  quote :: (MonadCompile m) => Provenance -> Lv -> a -> m b
+  quote :: Provenance -> Lv -> a -> b
 
-instance (Quote (VBinder strategy builtin, Body strategy builtin) (Expr Ix builtin)) => Quote (Value strategy builtin) (Expr Ix builtin) where
+instance Quote (Value strategy builtin) (Expr Ix builtin) where
   quote p level = \case
-    VUniverse u -> return $ Universe p u
+    VUniverse u -> Universe p u
     VMeta m spine -> quoteApp level p (Meta p m) spine
     VFreeVar v spine -> quoteApp level p (FreeVar p v) spine
     VBoundVar v spine -> quoteApp level p (BoundVar p (dbLevelToIndex level v)) spine
     VBuiltin b spine -> quoteApp level p (Builtin p b) spine
     VPi binder body -> do
-      quotedBinder <- quote p level binder
-      quotedBody <- quote p level body
-      return $ Pi p quotedBinder quotedBody
+      let quotedBinder = quote p level binder
+      let quotedBody = quote p level body
+      Pi p quotedBinder quotedBody
     VLam binder body -> do
-      quotedBinder <- quote p level binder
-      quotedBody <- quote p level (binder, body)
-      return $ Lam mempty quotedBinder quotedBody
+      let quotedBinder = quote p level binder
+      let quotedBody = quote p level (binder, body)
+      Lam mempty quotedBinder quotedBody
 
-instance Quote (WHNFBinder builtin, Body 'WHNF builtin) (Expr Ix builtin) where
-  quote p level (binder, WHNFBody env body) = do
-    -- Here we deliberately avoid using the standard `quote . eval` approach below
-    -- on the body of the lambda, in order to avoid the dependency cycles that
-    -- prevent us from printing during NBE.
-    --
-    -- normBody <- runReaderT (eval (liftEnvOverBinder p env) body) mempty
-    -- quotedBody <- quote (level + 1) normBody
-    let lamBinderEnvEntry = fmap (const (VBoundVar level [])) binder
-    quotedEnv <- traverse (\b -> quote p (level + 1) b) (lamBinderEnvEntry : env)
-    return $ substituteDB 0 (envSubst quotedEnv) body
+instance Quote (VBinder strategy builtin, Body strategy builtin) (Expr Ix builtin) where
+  quote p level (binder, body) = case body of
+    NFBody value -> quote p level value
+    WHNFBody env value -> do
+      -- Here we deliberately avoid using the standard `quote . eval` approach below
+      -- on the body of the lambda, in order to avoid the dependency cycles that
+      -- prevent us from printing during NBE.
+      --
+      -- normBody <- runReaderT (eval (liftEnvOverBinder p env) body) mempty
+      -- quotedBody <- quote (level + 1) normBody
+      let newEnv = extendEnvWithBound binder env
+      substituteDB 0 (envSubst p level newEnv) value
 
-instance (Quote (VBinder strategy builtin, Body strategy builtin) (Expr Ix builtin)) => Quote (VBinder strategy builtin) (Binder Ix builtin) where
-  quote p level = traverse (quote p level)
+instance Quote (VBinder strategy builtin) (Binder Ix builtin) where
+  quote p level = fmap (quote p level)
 
-instance (Quote (VBinder strategy builtin, Body strategy builtin) (Expr Ix builtin)) => Quote (VArg strategy builtin) (Arg Ix builtin) where
-  quote p level = traverse (quote p level)
+instance Quote (VArg strategy builtin) (Arg Ix builtin) where
+  quote p level = fmap (quote p level)
 
-quoteApp :: (MonadCompile m, Quote (VBinder strategy builtin, Body strategy builtin) (Expr Ix builtin)) => Lv -> Provenance -> Expr Ix builtin -> Spine strategy builtin -> m (Expr Ix builtin)
-quoteApp l p fn spine = normAppList p fn <$> traverse (quote p l) spine
+quoteApp :: Lv -> Provenance -> Expr Ix builtin -> Spine strategy builtin -> Expr Ix builtin
+quoteApp l p fn spine = normAppList p fn (fmap (quote p l) spine)
 
-envSubst :: BoundCtx builtin -> Substitution (Expr Ix builtin)
-envSubst env i = case lookupIx env i of
-  Just v -> Right (binderValue v)
+envSubst :: Provenance -> Lv -> WHNFEnv builtin -> Substitution (Expr Ix builtin)
+envSubst p level env i = case lookupIx env i of
   Nothing ->
     developerError $
       "Mis-sized environment" <+> pretty (length env) <+> "when quoting variable" <+> pretty i
+  Just (_binder, value) -> case value of
+    Bound {} -> Left i
+    Defined v -> Right (quote p (level + 1) v)

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -108,7 +108,7 @@ typeCheckAbstractDef p ident defSort uncheckedType = do
   -- solve constraints beforehand in order to allow for normalisation,
   -- but really only need to have solved type-class constraints.
   logDebug MaxDetail $ prettyVerbose substCheckedType
-  gluedType <- glueNBE mempty substCheckedType
+  gluedType <- glueNBE emptyEnv substCheckedType
   updatedCheckedType <- restrictAbstractDefType defSort (ident, p) gluedType
   let updatedCheckedDecl = DefAbstract p ident defSort updatedCheckedType
 
@@ -146,7 +146,7 @@ typeCheckFunction p ident anns typ body = do
 
   if isProperty anns
     then do
-      gluedDeclType <- glueNBE mempty (typeOf substDecl)
+      gluedDeclType <- glueNBE emptyEnv (typeOf substDecl)
       restrictPropertyType (ident, p) gluedDeclType
       solveConstraints (Just substDecl)
       substAgainDecl <- substMetas substDecl

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -103,7 +103,7 @@ createSubInstance (ctx, origin) r t = do
   let p = provenanceOf ctx
   newCtx <- copyContext ctx
   let dbLevel = contextDBLevel ctx
-  newTypeClassExpr <- quote p dbLevel t
+  let newTypeClassExpr = quote p dbLevel t
   (meta, metaExpr) <- freshMetaIdAndExpr p newTypeClassExpr (boundContext ctx)
   let newConstraint = InstanceConstraint (Resolve origin meta r t)
   return (unnormalised metaExpr, WithContext newConstraint newCtx)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -171,9 +171,8 @@ solveLam info@(ctx, origin) (binder1, WHNFBody env1 body1) (binder2, WHNFBody en
 
   -- Evaluate the normalised bodies of the lambdas
   let lv = contextDBLevel ctx
-  let var = VBoundVar lv []
-  nbody1 <- eval defaultNBEOptions (extendEnv binder1 var env1) body1
-  nbody2 <- eval defaultNBEOptions (extendEnv binder2 var env2) body2
+  nbody1 <- eval defaultNBEOptions (extendEnvWithBound binder1 env1) body1
+  nbody2 <- eval defaultNBEOptions (extendEnvWithBound binder2 env2) body2
 
   -- Update the context.
   -- NOTE: that we have to unnormalise here indicates something is wrong.
@@ -234,7 +233,7 @@ solveFlexRigidWithRenaming ctx meta@(metaID, _) renaming solution = do
       then pruneMetaDependencies ctx meta solution
       else return solution
 
-  unnormSolution <- quote mempty (contextDBLevel ctx) prunedSolution
+  let unnormSolution = quote mempty (contextDBLevel ctx) prunedSolution
   let substSolution = substDBAll 0 (\v -> unIx v `IntMap.lookup` renaming) unnormSolution
   solveMeta metaID substSolution (boundContext ctx)
   return $ Success mempty

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -70,7 +70,7 @@ prependConstraint ::
   m (Decl Ix builtin)
 prependConstraint decl (WithContext (Resolve _origin meta relevance expr) ctx) = do
   let p = originalProvenance ctx
-  typeClass <- quote p 0 expr
+  let typeClass = quote p 0 expr
 
   substTypeClass <- substMetas typeClass
   logCompilerPass MaxDetail ("generalisation over" <+> prettyVerbose substTypeClass) $

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -102,6 +102,17 @@ instance MetaSubstitutable m builtin (WHNFValue builtin) where
 instance MetaSubstitutable m builtin (Body 'WHNF builtin) where
   subst s (WHNFBody env body) = WHNFBody <$> subst s env <*> subst s body
 
+{-
+instance MetaSubstitutable m builtin (Env 'WHNF builtin) where
+  subst s Env{..} = do
+    newEnvEntries <- subst s envEntries
+    return $ Env { envEntries = newEnvEntries, .. }
+-}
+instance MetaSubstitutable m builtin (EnvValue 'WHNF builtin) where
+  subst s = \case
+    Bound -> return Bound
+    Defined value -> Defined <$> subst s value
+
 instance MetaSubstitutable m builtin (GluedExpr builtin) where
   subst s (Glued a b) = Glued <$> subst s a <*> subst s b
 

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -390,7 +390,6 @@ solveMeta m solution solutionCtx = do
       <+> pretty m
       <+> "as"
       <+> prettyExternal (WithContext abstractedSolution solutionCtx)
-  -- "as" <+> prettyFriendly (WithContext abstractedSolution solutionCtx)
 
   metaSubst <- getMetaSubstitution (Proxy @builtin)
   case MetaMap.lookup m metaSubst of

--- a/vehicle/src/Vehicle/Data/Hashing.hs
+++ b/vehicle/src/Vehicle/Data/Hashing.hs
@@ -12,16 +12,14 @@ import Vehicle.Syntax.AST
 -- but this proved to be unnecessary. It's still in the repo's history if
 -- need be though.
 
+instance (Hashable builtin, Generic builtin) => Hashable (EnvValue 'WHNF builtin)
+
 instance (Hashable builtin, Generic builtin) => Hashable (Body 'WHNF builtin)
 
 instance (Hashable builtin, Generic builtin) => Hashable (WHNFValue builtin)
 
-instance (Hashable builtin, Generic builtin) => Hashable (WHNFBinder builtin)
+instance (Hashable expr) => Hashable (GenericArg expr)
 
-instance (Hashable builtin, Generic builtin) => Hashable (WHNFArg builtin)
-
-instance (Hashable builtin) => Hashable (Arg Ix builtin)
-
-instance (Hashable builtin) => Hashable (Binder Ix builtin)
+instance (Hashable expr) => Hashable (GenericBinder expr)
 
 instance (Hashable builtin) => Hashable (Expr Ix builtin)

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -69,7 +69,7 @@ normalisationTest NBETest {..} =
     normInput <-
       runFreshFreeContextT (Proxy @Builtin) $
         eval defaultNBEOptions (mkNoOpEnv dbLevel) input
-    actual <- quote mempty dbLevel normInput
+    let actual = quote mempty dbLevel normInput
 
     let errorMessage =
           layoutAsString $
@@ -94,4 +94,4 @@ binding :: Type Ix Builtin -> Binder Ix Builtin
 binding = Binder p (BinderDisplayForm (OnlyName "x") False) Explicit Relevant
 
 mkNoOpEnv :: Lv -> WHNFEnv builtin
-mkNoOpEnv boundCtxSize = [mkDefaultBinder "_" (VBoundVar i []) | i <- reverse [0 .. boundCtxSize - 1]]
+mkNoOpEnv boundCtxSize = [mkDefaultEnvEntry "_" Bound | _ <- [0 .. boundCtxSize - 1]]

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -196,6 +196,7 @@ library
     Vehicle.Backend.Queries.Error.Polarity.Core
     Vehicle.Backend.Queries.Error.Polarity.PolaritySolver
     Vehicle.Backend.Queries.Error.Polarity.Type
+    Vehicle.Backend.Queries.UsedFunctions
     Vehicle.Compile.Arity
     Vehicle.Compile.Context.Bound.Class
     Vehicle.Compile.Context.Bound.Core


### PR DESCRIPTION
See `NBE.lookupIxValueInEnv` for crucial details. We now track whether a variable in the environment is either still `Bound` or is now `Defined`. This allows us to calculate the correct level in the final context after normalisation, which should resolve the pernicious bugs I've been having with the tensor operations.