### PR TITLE
Implement blocking of vector operations using postulates

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST.hs
@@ -13,4 +13,5 @@ import Vehicle.Syntax.AST.Name as X
 import Vehicle.Syntax.AST.Prog as X
 import Vehicle.Syntax.AST.Provenance as X
 import Vehicle.Syntax.AST.Relevance as X
+import Vehicle.Syntax.AST.Type as X
 import Vehicle.Syntax.AST.Visibility as X

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
@@ -10,6 +10,7 @@ import GHC.Generics (Generic)
 import Vehicle.Syntax.AST.Name (HasName (..), Name)
 import Vehicle.Syntax.AST.Provenance (HasProvenance (..), Provenance)
 import Vehicle.Syntax.AST.Relevance (HasRelevance (..), Relevance (..))
+import Vehicle.Syntax.AST.Type
 import Vehicle.Syntax.AST.Visibility (HasVisibility (..), Visibility (..))
 
 --------------------------------------------------------------------------------
@@ -110,6 +111,9 @@ instance HasRelevance (GenericBinder expr) where
 
 instance HasName (GenericBinder expr) (Maybe Name) where
   nameOf = nameOf . binderNamingForm
+
+instance HasType (GenericBinder expr) expr where
+  typeOf = binderValue
 
 --------------------------------------------------------------------------------
 -- Binders

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -7,6 +7,7 @@ import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
 import Vehicle.Syntax.AST.Name
 import Vehicle.Syntax.AST.Provenance
+import Vehicle.Syntax.AST.Type
 
 --------------------------------------------------------------------------------
 -- Declarations
@@ -44,6 +45,11 @@ instance HasIdentifier (GenericDecl expr) where
 
 instance HasName (GenericDecl expr) Name where
   nameOf = nameOf . identifierOf
+
+instance HasType (GenericDecl expr) expr where
+  typeOf = \case
+    DefAbstract _ _ _ t -> t
+    DefFunction _ _ _ t _ -> t
 
 bodyOf :: GenericDecl expr -> Maybe expr
 bodyOf = \case
@@ -123,6 +129,10 @@ isExternalResourceSort = \case
   DatasetDef -> True
   ParameterDef {} -> True
   PostulateDef -> False
+
+convertToPostulate :: GenericDecl expr -> GenericDecl expr
+convertToPostulate d =
+  DefAbstract (provenanceOf d) (identifierOf d) PostulateDef (typeOf d)
 
 --------------------------------------------------------------------------------
 -- Annotations options

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Type.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Type.hs
@@ -1,0 +1,7 @@
+module Vehicle.Syntax.AST.Type where
+
+--------------------------------------------------------------------------------
+-- HasType
+
+class HasType expr typ | expr -> typ where
+  typeOf :: expr -> typ

--- a/vehicle-syntax/vehicle-syntax.cabal
+++ b/vehicle-syntax/vehicle-syntax.cabal
@@ -113,6 +113,7 @@ library
     Vehicle.Syntax.AST.Prog
     Vehicle.Syntax.AST.Provenance
     Vehicle.Syntax.AST.Relevance
+    Vehicle.Syntax.AST.Type
     Vehicle.Syntax.AST.Visibility
     Vehicle.Syntax.BNFC.Delaborate.External
     Vehicle.Syntax.BNFC.Delaborate.Internal

--- a/vehicle/src/Vehicle/Backend/Queries.hs
+++ b/vehicle/src/Vehicle/Backend/Queries.hs
@@ -127,7 +127,7 @@ compilePropertyDecl ::
   m (Name, MultiProperty ())
 compilePropertyDecl prog queryFormat networkCtx queryFreeCtx p ident expr outputLocation = do
   logCompilerPass MinDetail ("property" <+> quotePretty ident) $ do
-    normalisedExpr <- eval (mkNBEOptions vectorStructureOperations) emptyEnv expr
+    normalisedExpr <- whilePreservingOperations vectorOperations $ normaliseInEmptyEnv expr
 
     let computeProperty = compileMultiProperty queryFormat networkCtx queryFreeCtx p ident outputLocation normalisedExpr
 

--- a/vehicle/src/Vehicle/Compile/Context/Free/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Context/Free/Instance.hs
@@ -81,3 +81,7 @@ instance
     local updateCtx (unFreeContextT cont)
 
   getFreeCtx _ = FreeContextT ask
+
+  locallyAdjustCtx _ f x =
+    FreeContextT $
+      local f (unFreeContextT x)

--- a/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
@@ -3,26 +3,8 @@ module Vehicle.Compile.Prelude.Utils where
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Data.Maybe (mapMaybe)
-import Vehicle.Data.NormalisedExpr
 import Vehicle.Prelude
 import Vehicle.Syntax.AST
-
---------------------------------------------------------------------------------
--- HasType
-
-class HasType expr typ | expr -> typ where
-  typeOf :: expr -> typ
-
-instance HasType (Binder var builtin) (Type var builtin) where
-  typeOf = binderValue
-
-instance HasType (VBinder strategy builtin) (Value strategy builtin) where
-  typeOf = binderValue
-
-instance HasType (GenericDecl expr) expr where
-  typeOf = \case
-    DefAbstract _ _ _ t -> t
-    DefFunction _ _ _ t _ -> t
 
 --------------------------------------------------------------------------------
 -- Utility functions

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
@@ -11,7 +11,7 @@ import Data.Proxy (Proxy (..))
 import Prettyprinter (list)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Error.Message (MeaningfulError (..))
-import Vehicle.Compile.Normalise.NBE (defaultNBEOptions, eval)
+import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (PrintableBuiltin, prettyExternal, prettyFriendly)
 import Vehicle.Compile.Type (runUnificationSolver)
@@ -190,7 +190,7 @@ instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin)
     let initialCtx = goalCtxExtension ++ candidateCtx
     (candidateBody, candidateSol, newInstanceConstraints, finalCtx) <-
       go (candidateExpr, candidateSolution, [], initialCtx)
-    normCandidateBody <- eval defaultNBEOptions (boundContextToEnv finalCtx) candidateBody
+    normCandidateBody <- normaliseInEnv (boundContextToEnv finalCtx) candidateBody
     return (normCandidateBody, candidateSol, newInstanceConstraints)
   where
     go ::
@@ -210,7 +210,7 @@ instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin)
           Instance {} -> do
             let newInfo = (setConstraintBoundCtx constraintCtx boundCtx, constraintOrigin)
             -- WARNING massive hack should be traversing the normalised type here.
-            normBinderType <- eval defaultNBEOptions (boundContextToEnv boundCtx) binderType
+            normBinderType <- normaliseInEnv (boundContextToEnv boundCtx) binderType
             (expr, constraint) <- createSubInstance newInfo (relevanceOf exprBinder) normBinderType
             return (expr, [constraint])
         let exprBodyResult = newArg `substDBInto` exprBody

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -171,8 +171,8 @@ solveLam info@(ctx, origin) (binder1, WHNFBody env1 body1) (binder2, WHNFBody en
 
   -- Evaluate the normalised bodies of the lambdas
   let lv = contextDBLevel ctx
-  nbody1 <- eval defaultNBEOptions (extendEnvWithBound binder1 env1) body1
-  nbody2 <- eval defaultNBEOptions (extendEnvWithBound binder2 env2) body2
+  nbody1 <- normaliseInEnv (extendEnvWithBound binder1 env1) body1
+  nbody2 <- normaliseInEnv (extendEnvWithBound binder2 env2) body2
 
   -- Update the context.
   -- NOTE: that we have to unnormalise here indicates something is wrong.
@@ -265,7 +265,7 @@ pruneMetaDependencies ctx (solvingMetaID, solvingMetaSpine) attemptedSolution = 
         | otherwise -> do
             metaSubst <- getMetaSubstitution (Proxy @builtin)
             case MetaMap.lookup m metaSubst of
-              Just solution -> go =<< evalApp defaultNBEOptions (normalised solution) spine
+              Just solution -> go =<< normaliseApp (normalised solution) spine
               Nothing -> do
                 let (deps, _) = getNormMetaDependencies solvingMetaSpine
                 let (jDeps, _) = getNormMetaDependencies spine

--- a/vehicle/src/Vehicle/Compile/Type/Force.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Force.hs
@@ -57,7 +57,7 @@ forceExpr subst = go
     goMeta m spine = do
       case MetaMap.lookup m subst of
         Just solution -> do
-          normMetaExpr <- evalApp defaultNBEOptions (normalised solution) spine
+          normMetaExpr <- normaliseApp (normalised solution) spine
           (maybeForcedExpr, blockingMetas) <- go normMetaExpr
           let forcedExpr = maybe (Just normMetaExpr) Just maybeForcedExpr
           return (forcedExpr, blockingMetas)
@@ -91,5 +91,5 @@ forceBuiltin subst b spine = case getBuiltinFunction b of
       if not anyArgsReduced
         then return Nothing
         else do
-          Just <$> evalBuiltin (evalApp defaultNBEOptions) b argResults
+          Just <$> evalBuiltin normaliseApp b argResults
     return (result, blockingMetas)

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -86,13 +86,13 @@ instance MetaSubstitutable m builtin (WHNFValue builtin) where
           substValue <- subst s $ normalised value
           case args of
             [] -> return substValue
-            (a : as) -> evalApp defaultNBEOptions substValue (a : as)
+            (a : as) -> normaliseApp substValue (a : as)
     VUniverse {} -> return expr
     VFreeVar v spine -> VFreeVar v <$> traverse (subst s) spine
     VBoundVar v spine -> VBoundVar v <$> traverse (subst s) spine
     VBuiltin b spine -> do
       spine' <- traverse (subst s) spine
-      evalBuiltin (evalApp defaultNBEOptions) b spine'
+      evalBuiltin normaliseApp b spine'
 
     -- NOTE: no need to lift the substitutions here as we're passing under the binders
     -- because by construction every meta-variable solution is a closed term.

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -140,7 +140,7 @@ createFreshInstanceConstraint boundCtx (fun, funArgs, funType) relevance tcExpr 
   let originProvenance = provenanceOf tcExpr
   cid <- generateFreshConstraintID (Proxy @builtin)
   let context = ConstraintContext cid originProvenance p unknownBlockingStatus boundCtx
-  nTCExpr <- eval defaultNBEOptions env tcExpr
+  nTCExpr <- normaliseInEnv env tcExpr
   let constraint = WithContext (Resolve origin meta relevance nTCExpr) context
 
   addInstanceConstraints [constraint]

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -10,7 +10,7 @@ import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Context.Bound.Instance
 import Vehicle.Compile.Context.Free.Class (MonadFreeContext)
 import Vehicle.Compile.Error (MonadCompile, compilerDeveloperError)
-import Vehicle.Compile.Normalise.NBE (defaultNBEOptions, eval)
+import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyExternal, prettyFriendly, prettyVerbose)
 import Vehicle.Compile.Type.Core
@@ -509,8 +509,8 @@ createFreshUnificationConstraint ::
   m ()
 createFreshUnificationConstraint p ctx origin expectedType actualType = do
   let env = boundContextToEnv ctx
-  normExpectedType <- eval defaultNBEOptions env expectedType
-  normActualType <- eval defaultNBEOptions env actualType
+  normExpectedType <- normaliseInEnv env expectedType
+  normActualType <- normaliseInEnv env actualType
   cid <- generateFreshConstraintID (Proxy @builtin)
   let context = ConstraintContext cid p p unknownBlockingStatus ctx
   let unification = Unify origin normExpectedType normActualType
@@ -529,4 +529,4 @@ copyContext (ConstraintContext _cid originProv creationProv _blockingStatus ctx)
 --------------------------------------------------------------------------------
 
 glueNBE :: (MonadFreeContext builtin m) => WHNFEnv builtin -> Expr Ix builtin -> m (GluedExpr builtin)
-glueNBE env e = Glued e <$> eval defaultNBEOptions env e
+glueNBE env e = Glued e <$> normaliseInEnv env e

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
@@ -76,6 +76,7 @@ mapTypeCheckerT f m = TypeCheckerT (mapFreeContextT (mapReaderT (mapStateT f)) (
 instance (PrintableBuiltin builtin, NormalisableBuiltin builtin, MonadCompile m) => MonadFreeContext builtin (TypeCheckerT builtin m) where
   addDeclToContext decl = TypeCheckerT . addDeclToContext decl . unTypeCheckerT
   getFreeCtx = TypeCheckerT . getFreeCtx
+  locallyAdjustCtx p f = TypeCheckerT . locallyAdjustCtx p f . unTypeCheckerT
 
 instance (PrintableBuiltin builtin, NormalisableBuiltin builtin, MonadCompile m) => MonadTypeChecker builtin (TypeCheckerT builtin m) where
   getMetaState = TypeCheckerT get

--- a/vehicle/src/Vehicle/Prelude/Misc.hs
+++ b/vehicle/src/Vehicle/Prelude/Misc.hs
@@ -13,6 +13,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Set (Set)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
@@ -121,6 +122,9 @@ prependList :: [a] -> NonEmpty a -> NonEmpty a
 prependList ls ne = case ls of
   [] -> ne
   (x : xs) -> x :| xs <> NonEmpty.toList ne
+
+alterKeys :: (Ord k) => Set k -> (a -> a) -> Map k a -> Map k a
+alterKeys keys f xs = foldr (Map.alter (fmap f)) xs keys
 
 partialSort :: forall a. (a -> a -> Maybe Ordering) -> [a] -> [a]
 partialSort partialCompare xs = sortedNodes

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -7,7 +7,7 @@ import Data.Data (Proxy (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool)
 import Vehicle.Compile.Context.Free
-import Vehicle.Compile.Normalise.NBE (defaultNBEOptions, eval)
+import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyVerbose)
@@ -68,7 +68,7 @@ normalisationTest NBETest {..} =
   unitTestCase ("normalise" <> name) $ do
     normInput <-
       runFreshFreeContextT (Proxy @Builtin) $
-        eval defaultNBEOptions (mkNoOpEnv dbLevel) input
+        normaliseInEnv (mkNoOpEnv dbLevel) input
     let actual = quote mempty dbLevel normInput
 
     let errorMessage =


### PR DESCRIPTION
Instead of passing in a hacky list of blocking identifiers to NBE, instead all vector operations are now temporarily converted to postulates in the context. 

In place of the old options, we now pass to the NBE algorithm a method to actually interpret abstract free variables such as networks, datasets and postulates.