### PR TITLE
Create reproducers automatically when verifiers fail and improve error messages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,13 @@
 
 * More powerful index solver: `i` is now a valid index for vectors of size `n + 1 + i`.
 
+* Fixed compilation bugs when using network outputs as inputs to higher order functions.
+
+* More accurate error messages when the verifier is killed during verification.
+
+* If during verification the verifier throws an error, Vehicle will now create a reproducer
+  automatically.
+
 ## Version 0.11.1
 
 * Fixed bug properties involving the comparison of abstract `Index` values would throw

--- a/vehicle/src/Vehicle/Verify/Verifier.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier.hs
@@ -1,8 +1,11 @@
 module Vehicle.Verify.Verifier
   ( VerifierID (..),
     Verifier (..),
+    VerificationError (..),
+    VerificationErrorAction (..),
     verifiers,
     marabouVerifier,
+    convertVerificationError,
     VerifierExecutable,
   )
 where

--- a/vehicle/src/Vehicle/Verify/Verifier/Core.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier/Core.hs
@@ -1,14 +1,20 @@
+{-# LANGUAGE CPP #-}
+
 module Vehicle.Verify.Verifier.Core where
 
-import Control.Monad.IO.Class (MonadIO)
-import Data.Text (Text)
+import Control.Monad.Error.Class (MonadError (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Verify.Core
 import Vehicle.Verify.QueryFormat.Core
 import Vehicle.Verify.Variable
 
+# ifdef mingw32_HOST_OS
+# else
+import System.Posix.Signals
+# endif
+
 --------------------------------------------------------------------------------
--- Verifiers
+-- Verifier interface
 
 data VerifierID
   = Marabou
@@ -20,14 +26,13 @@ instance Pretty VerifierID where
 -- | Location of the verifier executable file
 type VerifierExecutable = FilePath
 
--- | The type of methods to call a verifier on a query
-type VerifierInvocation =
-  forall m.
-  (MonadLogger m, MonadIO m) =>
-  VerifierExecutable ->
-  MetaNetwork ->
-  QueryFile ->
-  m (Either Text (QueryResult NetworkVariableAssignment))
+-- | The type of methods that prepare the command line arguments for the verifier
+type PrepareVerifierArgs =
+  MetaNetwork -> QueryFile -> [String]
+
+-- | The type of methods that parse the output of the verifier.
+type ParseVerifierOutput =
+  forall m. (MonadError VerificationError m) => MetaNetwork -> String -> m (QueryResult NetworkVariableAssignment)
 
 -- | A complete verifier implementation
 data Verifier = Verifier
@@ -37,6 +42,100 @@ data Verifier = Verifier
     verifierQueryFormat :: QueryFormatID,
     -- | The name of the executable for the verifier
     verifierExecutableName :: String,
-    -- | The command to invoke the verifier
-    invokeVerifier :: VerifierInvocation
+    -- | Prepare the command line arguments for the verifier.
+    prepareArgs :: PrepareVerifierArgs,
+    -- | Parse the output of the verifier.
+    parseOutput :: ParseVerifierOutput,
+    -- | Does the verifier support multiple network applications?
+    supportsMultipleNetworkApplications :: Bool
   }
+
+data VerificationError
+  = UnsupportedMultipleNetworks MetaNetwork
+  | VerifierTerminatedByOS Int
+  | VerifierError String
+  | VerifierOutputMalformed (forall a. Doc a)
+
+--------------------------------------------------------------------------------
+-- Error messages
+
+data VerificationErrorAction = VerificationErrorAction
+  { reproducerIsUseful :: Bool,
+    verificationErrorMessage :: forall a. Doc a
+  }
+
+convertVerificationError :: Verifier -> QueryAddress -> VerificationError -> VerificationErrorAction
+convertVerificationError Verifier {..} (propertyAddress, queryID) = \case
+  UnsupportedMultipleNetworks metaNetwork ->
+    VerificationErrorAction
+      { reproducerIsUseful = False,
+        verificationErrorMessage = do
+          let networkNames = fmap metaNetworkEntryName (networkEntries metaNetwork)
+          let duplicateNetworkNames = findDuplicates networkNames
+          "Marabou currently doesn't support properties that involve"
+            <+> if null duplicateNetworkNames
+              then
+                "multiple networks. This property involves:"
+                  <> line
+                  <> indent 2 (vsep $ fmap (\n -> "the network" <+> squotes (pretty n)) networkNames)
+              else
+                "multiple applications of the same network. This property applies:"
+                  <> line
+                  <> indent 2 (vsep $ fmap (\(n, v) -> "the network" <+> squotes (pretty n) <+> pretty v <+> "times") duplicateNetworkNames)
+      }
+  VerifierError errorMessage ->
+    VerificationErrorAction
+      { reproducerIsUseful = True,
+        verificationErrorMessage = do
+          "while verifying query"
+            <+> quotePretty queryID
+            <+> "of property"
+            <+> quotePretty propertyAddress
+            <+> "the"
+            <+> pretty verifierIdentifier
+            <+> "verifier threw the error:"
+            <> line
+            <> line
+            <> indent 2 (pretty errorMessage)
+      }
+  VerifierTerminatedByOS signal ->
+    exitFailureReason verifierIdentifier signal
+  VerifierOutputMalformed message ->
+    VerificationErrorAction
+      { reproducerIsUseful = False,
+        verificationErrorMessage = "Unexpected output from Marabou..." <+> message
+      }
+
+exitFailureReason :: VerifierID -> Int -> VerificationErrorAction
+# ifdef mingw32_HOST_OS
+exitFailureReason verifierID exitValue = VerificationErrorAction
+    { reproducerIsUseful = True
+    , verificationErrorMessage = basicExitFailureMessage verifierID exitValue <+>
+        "Vehicle is unable to interpret this error code on Windows but the most common reasons" <+>
+        "are Marabou either ran out of memory or performed an illegal instruction."
+    }
+# else
+exitFailureReason verifierID exitValue
+  | toEnum exitValue == illegalInstruction = VerificationErrorAction
+    { reproducerIsUseful = True
+    , verificationErrorMessage = basicExitFailureMessage verifierID exitValue <+>
+        "This is an `Illegal Instruction` error and indicates a bug in Marabou itself"
+    }
+  | toEnum exitValue == killProcess = VerificationErrorAction
+    { reproducerIsUseful = True
+    , verificationErrorMessage = basicExitFailureMessage verifierID exitValue <+>
+        "This is often (but not always) a result of Marabou running out of memory."
+    }
+  | otherwise = VerificationErrorAction
+    { reproducerIsUseful = True
+    , verificationErrorMessage = basicExitFailureMessage verifierID exitValue <+>
+        "Please consult the manual on Unix signals to work out what this means."
+    }
+# endif
+
+basicExitFailureMessage :: VerifierID -> Int -> Doc a
+basicExitFailureMessage verifierID exitValue =
+  pretty verifierID
+    <+> "was killed with the signal"
+    <+> quotePretty exitValue
+    <> "."

--- a/vehicle/src/Vehicle/Verify/Verifier/Marabou.hs
+++ b/vehicle/src/Vehicle/Verify/Verifier/Marabou.hs
@@ -3,16 +3,12 @@ module Vehicle.Verify.Verifier.Marabou
   )
 where
 
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Except (MonadError (..))
 import Data.List (elemIndex, findIndex)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text (pack, splitOn, strip)
-import Data.Text.IO (hPutStrLn)
-import System.Exit (ExitCode (..), exitFailure)
-import System.IO (stderr)
-import System.Process (readProcessWithExitCode)
 import Vehicle.Compile.Prelude
 import Vehicle.Verify.Core
 import Vehicle.Verify.QueryFormat.Core
@@ -28,94 +24,37 @@ marabouVerifier =
   Verifier
     { verifierIdentifier = Marabou,
       verifierExecutableName = "Marabou",
-      invokeVerifier = invokeMarabou,
-      verifierQueryFormat = MarabouQueries
+      verifierQueryFormat = MarabouQueries,
+      prepareArgs = prepareMarabouArgs,
+      parseOutput = parseMarabouOutput,
+      -- Marabou seems to output its error messages to stdout rather than stderr...
+      -- https://github.com/NeuralNetworkVerification/Marabou/issues/714
+      supportsMultipleNetworkApplications = False
     }
 
---------------------------------------------------------------------------------
--- Invoking Marabou
+prepareMarabouArgs :: PrepareVerifierArgs
+prepareMarabouArgs metaNetwork queryFile = case networkEntries metaNetwork of
+  [MetaNetworkEntry {..}] -> [networkFilepath metaNetworkEntryInfo, queryFile]
+  _ -> developerError "Should have caught unsupported multiple network applications earlier"
 
-invokeMarabou :: VerifierInvocation
-invokeMarabou marabouExecutable metaNetwork queryFile = do
-  -- Prepare arguments
-  networkArg <- prepareNetworkArg (networkEntries metaNetwork)
-  let args = [networkArg, queryFile]
-  let command = unwords (marabouExecutable : args)
+parseMarabouOutput :: ParseVerifierOutput
+parseMarabouOutput metaNetwork out = do
+  let outputLines = fmap Text.pack (lines out)
+  let resultIndex = findIndex (\v -> v == "sat" || v == "unsat") outputLines
+  case resultIndex of
+    Nothing -> throwError $ VerifierOutputMalformed "cannot find 'sat' or 'unsat'"
+    Just i
+      | outputLines !! i == "unsat" -> return $ UnSAT
+      | otherwise -> do
+          let assignmentOutput = drop (i + 1) outputLines
+          ioVarAssignment <- parseSATAssignment metaNetwork (filter (/= "") assignmentOutput)
+          return $ SAT $ Just ioVarAssignment
 
-  -- Run command
-  logDebug MaxDetail $ "Running verify command: " <> pretty command
-  (exitCode, out, err) <- liftIO $ readProcessWithExitCode marabouExecutable args ""
-
-  -- Parse result
-  logDebug MaxDetail $ "Output of verify command: " <> line <> indent 2 (pretty out)
-  parseMarabouOutput metaNetwork command (exitCode, out, err)
-
-prepareNetworkArg :: (MonadIO m) => [MetaNetworkEntry] -> m String
-prepareNetworkArg [MetaNetworkEntry {..}] = return (networkFilepath metaNetworkEntryInfo)
-prepareNetworkArg metaNetwork = do
-  let duplicateNetworkNames = findDuplicates (fmap metaNetworkEntryName metaNetwork)
-
-  let errorMsg =
-        "Error: Marabou currently doesn't support properties that involve"
-          <+> if null duplicateNetworkNames
-            then
-              "multiple networks. This property involves:"
-                <> line
-                <> indent 2 (vsep $ fmap (\e -> "the network" <+> squotes (pretty $ metaNetworkEntryName e)) metaNetwork)
-            else
-              "multiple applications of the same network. This property applies:"
-                <> line
-                <> indent 2 (vsep $ fmap (\(n, v) -> "the network" <+> squotes (pretty n) <+> pretty v <+> "times") duplicateNetworkNames)
-
-  liftIO $ do
-    hPutStrLn stderr $ layoutAsText errorMsg
-    exitFailure
-
-parseMarabouOutput ::
-  (MonadIO m) =>
+parseSATAssignment ::
+  (MonadError VerificationError m) =>
   MetaNetwork ->
-  String ->
-  (ExitCode, String, String) ->
-  m (Either Text (QueryResult NetworkVariableAssignment))
-parseMarabouOutput metaNetwork command (exitCode, out, _err) = case exitCode of
-  ExitFailure exitValue
-    | exitValue < 0 -> do
-        -- Marabou was killed by the system.
-        -- See System.Process.html#waitForProcess documentation
-        let errorDoc =
-              "Marabou was automatically killed by the OS with signal"
-                <+> quotePretty (-exitValue)
-                <> "."
-                <> line
-                <> "The most common reason for this is an out-of-memory-error."
-        return $ Left $ layoutAsText errorDoc
-    | otherwise -> do
-        -- Marabou seems to output its error messages to stdout rather than stderr...
-        let errorDoc =
-              "Marabou threw the following error:"
-                <> line
-                <> indent 2 (pretty out)
-                <> line
-                <> "when running the command:"
-                <> line
-                <> indent 2 (pretty command)
-        liftIO $ do
-          hPutStrLn stderr (layoutAsText errorDoc)
-          exitFailure
-  ExitSuccess -> do
-    let outputLines = fmap Text.pack (lines out)
-    let resultIndex = findIndex (\v -> v == "sat" || v == "unsat") outputLines
-    case resultIndex of
-      Nothing -> malformedOutwriteStderror "cannot find 'sat' or 'unsat'"
-      Just i
-        | outputLines !! i == "unsat" ->
-            return $ Right UnSAT
-        | otherwise -> do
-            let assignmentOutput = drop (i + 1) outputLines
-            ioVarAssignment <- parseSATAssignment metaNetwork (filter (/= "") assignmentOutput)
-            return $ Right $ SAT $ Just ioVarAssignment
-
-parseSATAssignment :: (MonadIO m) => MetaNetwork -> [Text] -> m NetworkVariableAssignment
+  [Text] ->
+  m NetworkVariableAssignment
 parseSATAssignment metaNetwork output = do
   let variableMap = Map.fromList $ fmap (\var -> (layoutAsText $ compileVar var, var)) (variables metaNetwork)
   let mInputIndex = elemIndex "Input assignment:" output
@@ -124,27 +63,20 @@ parseSATAssignment metaNetwork output = do
     (Just inputIndex, Just outputIndex) -> do
       let inputVarLines = take (outputIndex - inputIndex - 1) $ drop (inputIndex + 1) output
       let outputVarLines = drop (outputIndex + 1) output
-      let values = parseSATAssignmentLine variableMap <$> (inputVarLines <> outputVarLines)
+      values <- traverse (parseSATAssignmentLine variableMap) (inputVarLines <> outputVarLines)
       return $ NetworkVariableAssignment $ Map.fromList values
-    _ -> malformedOutwriteStderror "could not find strings 'Input assignment:' and 'Output:'"
+    _ -> throwError $ VerifierOutputMalformed "could not find strings 'Input assignment:' and 'Output:'"
 
 parseSATAssignmentLine ::
+  (MonadError VerificationError m) =>
   Map Text NetworkRationalVariable ->
   Text ->
-  (NetworkRationalVariable, Rational)
-parseSATAssignmentLine varsByName txt =
+  m (NetworkRationalVariable, Rational)
+parseSATAssignmentLine varsByName txt = do
   let parts = Text.strip <$> Text.splitOn "=" txt
-   in case parts of
-        [namePart, valuePart] -> do
-          let var = case Map.lookup namePart varsByName of
-                Just v -> v
-                Nothing -> malformedOutwriteStderror $ "could not parse variable" <+> quotePretty namePart
-          let value = readFloatAsRational valuePart
-          (var, value)
-        _ ->
-          malformedOutwriteStderror $
-            "could not split assignment line" <+> quotePretty txt <+> "on '=' sign"
-
-malformedOutwriteStderror :: Doc a -> b
-malformedOutwriteStderror x =
-  error $ layoutAsString ("Unexpected output from Marabou..." <+> x)
+  case parts of
+    [namePart, valuePart] -> do
+      case Map.lookup namePart varsByName of
+        Just var -> return (var, readFloatAsRational valuePart)
+        Nothing -> throwError $ VerifierOutputMalformed $ "could not parse variable" <+> quotePretty namePart
+    _ -> throwError $ VerifierOutputMalformed $ "could not split assignment line" <+> quotePretty txt <+> "on '=' sign"

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
@@ -3,7 +3,6 @@ module Vehicle.Test.Unit.Compile.CommandLine
   )
 where
 
-import Control.Concurrent (threadDelay)
 import Data.Map qualified as Map (fromList)
 import Options.Applicative (ParserResult (..), defaultPrefs, execParserPure)
 import Test.Tasty (TestTree, testGroup)
@@ -187,8 +186,6 @@ parserTest name command expected = testCase name $ do
         (_ : as) -> as
         _ -> developerError "Malformed command. Commands must start with 'vehicle'"
   let result = execParserPure defaultPrefs commandLineOptionsParserInfo args
-
-  threadDelay 10000000
 
   case result of
     Failure failure -> assertFailure (show failure)

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -287,12 +287,14 @@ library
     , optparse-applicative   >=0.16     && <1
     , prettyprinter          >=1.7      && <2
     , process                >=1.6.13   && <1.7
+    , random                 >=1.2
     , split                  >=0.2.3    && <0.3
     , sscript                >=0.1.0.2  && <1
     , temporary              >=1.3      && <1.4
     , terminal-progress-bar  >=0.4.1    && <1
     , text                   >=1.2      && <3
     , transformers           >=0.4      && <0.7
+    , unix                   >=2.7
     , unordered-containers   >=0.2.19   && <0.3
     , vector                 >=0.12.3   && <0.14
     , vehicle-syntax

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -299,6 +299,7 @@ library
     , vehicle-syntax
 
   if (os(linux) || os(osx))
+    -- For Verifier exit code analysis
     build-depends: unix >=2.7
 
 executable vehicle

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -294,10 +294,12 @@ library
     , terminal-progress-bar  >=0.4.1    && <1
     , text                   >=1.2      && <3
     , transformers           >=0.4      && <0.7
-    , unix                   >=2.7
     , unordered-containers   >=0.2.19   && <0.3
     , vector                 >=0.12.3   && <0.14
     , vehicle-syntax
+
+  if (os(linux) || os(osx))
+    build-depends: unix >=2.7
 
 executable vehicle
   import:         common-library


### PR DESCRIPTION
Required some OS dependent pragmas to parse the `ExitFailure` code...