### PR TITLE
Refactored normalisation of builtins

### DIFF
--- a/vehicle/src/Vehicle/Compile/Normalise/Builtin.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Builtin.hs
@@ -26,7 +26,7 @@ where
 
 import Control.Monad (zipWithM)
 import Data.Foldable (foldrM)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Data.BuiltinInterface
@@ -56,16 +56,11 @@ evalBuiltin ::
   m (WHNFValue builtin)
 evalBuiltin evalApp b args = do
   let runtimeRelevantArgs = filterRuntimeRelevantArgs args
-  case tryToEvaluateOnRuntimeRelevantArgs evalApp b runtimeRelevantArgs of
-    Just result -> result
-    _ -> return $ VBuiltin b args
+  let originalExpr = VBuiltin b args
+  case getBuiltinFunction b of
+    Just f -> evalBuiltinFunction f evalApp originalExpr runtimeRelevantArgs
+    _ -> return originalExpr
 
------------------------------------------------------------------------------
--- Runtime relevance
-{-
-isRuntimeRelevant :: WHNFArg builtin -> Bool
-isRuntimeRelevant = isExplicit
--}
 filterRuntimeRelevantArgs :: WHNFSpine builtin -> [WHNFValue builtin]
 filterRuntimeRelevantArgs = mapMaybe getExplicitArg
 
@@ -88,167 +83,69 @@ type EvalApp builtin m =
 -- functions such as fold, map etc.
 type EvalBuiltin builtin m =
   (MonadCompile m, PrintableBuiltin builtin, HasStandardData builtin) =>
+  EvalApp builtin m ->
+  WHNFValue builtin ->
   [WHNFValue builtin] ->
-  Maybe (m (WHNFValue builtin))
+  m (WHNFValue builtin)
 
 type EvalSimpleBuiltin builtin =
   forall strategy.
   (HasStandardData builtin) =>
+  Value strategy builtin ->
   [Value strategy builtin] ->
-  Maybe (Value strategy builtin)
+  Value strategy builtin
 
-tryToEvaluateOnRuntimeRelevantArgs ::
-  (MonadCompile m, HasStandardData builtin, PrintableBuiltin builtin) =>
-  EvalApp builtin m ->
-  builtin ->
-  [WHNFValue builtin] ->
-  Maybe (m (WHNFValue builtin))
-tryToEvaluateOnRuntimeRelevantArgs evalApp b runtimeRelevantArgs =
-  case getBuiltinFunction b of
-    Just f -> evalBuiltinFunction evalApp f runtimeRelevantArgs
-    Nothing -> Nothing
+evalBuiltinFunction :: BuiltinFunction -> EvalBuiltin builtin m
+evalBuiltinFunction b evalApp originalValue args = case b of
+  Quantifier {} -> return originalValue
+  Optimise {} -> return originalValue
+  Not -> return $ evalNot originalValue args
+  And -> return $ evalAnd originalValue args
+  Or -> return $ evalOr originalValue args
+  Neg dom -> return $ evalNeg dom originalValue args
+  Add dom -> return $ evalAdd dom originalValue args
+  Sub dom -> return $ evalSub dom originalValue args
+  Mul dom -> return $ evalMul dom originalValue args
+  Div dom -> return $ evalDiv dom originalValue args
+  PowRat -> return $ evalPowRat originalValue args
+  MinRat -> return $ evalMinRat originalValue args
+  MaxRat -> return $ evalMaxRat originalValue args
+  Equals dom op -> return $ evalEquals dom op originalValue args
+  Order dom op -> return $ evalOrder dom op originalValue args
+  If -> return $ evalIf originalValue args
+  At -> return $ evalAt originalValue args
+  FoldVector -> evalFoldVector evalApp originalValue args
+  FoldList -> evalFoldList evalApp originalValue args
+  ZipWithVector -> evalZipWith evalApp originalValue args
+  MapList -> evalMapList evalApp originalValue args
+  MapVector -> evalMapVector evalApp originalValue args
+  FromNat dom -> return $ evalFromNat dom originalValue args
+  FromRat dom -> return $ evalFromRat dom originalValue args
+  Indices -> return $ evalIndices originalValue args
+  Implies -> return $ evalImplies originalValue args
 
-evalBuiltinFunction ::
-  (MonadCompile m, PrintableBuiltin builtin, HasStandardData builtin) =>
-  EvalApp builtin m ->
-  BuiltinFunction ->
-  [WHNFValue builtin] ->
-  Maybe (m (WHNFValue builtin))
-evalBuiltinFunction evalApp b args = case b of
-  Quantifier {} -> Nothing
-  Optimise {} -> Nothing
-  Not -> return <$> evalNot args
-  And -> return <$> evalAnd args
-  Or -> return <$> evalOr args
-  Neg dom -> return <$> evalNeg dom args
-  Add dom -> return <$> evalAdd dom args
-  Sub dom -> return <$> evalSub dom args
-  Mul dom -> return <$> evalMul dom args
-  Div dom -> return <$> evalDiv dom args
-  PowRat -> return <$> evalPowRat args
-  MinRat -> return <$> evalMinRat args
-  MaxRat -> return <$> evalMaxRat args
-  Equals dom op -> return <$> evalEquals dom op args
-  Order dom op -> return <$> evalOrder dom op args
-  If -> return <$> evalIf args
-  At -> return <$> evalAt args
-  FoldVector -> evalFoldVector evalApp args
-  FoldList -> evalFoldList evalApp args
-  ZipWithVector -> evalZipWith evalApp args
-  MapList -> evalMapList evalApp args
-  MapVector -> evalMapVector evalApp args
-  FromNat dom -> return <$> evalFromNat dom args
-  FromRat dom -> return <$> evalFromRat dom args
-  Indices -> return <$> evalIndices args
-  Implies -> return <$> evalImplies args
-
------------------------------------------------------------------------------
--- Blocking
------------------------------------------------------------------------------
-{-
--- | Indices into the the list of runtime-relevant arguments, indicating which
--- arguments are blocking the evaluation of the builtin.
--- Numbering starts from 0 at the front the list.
--- NOTE: a difference list would better preserve the invariant that this should
--- always be monotonically ascending.
-type BlockingArgs = [Int]
-
-traverseBuiltinBlockingArgs ::
-  (MonadCompile m, PrintableBuiltin builtin, HasStandardData builtin) =>
-  (WHNFValue builtin -> m (WHNFValue builtin)) ->
-  builtin ->
-  WHNFSpine builtin ->
-  m (WHNFSpine builtin)
-traverseBuiltinBlockingArgs f b args = case getBuiltinFunction b of
-  Just func -> traverseBuiltinFunctionBlockingArgs f func args
-  Nothing -> return args
-
-traverseBuiltinFunctionBlockingArgs ::
-  (MonadCompile m, PrintableBuiltin builtin, HasStandardData builtin) =>
-  (WHNFValue builtin -> m (WHNFValue builtin)) ->
-  BuiltinFunction ->
-  WHNFSpine builtin ->
-  m (WHNFSpine builtin)
-traverseBuiltinFunctionBlockingArgs f b args =
-  traverseBlockingArgs f b args $ case b of
-    Quantifier {} -> []
-    Optimise {} -> []
-    Not -> [0]
-    And -> [0, 1]
-    Or -> [0, 1]
-    Neg {} -> [0]
-    Add {} -> [0, 1]
-    Sub {} -> [0, 1]
-    Mul {} -> [0, 1]
-    Div {} -> [0, 1]
-    PowRat -> [0, 1]
-    MinRat -> [0, 1]
-    MaxRat -> [0, 1]
-    Equals {} -> [0, 1]
-    Order {} -> [0, 1]
-    If -> [0]
-    At -> [0, 1]
-    Fold {} -> [2]
-    ZipWithVector -> [1, 2]
-    MapList -> [1]
-    MapVector -> [1]
-    FromNat {} -> [0]
-    FromRat {} -> [0]
-    Indices -> [0]
-    Implies -> [0, 1]
-    Ann -> []
-
-traverseBlockingArgs ::
-  forall m builtin.
-  (MonadCompile m, PrintableBuiltin builtin) =>
-  (WHNFValue builtin -> m (WHNFValue builtin)) ->
-  BuiltinFunction ->
-  WHNFSpine builtin ->
-  BlockingArgs ->
-  m (WHNFSpine builtin)
-traverseBlockingArgs f b originalSpine originalBlockingArgs = go 0 originalSpine originalBlockingArgs
-  where
-    go ::
-      Int ->
-      WHNFSpine builtin ->
-      BlockingArgs ->
-      m (WHNFSpine builtin)
-    go _ spine [] = return spine
-    go _ [] _ =
-      compilerDeveloperError $
-        "run out of args when traversing blocked arguments"
-          <+> pretty originalBlockingArgs
-          <+> "in spine"
-          <+> prettyVerbose originalSpine
-          <+> "for"
-          <+> quotePretty b
-    go argNo (arg : args) (blockedArg : blockedArgs)
-      | isRuntimeRelevant arg && argNo == blockedArg = (:) <$> traverse f arg <*> go (argNo + 1) args blockedArgs
-      | isRuntimeRelevant arg = (arg :) <$> go (argNo + 1) args (blockedArg : blockedArgs)
-      | otherwise = (arg :) <$> go argNo args (blockedArg : blockedArgs)
--}
 -----------------------------------------------------------------------------
 -- Individual builtin evaluation
 -----------------------------------------------------------------------------
 
 evalNot :: EvalSimpleBuiltin builtin
-evalNot e = case e of
-  [VBoolLiteral x] -> Just $ VBoolLiteral (not x)
-  _ -> Nothing
+evalNot originalExpr = \case
+  [VBoolLiteral x] -> VBoolLiteral (not x)
+  _ -> originalExpr
 
 evalAnd :: EvalSimpleBuiltin builtin
-evalAnd = \case
-  [VBoolLiteral x, VBoolLiteral y] -> Just $ VBoolLiteral (x && y)
-  [VBoolLiteral b, y] -> Just $ if b then y else VBoolLiteral b
-  [x, VBoolLiteral b] -> Just $ if b then x else VBoolLiteral b
-  _ -> Nothing
+evalAnd originalExpr = \case
+  [VBoolLiteral x, VBoolLiteral y] -> VBoolLiteral (x && y)
+  [VBoolLiteral b, y] -> if b then y else VBoolLiteral b
+  [x, VBoolLiteral b] -> if b then x else VBoolLiteral b
+  _ -> originalExpr
 
 evalOr :: EvalSimpleBuiltin builtin
-evalOr = \case
-  [VBoolLiteral x, VBoolLiteral y] -> Just $ VBoolLiteral (x || y)
-  [VBoolLiteral b, y] -> Just $ if b then VBoolLiteral b else y
-  [x, VBoolLiteral b] -> Just $ if b then VBoolLiteral b else x
-  _ -> Nothing
+evalOr originalExpr = \case
+  [VBoolLiteral x, VBoolLiteral y] -> VBoolLiteral (x || y)
+  [VBoolLiteral b, y] -> if b then VBoolLiteral b else y
+  [x, VBoolLiteral b] -> if b then VBoolLiteral b else x
+  _ -> originalExpr
 
 evalNeg :: NegDomain -> EvalSimpleBuiltin builtin
 evalNeg = \case
@@ -256,14 +153,14 @@ evalNeg = \case
   NegRat -> evalNegRat
 
 evalNegInt :: EvalSimpleBuiltin builtin
-evalNegInt = \case
-  [VIntLiteral x] -> Just $ VIntLiteral (-x)
-  _ -> Nothing
+evalNegInt originalExpr = \case
+  [VIntLiteral x] -> VIntLiteral (-x)
+  _ -> originalExpr
 
 evalNegRat :: EvalSimpleBuiltin builtin
-evalNegRat = \case
-  [VRatLiteral x] -> Just $ VRatLiteral (-x)
-  _ -> Nothing
+evalNegRat originalExpr = \case
+  [VRatLiteral x] -> VRatLiteral (-x)
+  _ -> originalExpr
 
 evalAdd :: AddDomain -> EvalSimpleBuiltin builtin
 evalAdd = \case
@@ -272,19 +169,19 @@ evalAdd = \case
   AddRat -> evalAddRat
 
 evalAddNat :: EvalSimpleBuiltin builtin
-evalAddNat = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VNatLiteral (x + y)
-  _ -> Nothing
+evalAddNat originalExpr = \case
+  [VNatLiteral x, VNatLiteral y] -> VNatLiteral (x + y)
+  _ -> originalExpr
 
 evalAddInt :: EvalSimpleBuiltin builtin
-evalAddInt = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x + y)
-  _ -> Nothing
+evalAddInt originalExpr = \case
+  [VIntLiteral x, VIntLiteral y] -> VIntLiteral (x + y)
+  _ -> originalExpr
 
 evalAddRat :: EvalSimpleBuiltin builtin
-evalAddRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x + y)
-  _ -> Nothing
+evalAddRat originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VRatLiteral (x + y)
+  _ -> originalExpr
 
 evalSub :: SubDomain -> EvalSimpleBuiltin builtin
 evalSub = \case
@@ -292,14 +189,14 @@ evalSub = \case
   SubRat -> evalSubRat
 
 evalSubInt :: EvalSimpleBuiltin builtin
-evalSubInt = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x - y)
-  _ -> Nothing
+evalSubInt originalExpr = \case
+  [VIntLiteral x, VIntLiteral y] -> VIntLiteral (x - y)
+  _ -> originalExpr
 
 evalSubRat :: EvalSimpleBuiltin builtin
-evalSubRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x - y)
-  _ -> Nothing
+evalSubRat originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VRatLiteral (x - y)
+  _ -> originalExpr
 
 evalMul :: MulDomain -> EvalSimpleBuiltin builtin
 evalMul = \case
@@ -308,43 +205,43 @@ evalMul = \case
   MulRat -> evalMulRat
 
 evalMulNat :: EvalSimpleBuiltin builtin
-evalMulNat = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VNatLiteral (x * y)
-  _ -> Nothing
+evalMulNat originalExpr = \case
+  [VNatLiteral x, VNatLiteral y] -> VNatLiteral (x * y)
+  _ -> originalExpr
 
 evalMulInt :: EvalSimpleBuiltin builtin
-evalMulInt = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VIntLiteral (x * y)
-  _ -> Nothing
+evalMulInt originalExpr = \case
+  [VIntLiteral x, VIntLiteral y] -> VIntLiteral (x * y)
+  _ -> originalExpr
 
 evalMulRat :: EvalSimpleBuiltin builtin
-evalMulRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x * y)
-  _ -> Nothing
+evalMulRat originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VRatLiteral (x * y)
+  _ -> originalExpr
 
 evalDiv :: DivDomain -> EvalSimpleBuiltin builtin
 evalDiv = \case
   DivRat -> evalDivRat
 
 evalDivRat :: EvalSimpleBuiltin builtin
-evalDivRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (x / y)
-  _ -> Nothing
+evalDivRat originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VRatLiteral (x / y)
+  _ -> originalExpr
 
 evalPowRat :: EvalSimpleBuiltin builtin
-evalPowRat = \case
-  [VRatLiteral x, VIntLiteral y] -> Just $ VRatLiteral (x ^^ y)
-  _ -> Nothing
+evalPowRat originalExpr = \case
+  [VRatLiteral x, VIntLiteral y] -> VRatLiteral (x ^^ y)
+  _ -> originalExpr
 
 evalMinRat :: EvalSimpleBuiltin builtin
-evalMinRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (min x y)
-  _ -> Nothing
+evalMinRat originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VRatLiteral (min x y)
+  _ -> originalExpr
 
 evalMaxRat :: EvalSimpleBuiltin builtin
-evalMaxRat = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VRatLiteral (max x y)
-  _ -> Nothing
+evalMaxRat originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VRatLiteral (max x y)
+  _ -> originalExpr
 
 evalOrder :: OrderDomain -> OrderOp -> EvalSimpleBuiltin builtin
 evalOrder = \case
@@ -354,24 +251,24 @@ evalOrder = \case
   OrderRat -> evalOrderRat
 
 evalOrderIndex :: OrderOp -> EvalSimpleBuiltin builtin
-evalOrderIndex op = \case
-  [VIndexLiteral x, VIndexLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
+evalOrderIndex op originalExpr = \case
+  [VIndexLiteral x, VIndexLiteral y] -> VBoolLiteral (orderOp op x y)
+  _ -> originalExpr
 
 evalOrderNat :: OrderOp -> EvalSimpleBuiltin builtin
-evalOrderNat op = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
+evalOrderNat op originalExpr = \case
+  [VNatLiteral x, VNatLiteral y] -> VBoolLiteral (orderOp op x y)
+  _ -> originalExpr
 
 evalOrderInt :: OrderOp -> EvalSimpleBuiltin builtin
-evalOrderInt op = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
+evalOrderInt op originalExpr = \case
+  [VIntLiteral x, VIntLiteral y] -> VBoolLiteral (orderOp op x y)
+  _ -> originalExpr
 
 evalOrderRat :: OrderOp -> EvalSimpleBuiltin builtin
-evalOrderRat op = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VBoolLiteral (orderOp op x y)
-  _ -> Nothing
+evalOrderRat op originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VBoolLiteral (orderOp op x y)
+  _ -> originalExpr
 
 evalEquals :: EqualityDomain -> EqualityOp -> EvalSimpleBuiltin builtin
 evalEquals = \case
@@ -381,24 +278,24 @@ evalEquals = \case
   EqRat -> evalEqualityRat
 
 evalEqualityIndex :: EqualityOp -> EvalSimpleBuiltin builtin
-evalEqualityIndex op = \case
-  [VIndexLiteral x, VIndexLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
+evalEqualityIndex op originalExpr = \case
+  [VIndexLiteral x, VIndexLiteral y] -> VBoolLiteral (equalityOp op x y)
+  _ -> originalExpr
 
 evalEqualityNat :: EqualityOp -> EvalSimpleBuiltin builtin
-evalEqualityNat op = \case
-  [VNatLiteral x, VNatLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
+evalEqualityNat op originalExpr = \case
+  [VNatLiteral x, VNatLiteral y] -> VBoolLiteral (equalityOp op x y)
+  _ -> originalExpr
 
 evalEqualityInt :: EqualityOp -> EvalSimpleBuiltin builtin
-evalEqualityInt op = \case
-  [VIntLiteral x, VIntLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
+evalEqualityInt op originalExpr = \case
+  [VIntLiteral x, VIntLiteral y] -> VBoolLiteral (equalityOp op x y)
+  _ -> originalExpr
 
 evalEqualityRat :: EqualityOp -> EvalSimpleBuiltin builtin
-evalEqualityRat op = \case
-  [VRatLiteral x, VRatLiteral y] -> Just $ VBoolLiteral (equalityOp op x y)
-  _ -> Nothing
+evalEqualityRat op originalExpr = \case
+  [VRatLiteral x, VRatLiteral y] -> VBoolLiteral (equalityOp op x y)
+  _ -> originalExpr
 
 evalFromNat :: FromNatDomain -> EvalSimpleBuiltin builtin
 evalFromNat = \case
@@ -408,67 +305,59 @@ evalFromNat = \case
   FromNatToRat -> evalFromNatToRat
 
 evalFromNatToIndex :: EvalSimpleBuiltin builtin
-evalFromNatToIndex = \case
-  [VNatLiteral x] -> Just $ VIndexLiteral x
-  _ -> Nothing
+evalFromNatToIndex originalExpr = \case
+  [VNatLiteral x] -> VIndexLiteral x
+  _ -> originalExpr
 
 evalFromNatToNat :: EvalSimpleBuiltin builtin
-evalFromNatToNat = \case
-  [x] -> Just x
-  _ -> Nothing
+evalFromNatToNat originalExpr = \case
+  [x] -> x
+  _ -> originalExpr
 
 evalFromNatToInt :: EvalSimpleBuiltin builtin
-evalFromNatToInt = \case
-  [VNatLiteral x] -> Just $ VIntLiteral x
-  _ -> Nothing
+evalFromNatToInt originalExpr = \case
+  [VNatLiteral x] -> VIntLiteral x
+  _ -> originalExpr
 
 evalFromNatToRat :: EvalSimpleBuiltin builtin
-evalFromNatToRat = \case
-  [VNatLiteral x] -> Just $ VRatLiteral (fromIntegral x)
-  _ -> Nothing
+evalFromNatToRat originalExpr = \case
+  [VNatLiteral x] -> VRatLiteral (fromIntegral x)
+  _ -> originalExpr
 
 evalFromRat :: FromRatDomain -> EvalSimpleBuiltin builtin
 evalFromRat = \case
   FromRatToRat -> evalFromRatToRat
 
 evalFromRatToRat :: EvalSimpleBuiltin builtin
-evalFromRatToRat = \case
-  [x] -> Just x
-  _ -> Nothing
+evalFromRatToRat originalExpr = \case
+  [x] -> x
+  _ -> originalExpr
 
 evalIf :: EvalSimpleBuiltin builtin
-evalIf = \case
-  [VBoolLiteral True, e1, _e2] -> Just e1
-  [VBoolLiteral False, _e1, e2] -> Just e2
-  _ -> Nothing
+evalIf originalExpr = \case
+  [VBoolLiteral True, e1, _e2] -> e1
+  [VBoolLiteral False, _e1, e2] -> e2
+  _ -> originalExpr
 
 evalAt :: EvalSimpleBuiltin builtin
-evalAt = \case
-  [VVecLiteral xs, VIndexLiteral i] -> Just $ case xs !!? fromIntegral i of
+evalAt originalExpr = \case
+  [VVecLiteral xs, VIndexLiteral i] -> case xs !!? fromIntegral i of
     Nothing -> developerError $ "out of bounds error:" <+> pretty (length xs) <+> "<=" <+> pretty i
     Just xsi -> argExpr xsi
-  _ -> Nothing
+  _ -> originalExpr
 
-evalFoldList ::
-  EvalApp builtin m ->
-  EvalBuiltin builtin m
-evalFoldList evalApp = \case
-  [_f, e, VNil] ->
-    Just $ return e
-  [f, e, VCons x xs] ->
-    Just $ do
-      let defaultFold = return $ VBuiltin (mkBuiltinFunction FoldList) [Arg mempty Explicit Relevant f, Arg mempty Explicit Relevant e, xs]
-      r <- fromMaybe defaultFold $ evalFoldList evalApp [f, e, argExpr xs]
-      evalApp f [x, Arg mempty Explicit Relevant r]
-  _ -> Nothing
+evalFoldList :: EvalBuiltin builtin m
+evalFoldList evalApp originalExpr = \case
+  [_f, e, VNil] -> return e
+  [f, e, VCons x xs] -> do
+    let defaultFold = VBuiltin (mkBuiltinFunction FoldList) [Arg mempty Explicit Relevant f, Arg mempty Explicit Relevant e, xs]
+    r <- evalFoldList evalApp defaultFold [f, e, argExpr xs]
+    evalApp f [x, Arg mempty Explicit Relevant r]
+  _ -> return originalExpr
 
-evalFoldVector ::
-  (MonadCompile m, PrintableBuiltin builtin) =>
-  EvalApp builtin m ->
-  EvalBuiltin builtin m
-evalFoldVector evalApp = \case
-  [f, e, VVecLiteral xs] ->
-    Just $ foldrM f' e xs
+evalFoldVector :: EvalBuiltin builtin m
+evalFoldVector evalApp originalExpr = \case
+  [f, e, VVecLiteral xs] -> foldrM f' e xs
     where
       f' x r =
         evalApp
@@ -476,15 +365,12 @@ evalFoldVector evalApp = \case
           [ x,
             Arg mempty Explicit Relevant r
           ]
-  _ -> Nothing
+  _ -> return originalExpr
 
-evalZipWith ::
-  (MonadCompile m, PrintableBuiltin builtin) =>
-  EvalApp builtin m ->
-  EvalBuiltin builtin m
-evalZipWith evalApp = \case
+evalZipWith :: EvalBuiltin builtin m
+evalZipWith evalApp originalExpr = \case
   [f, VVecLiteral xs, VVecLiteral ys] ->
-    Just $ mkVLVec <$> zipWithM f' xs ys
+    mkVLVec <$> zipWithM f' xs ys
     where
       f' x y =
         evalApp
@@ -492,49 +378,41 @@ evalZipWith evalApp = \case
           [ x,
             y
           ]
-  _ -> Nothing
+  _ -> return originalExpr
 
-evalMapList ::
-  (MonadCompile m, PrintableBuiltin builtin) =>
-  EvalApp builtin m ->
-  EvalBuiltin builtin m
-evalMapList evalApp = \case
+evalMapList :: EvalBuiltin builtin m
+evalMapList evalApp originalExpr = \case
   [_f, e@VNil] ->
-    Just $ return e
-  [f, VCons x xs] -> Just $ do
+    return e
+  [f, VCons x xs] -> do
     fx <- evalApp f [x]
-    fxs <- case evalMapList evalApp [f, argExpr xs] of
-      Nothing -> return $ VBuiltin (mkBuiltinFunction MapList) [Arg mempty Explicit Relevant f, xs]
-      Just fxs -> fxs
+    let defaultMap = VBuiltin (mkBuiltinFunction MapList) [Arg mempty Explicit Relevant f, xs]
+    fxs <- evalMapList evalApp defaultMap [f, argExpr xs]
     return $ VBuiltin (mkBuiltinConstructor Cons) (Arg mempty Explicit Relevant <$> [fx, fxs])
-  _ -> Nothing
+  _ -> return originalExpr
 
-evalMapVector ::
-  (MonadCompile m, PrintableBuiltin builtin) =>
-  EvalApp builtin m ->
-  EvalBuiltin builtin m
-evalMapVector evalApp = \case
+evalMapVector :: EvalBuiltin builtin m
+evalMapVector evalApp originalExpr = \case
   [f, VVecLiteral xs] ->
-    Just $ mkVLVec <$> traverse f' xs
+    mkVLVec <$> traverse f' xs
     where
       f' x = evalApp f [x]
-  _ -> Nothing
+  _ -> return originalExpr
 
 evalIndices :: EvalSimpleBuiltin builtin
-evalIndices = \case
-  [VNatLiteral n] -> Just $ mkVLVec (fmap VIndexLiteral [0 .. n - 1])
-  _ -> Nothing
+evalIndices originalExpr = \case
+  [VNatLiteral n] -> mkVLVec (fmap VIndexLiteral [0 .. n - 1])
+  _ -> originalExpr
 
 -----------------------------------------------------------------------------
 -- Derived
 
 -- TODO define in terms of language. The problem is the polarity checking...
 evalImplies :: EvalSimpleBuiltin builtin
-evalImplies = \case
-  [e1, e2] -> Just $ do
+evalImplies originalExpr = \case
+  [e1, e2] -> do
     let defaultNot = VBuiltinFunction Not [Arg mempty Explicit Relevant e1]
-    let ne1 = fromMaybe defaultNot (evalNot [e1])
+    let ne1 = evalNot defaultNot [e1]
     let defaultOr = VBuiltinFunction Or [Arg mempty Explicit Relevant ne1, Arg mempty Explicit Relevant e2]
-    let maybeRes = evalOr [ne1, e2]
-    fromMaybe defaultOr maybeRes
-  _ -> Nothing
+    evalOr defaultOr [ne1, e2]
+  _ -> originalExpr


### PR DESCRIPTION
Removes the use of `Just` in the simplification code, giving one less level of constructors to have a space-leak in.