### PR TITLE
Remove closure type parameter from Value

### DIFF
--- a/vehicle/src/Vehicle/Backend/LossFunction/Core.hs
+++ b/vehicle/src/Vehicle/Backend/LossFunction/Core.hs
@@ -8,7 +8,7 @@ import GHC.Generics (Generic)
 import Vehicle.Backend.Prelude (DifferentiableLogicID)
 import Vehicle.Compile.Prelude
 import Vehicle.Data.Builtin.Loss
-import Vehicle.Data.Code.Value (Value (..), WHNFBinder, WHNFBoundEnv, WHNFClosure (..), WHNFValue)
+import Vehicle.Data.Code.Value (BoundEnv, Closure (..), VBinder, Value (..))
 import Vehicle.Libraries.StandardLibrary.Definitions (StdLibFunction (..))
 
 --------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ instance Pretty TensorDifferentiableLogicField where
   pretty = pretty . show
 
 type DifferentiableLogicImplementation =
-  Map TensorDifferentiableLogicField (WHNFValue LossTensorBuiltin)
+  Map TensorDifferentiableLogicField (Value LossTensorBuiltin)
 
 type CompiledDifferentiableLogic = (DifferentiableLogicID, DifferentiableLogicImplementation)
 
@@ -130,7 +130,7 @@ data RatTensorView expr
   | VReduceMaxRatTensor expr
   | VSearchRatTensor expr expr expr expr
 
-fromRatTensorView :: (BuiltinHasRatTensor builtin, BuiltinHasDimensionData builtin) => RatTensorView (WHNFValue builtin) -> WHNFValue builtin
+fromRatTensorView :: (BuiltinHasRatTensor builtin, BuiltinHasDimensionData builtin) => RatTensorView (Value builtin) -> Value builtin
 fromRatTensorView = \case
   VRatTensor y -> INullaryRatTensorOp (RatTensor y)
   VNegRatTensor x -> IRatTensorOp NegRatTensor (explicit <$> [x])
@@ -149,7 +149,7 @@ fromRatTensorView = \case
   VSearchRatTensor reduce lower upper fn -> IRatTensorOp SearchRatTensor (explicit <$> [reduce, lower, upper, fn])
   VRatTensorVar v -> VBoundVar v []
 
-toRatTensorView :: (BuiltinHasRatTensor builtin, BuiltinHasDimensionData builtin) => WHNFValue builtin -> RatTensorView (WHNFValue builtin)
+toRatTensorView :: (BuiltinHasRatTensor builtin, BuiltinHasDimensionData builtin) => Value builtin -> RatTensorView (Value builtin)
 toRatTensorView expr = case getRatTensorOp expr of
   Just (RatTensor b, []) -> VRatTensor b
   Just (NegRatTensor, [x]) -> VNegRatTensor (argExpr x)
@@ -181,5 +181,5 @@ preservedStdLibOps =
     [ StdForeachIndex
     ]
 
-pattern VLam2 :: WHNFBinder builtin -> WHNFBoundEnv builtin -> Binder builtin -> Expr builtin -> WHNFValue builtin
-pattern VLam2 binder1 env binder2 body <- VLam binder1 (WHNFClosure env (Lam _ binder2 body))
+pattern VLam2 :: VBinder builtin -> BoundEnv builtin -> Binder builtin -> Expr builtin -> Value builtin
+pattern VLam2 binder1 env binder2 body <- VLam binder1 (Closure env (Lam _ binder2 body))

--- a/vehicle/src/Vehicle/Backend/Queries.hs
+++ b/vehicle/src/Vehicle/Backend/Queries.hs
@@ -146,11 +146,11 @@ compileMultiProperty ::
   forall m.
   (MonadStdIO m, MonadFreeContext Builtin m, MonadCompile m) =>
   MultiPropertyMetaData ->
-  WHNFValue Builtin ->
+  Value Builtin ->
   m (MultiProperty ())
 compileMultiProperty multiPropertyMetaData = go []
   where
-    go :: TensorIndices -> WHNFValue Builtin -> m (MultiProperty ())
+    go :: TensorIndices -> Value Builtin -> m (MultiProperty ())
     go indices expr = case expr of
       IVecLiteral _ es -> do
         let es' = zip [0 :: Int ..] es
@@ -165,7 +165,7 @@ compileMultiProperty multiPropertyMetaData = go []
 -- Compiles an individual property
 compileSingleProperty ::
   (MonadPropertyStructure m, MonadStdIO m) =>
-  WHNFValue Builtin ->
+  Value Builtin ->
   m ()
 compileSingleProperty expr = do
   queries <- flip runSupplyT [1 :: QueryID ..] $ eliminateUserVariables expr

--- a/vehicle/src/Vehicle/Compile/Arity.hs
+++ b/vehicle/src/Vehicle/Compile/Arity.hs
@@ -9,7 +9,7 @@ type Arity = Int
 class HasArity a where
   arityOf :: a -> Arity
 
-arityFromVType :: Value closure builtin -> Arity
+arityFromVType :: Value builtin -> Arity
 arityFromVType = \case
   VPi _ r -> 1 + arityFromVType r
   _ -> 0

--- a/vehicle/src/Vehicle/Compile/Boolean/LiftIf.hs
+++ b/vehicle/src/Vehicle/Compile/Boolean/LiftIf.hs
@@ -18,33 +18,33 @@ import Vehicle.Data.Code.Value
 
 liftIf ::
   (Monad m) =>
-  WHNFValue Builtin ->
-  (WHNFValue Builtin -> m (WHNFValue Builtin)) ->
-  m (WHNFValue Builtin)
+  Value Builtin ->
+  (Value Builtin -> m (Value Builtin)) ->
+  m (Value Builtin)
 liftIf (IIf t cond e1 e2) k = IIf t cond <$> liftIf e1 k <*> liftIf e2 k
 liftIf e k = k e
 
 liftIfArg ::
   (Monad m) =>
-  WHNFArg Builtin ->
-  (WHNFArg Builtin -> m (WHNFValue Builtin)) ->
-  m (WHNFValue Builtin)
+  VArg Builtin ->
+  (VArg Builtin -> m (Value Builtin)) ->
+  m (Value Builtin)
 liftIfArg (Arg p v r e) k = liftIf e (k . Arg p v r)
 
 liftIfSpine ::
   (Monad m) =>
-  WHNFSpine Builtin ->
-  (WHNFSpine Builtin -> m (WHNFValue Builtin)) ->
-  m (WHNFValue Builtin)
+  Spine Builtin ->
+  (Spine Builtin -> m (Value Builtin)) ->
+  m (Value Builtin)
 liftIfSpine [] k = k []
 liftIfSpine (x : xs) k = liftIfArg x (\a -> liftIfSpine xs (\as -> k (a : as)))
 
 unfoldIf ::
   (Monad m, MonadFreeContext Builtin m) =>
-  WHNFValue Builtin ->
-  WHNFValue Builtin ->
-  WHNFValue Builtin ->
-  m (WHNFValue Builtin)
+  Value Builtin ->
+  Value Builtin ->
+  Value Builtin ->
+  m (Value Builtin)
 unfoldIf c x y = do
   let mkArgs = fmap (Arg mempty Explicit Relevant)
   cAndX <- normaliseBuiltin (BuiltinFunction And) (mkArgs [c, x])

--- a/vehicle/src/Vehicle/Compile/Boolean/LowerNot.hs
+++ b/vehicle/src/Vehicle/Compile/Boolean/LowerNot.hs
@@ -26,12 +26,12 @@ type MonadDropNot m =
 lowerNot ::
   forall m.
   (MonadDropNot m) =>
-  (WHNFValue Builtin -> m (WHNFValue Builtin)) ->
-  WHNFValue Builtin ->
-  m (WHNFValue Builtin)
+  (Value Builtin -> m (Value Builtin)) ->
+  Value Builtin ->
+  m (Value Builtin)
 lowerNot whenBlocked = go
   where
-    go :: WHNFValue Builtin -> m (WHNFValue Builtin)
+    go :: Value Builtin -> m (Value Builtin)
     go = \case
       ----------------
       -- Base cases --
@@ -44,8 +44,8 @@ lowerNot whenBlocked = go
       -- it is not yet unnormalised. However, it's fine to stop here as we'll
       -- simply continue to normalise it once we re-encounter it again after
       -- normalising the quantifier.
-      IForall args (VLam binder (WHNFClosure env body)) -> return $ IExists args (VLam binder (WHNFClosure env (INot body)))
-      IExists args (VLam binder (WHNFClosure env body)) -> return $ IForall args (VLam binder (WHNFClosure env (INot body)))
+      IForall args (VLam binder (Closure env body)) -> return $ IExists args (VLam binder (Closure env (INot body)))
+      IExists args (VLam binder (Closure env body)) -> return $ IForall args (VLam binder (Closure env (INot body)))
       -- It's not enough simply to negate the free variable, we also need
       -- to negate the instance argument solution for the function
       -- which is a function accepting two arguments and returning a bool.
@@ -59,7 +59,7 @@ lowerNot whenBlocked = go
       IIf t c x y -> IIf t c <$> go x <*> go y
       expr -> whenBlocked expr
 
-negVectorEqSpine :: (MonadDropNot m) => WHNFSpine Builtin -> m (WHNFSpine Builtin)
+negVectorEqSpine :: (MonadDropNot m) => Spine Builtin -> m (Spine Builtin)
 negVectorEqSpine (IVecEqSpine a b n fn x y) = do
   fn' <- appHiddenStdlibDef StdNotBoolOp2 [a, b, fn]
   return $ IVecEqSpine a b n (Arg mempty Explicit Relevant fn') x y

--- a/vehicle/src/Vehicle/Compile/Context/Bound.hs
+++ b/vehicle/src/Vehicle/Compile/Context/Bound.hs
@@ -16,7 +16,7 @@ import Vehicle.Compile.Error (MonadCompile, lookupIxInBoundCtx, lookupLvInBoundC
 import Vehicle.Compile.Normalise.Quote qualified as Quote (unnormalise)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (PrettyFriendly, prettyFriendly)
-import Vehicle.Data.Code.Value (WHNFValue)
+import Vehicle.Data.Code.Value (Value)
 
 prettyFriendlyInCtx ::
   (MonadBoundContext expr m, MonadLogger m, PrettyFriendly (Contextualised a NamedBoundCtx)) =>
@@ -50,7 +50,7 @@ getBoundVarByLv _ compilerPass lv =
 unnormalise ::
   forall expr m.
   (MonadBoundContext expr m, Show expr) =>
-  WHNFValue expr ->
+  Value expr ->
   m (Expr expr)
 unnormalise e = do
   lv <- getCurrentLv (Proxy @expr)

--- a/vehicle/src/Vehicle/Compile/Context/Free.hs
+++ b/vehicle/src/Vehicle/Compile/Context/Free.hs
@@ -20,8 +20,8 @@ appHiddenStdlibDef ::
   forall builtin m.
   (MonadFreeContext builtin m, NormalisableBuiltin builtin) =>
   StdLibFunction ->
-  WHNFSpine builtin ->
-  m (WHNFValue builtin)
+  Spine builtin ->
+  m (Value builtin)
 appHiddenStdlibDef fn spine = do
   (_fnDef, normBody) <- getHiddenStdLibDecl (Proxy @builtin) fn
   case bodyOf normBody of

--- a/vehicle/src/Vehicle/Compile/Context/Free/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Context/Free/Class.hs
@@ -103,14 +103,14 @@ getDecl ::
   Proxy builtin ->
   CompilerPass ->
   Identifier ->
-  m (WHNFDecl builtin)
+  m (VDecl builtin)
 getDecl proxy compilerPass ident =
   snd <$> getDeclEntry proxy compilerPass ident
 
 getFreeEnv ::
   forall builtin m.
   (MonadFreeContext builtin m) =>
-  m (WHNFFreeEnv builtin)
+  m (FreeEnv builtin)
 getFreeEnv = do
   ctx <- getFreeCtx (Proxy @builtin)
   return $ fmap snd ctx

--- a/vehicle/src/Vehicle/Compile/Context/Free/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Context/Free/Core.hs
@@ -11,7 +11,7 @@ type GenericFreeCtx a = Map Identifier a
 
 type FreeCtxEntry builtin =
   ( Decl builtin,
-    WHNFDecl builtin
+    VDecl builtin
   )
 
 type FreeCtx builtin = GenericFreeCtx (FreeCtxEntry builtin)

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -58,19 +58,19 @@ data CompileError
   | UnsupportedResourceFormat DeclProvenance ExternalResource String
   | UnableToParseResource DeclProvenance ExternalResource String
   | -- Unsupported networks
-    NetworkTypeHasVariableSizeTensor DeclProvenance (GluedType Builtin) (WHNFType Builtin) InputOrOutput
+    NetworkTypeHasVariableSizeTensor DeclProvenance (GluedType Builtin) (VType Builtin) InputOrOutput
   | NetworkTypeHasImplicitSizeTensor DeclProvenance (GluedType Builtin) Identifier InputOrOutput
   | NetworkTypeIsNotAFunction DeclProvenance (GluedType Builtin)
-  | NetworkTypeIsNotOverTensors DeclProvenance (GluedType Builtin) (WHNFType Builtin) InputOrOutput
-  | NetworkTypeHasNonExplicitArguments DeclProvenance (GluedType Builtin) (WHNFBinder Builtin)
-  | NetworkTypeHasUnsupportedElementType DeclProvenance (GluedType Builtin) (WHNFType Builtin) InputOrOutput
+  | NetworkTypeIsNotOverTensors DeclProvenance (GluedType Builtin) (VType Builtin) InputOrOutput
+  | NetworkTypeHasNonExplicitArguments DeclProvenance (GluedType Builtin) (VBinder Builtin)
+  | NetworkTypeHasUnsupportedElementType DeclProvenance (GluedType Builtin) (VType Builtin) InputOrOutput
   | -- Unsupported datasets
     DatasetTypeUnsupportedContainer DeclProvenance (GluedType Builtin)
-  | DatasetTypeUnsupportedElement DeclProvenance (GluedType Builtin) (WHNFType Builtin)
-  | DatasetVariableSizeTensor DeclProvenance (GluedType Builtin) (WHNFType Builtin)
+  | DatasetTypeUnsupportedElement DeclProvenance (GluedType Builtin) (VType Builtin)
+  | DatasetVariableSizeTensor DeclProvenance (GluedType Builtin) (VType Builtin)
   | DatasetDimensionSizeMismatch DeclProvenance FilePath Int Int TensorShape TensorShape
   | DatasetDimensionsMismatch DeclProvenance FilePath (GluedExpr Builtin) TensorShape
-  | DatasetTypeMismatch DeclProvenance FilePath (GluedType Builtin) (WHNFType Builtin) (Doc Void)
+  | DatasetTypeMismatch DeclProvenance FilePath (GluedType Builtin) (VType Builtin) (Doc Void)
   | DatasetInvalidIndex DeclProvenance FilePath Int Int
   | DatasetInvalidNat DeclProvenance FilePath Int
   | -- Unsupported parameters
@@ -87,17 +87,17 @@ data CompileError
     PropertyTypeUnsupported DeclProvenance (GluedType Builtin)
   | NoPropertiesFound
   | -- Verification backend errors
-    forall closure builtin.
-    (PrintableBuiltin builtin, Show closure, Eq closure, Eq builtin, PrettyFriendly (Contextualised (VType closure builtin) NamedBoundCtx)) =>
-    UnsupportedVariableType DeclProvenance Provenance Name (VType closure builtin) (VType closure builtin) [builtin]
-  | HigherOrderVectors DeclProvenance NamedBoundCtx (WHNFType TensorBuiltin) (WHNFType TensorBuiltin)
+    forall builtin.
+    (PrintableBuiltin builtin, Eq builtin, PrettyFriendly (Contextualised (VType builtin) NamedBoundCtx)) =>
+    UnsupportedVariableType DeclProvenance Provenance Name (VType builtin) (VType builtin) [builtin]
+  | HigherOrderVectors DeclProvenance NamedBoundCtx (VType TensorBuiltin) (VType TensorBuiltin)
   | UnsupportedAlternatingQuantifiers QueryFormatID DeclProvenance (Either CompileError (Quantifier, Provenance, PolarityProvenance))
   | DuplicateQuantifierNames DeclProvenance Name
   | UnsupportedNonLinearConstraint QueryFormatID DeclProvenance (Either CompileError NonLinearitySource)
   | -- Loss backend errors
     UnsupportedLossOperation DeclProvenance Provenance (Doc Void)
-  | UnsupportedHigherOrderTensorCode DeclProvenance NamedBoundCtx (WHNFValue Builtin) NamedBoundCtx (WHNFValue TensorBuiltin)
-  | UnableToLiftLogicFieldToTensors DifferentiableLogicID TensorDifferentiableLogicField (BooleanDifferentiableLogicField, WHNFValue Builtin) NamedBoundCtx (WHNFValue Builtin)
+  | UnsupportedHigherOrderTensorCode DeclProvenance NamedBoundCtx (Value Builtin) NamedBoundCtx (Value TensorBuiltin)
+  | UnableToLiftLogicFieldToTensors DifferentiableLogicID TensorDifferentiableLogicField (BooleanDifferentiableLogicField, Value Builtin) NamedBoundCtx (Value Builtin)
   | NoQuantifierDomainFound DeclProvenance (GenericBinder ()) (Maybe [(UserElementVariable, UnderConstrainedVariableStatus)])
   | -- ITP backend errors
     UnsupportedPolymorphicEquality ITP Provenance Name

--- a/vehicle/src/Vehicle/Compile/EtaConversion.hs
+++ b/vehicle/src/Vehicle/Compile/EtaConversion.hs
@@ -55,7 +55,7 @@ etaExpand declIdent originalType originalBody = do
     go ::
       forall n.
       (MonadBoundContext builtin n, MonadCompile n) =>
-      WHNFType builtin ->
+      VType builtin ->
       Expr builtin ->
       n (Expr builtin)
     go typ body = case (typ, body) of

--- a/vehicle/src/Vehicle/Compile/ExpandResources.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources.hs
@@ -47,7 +47,7 @@ expandResources resources prog =
     integrityInfo <- generateResourcesIntegrityInfo resources
     return (progWithoutResources, networkCtx, freeCtx, integrityInfo)
 
-mkFunctionDefFromResource :: Provenance -> Identifier -> GluedType Builtin -> WHNFValue Builtin -> FreeCtxEntry Builtin
+mkFunctionDefFromResource :: Provenance -> Identifier -> GluedType Builtin -> Value Builtin -> FreeCtxEntry Builtin
 mkFunctionDefFromResource p ident typ normValue = do
   -- We're doing something wrong here as we only really need the value.
   -- We should really be storing the parameter values in their own environment,

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Core.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Core.hs
@@ -24,7 +24,7 @@ type InferableParameterEntry = (DeclProvenance, ExternalResource, Int)
 
 type InferableParameterContext = Map Identifier (Provenance, GluedType Builtin, Maybe InferableParameterEntry)
 
-type ExplicitParameterContext = Map Identifier (WHNFValue Builtin)
+type ExplicitParameterContext = Map Identifier (Value Builtin)
 
 --------------------------------------------------------------------------------
 -- The resource monad
@@ -71,7 +71,7 @@ noteInferableParameter p ident paramType =
 noteExplicitParameter ::
   (MonadExpandResources m) =>
   Identifier ->
-  WHNFValue Builtin ->
+  Value Builtin ->
   m ()
 noteExplicitParameter ident value =
   modify (\(u, v, w) -> (u, v, Map.insert ident value w))

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Dataset.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Dataset.hs
@@ -22,7 +22,7 @@ parseDataset ::
   DatasetLocations ->
   DeclProvenance ->
   GluedType Builtin ->
-  m (WHNFValue Builtin)
+  m (Value Builtin)
 parseDataset datasetLocations decl@(ident, _) expectedType =
   case Map.lookup (nameOf ident) datasetLocations of
     Just file -> do

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Network.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Network.hs
@@ -51,12 +51,12 @@ getNetworkType decl networkType = case normalised networkType of
         return networkDetails
   _ -> compilerDeveloperError "Should have caught the fact that the network type is not a function during type-checking"
   where
-    getTensorType :: InputOrOutput -> WHNFType Builtin -> m NetworkTensorType
+    getTensorType :: InputOrOutput -> VType Builtin -> m NetworkTensorType
     getTensorType io tensorType = do
       (baseType, dims) <- go True tensorType
       return $ NetworkTensorType baseType dims
       where
-        go :: Bool -> WHNFType Builtin -> m (NetworkBaseType, TensorShape)
+        go :: Bool -> VType Builtin -> m (NetworkBaseType, TensorShape)
         go topLevel = \case
           IVectorType _ tElem dim -> do
             d <- getTensorDimension io dim
@@ -69,7 +69,7 @@ getNetworkType decl networkType = case normalised networkType of
                 elemType <- getElementType t
                 return (elemType, [])
 
-    getTensorDimension :: InputOrOutput -> WHNFType Builtin -> m Int
+    getTensorDimension :: InputOrOutput -> VType Builtin -> m Int
     getTensorDimension io dim = case dim of
       INatLiteral _ n -> return n
       VFreeVar varIdent _ -> do
@@ -84,7 +84,7 @@ getNetworkType decl networkType = case normalised networkType of
               Just value -> getTensorDimension io value
       _ -> throwError $ NetworkTypeHasVariableSizeTensor decl networkType dim io
 
-    getElementType :: WHNFType Builtin -> m NetworkBaseType
+    getElementType :: VType Builtin -> m NetworkBaseType
     getElementType = \case
       IRatType {} -> return NetworkRatType
       _ -> typingError

--- a/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
+++ b/vehicle/src/Vehicle/Compile/ExpandResources/Parameter.hs
@@ -24,7 +24,7 @@ parseParameterValue ::
   ParameterValues ->
   DeclProvenance ->
   GluedType Builtin ->
-  m (WHNFValue Builtin)
+  m (Value Builtin)
 parseParameterValue parameterValues decl@(ident, _) parameterType = do
   implicitParams <- getInferableParameterContext
 
@@ -50,24 +50,24 @@ parseParameterValue parameterValues decl@(ident, _) parameterType = do
     Nothing -> throwError $ ResourceNotProvided decl Parameter
     Just value -> parser decl value
 
-parseBool :: (MonadCompile m) => DeclProvenance -> String -> m (WHNFValue Builtin)
+parseBool :: (MonadCompile m) => DeclProvenance -> String -> m (Value Builtin)
 parseBool decl value = case readMaybe value of
   Just v -> return $ IBoolLiteral mempty v
   Nothing -> throwError $ ParameterValueUnparsable decl value Bool
 
-parseNat :: (MonadCompile m) => DeclProvenance -> String -> m (WHNFValue Builtin)
+parseNat :: (MonadCompile m) => DeclProvenance -> String -> m (Value Builtin)
 parseNat decl value = case readMaybe value of
   Just v
     | v >= 0 -> return $ INatLiteral mempty v
     | otherwise -> throwError $ ParameterValueInvalidNat decl v
   Nothing -> throwError $ ParameterValueUnparsable decl value Nat
 
-parseRat :: (MonadCompile m) => DeclProvenance -> String -> m (WHNFValue Builtin)
+parseRat :: (MonadCompile m) => DeclProvenance -> String -> m (Value Builtin)
 parseRat decl value = case rational (pack value) of
   Left _err -> throwError $ ParameterValueUnparsable decl value Rat
   Right (v, _) -> return $ IRatLiteral mempty v
 
-parseIndex :: (MonadCompile m) => Int -> DeclProvenance -> String -> m (WHNFValue Builtin)
+parseIndex :: (MonadCompile m) => Int -> DeclProvenance -> String -> m (Value Builtin)
 parseIndex n decl value = case readMaybe value of
   Nothing -> throwError $ ParameterValueUnparsable decl value Index
   Just v ->

--- a/vehicle/src/Vehicle/Compile/Normalise/Builtin.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Builtin.hs
@@ -45,25 +45,25 @@ import Vehicle.Data.Tensor (Tensor, foldTensor, mapTensor, zipWithTensor)
 -- methods of normalisation.
 type EvalBuiltinApp m builtin =
   (MonadCompile m) =>
-  EvalApp (WHNFValue builtin) m ->
+  EvalApp (Value builtin) m ->
   Eval builtin m ->
   builtin ->
   [Arg builtin] ->
-  m (WHNFValue builtin)
+  m (Value builtin)
 
 type Eval builtin m =
   (MonadCompile m) =>
   Expr builtin ->
-  m (WHNFValue builtin)
+  m (Value builtin)
 
 evalTypeClassOp ::
   (MonadLogger m, BuiltinHasStandardData builtin, Show builtin) =>
-  (BuiltinFunction -> EvalBuiltin (Value closure builtin) m) ->
-  EvalApp (Value closure builtin) m ->
-  Value closure builtin ->
+  (BuiltinFunction -> EvalBuiltin (Value builtin) m) ->
+  EvalApp (Value builtin) m ->
+  Value builtin ->
   builtin ->
-  Spine closure builtin ->
-  m (Value closure builtin)
+  Spine builtin ->
+  m (Value builtin)
 evalTypeClassOp evalFn evalApp originalExpr b normArgs
   | isTypeClassOp b = do
       (inst, remainingArgs) <- findInstanceArg b normArgs
@@ -457,12 +457,12 @@ class (PrintableBuiltin builtin) => NormalisableBuiltin builtin where
   -- and irrelevant arguments), the builtin that is in the head position
   -- and the list of computationally relevant arguments.
   evalBuiltinApp ::
-    (MonadLogger m, Show closure) =>
-    EvalApp (Value closure builtin) m ->
-    Value closure builtin ->
+    (MonadLogger m) =>
+    EvalApp (Value builtin) m ->
+    Value builtin ->
     builtin ->
-    Spine closure builtin ->
-    m (Value closure builtin)
+    Spine builtin ->
+    m (Value builtin)
 
   blockingArgs ::
     builtin ->
@@ -544,7 +544,7 @@ instance NormalisableBuiltin Builtin where
     BuiltinFunction f -> functionBlockingArgs f
     _ -> []
 
-evalTensorBuiltin :: (Show closure) => TensorBuiltin -> EvalSimpleBuiltin (Value closure TensorBuiltin)
+evalTensorBuiltin :: TensorBuiltin -> EvalSimpleBuiltin (Value TensorBuiltin)
 evalTensorBuiltin b originalExpr spine =
   case b of
     TensorRat op -> evalRatTensorBuiltin op originalExpr spine
@@ -608,7 +608,7 @@ instance NormalisableBuiltin LinearityBuiltin where
     _ -> []
 
 -- Need foldList at the type-level to evaluate the Tensor definition
-evalLinearityFoldList :: EvalBuiltin (Value closure LinearityBuiltin) m
+evalLinearityFoldList :: EvalBuiltin (Value LinearityBuiltin) m
 evalLinearityFoldList evalApp originalExpr args =
   case args of
     [_a, _b, _c, _f, e, argExpr -> VBuiltin (LinearityConstructor Nil) []] -> return $ argExpr e
@@ -661,7 +661,7 @@ instance NormalisableBuiltin PolarityBuiltin where
     _ -> []
 
 -- Need foldList at the type-level to evaluate the Tensor definition
-evalPolarityFoldList :: EvalBuiltin (Value closure PolarityBuiltin) m
+evalPolarityFoldList :: EvalBuiltin (Value PolarityBuiltin) m
 evalPolarityFoldList evalApp originalExpr args =
   case args of
     [_a, _b, _c, _f, e, argExpr -> VBuiltin (PolarityConstructor Nil) []] -> return $ argExpr e

--- a/vehicle/src/Vehicle/Compile/Print/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Print/Error.hs
@@ -781,7 +781,7 @@ instance MeaningfulError CompileError where
             fix = Just $ datasetDimensionsFix "dimensions" ident file
           }
       where
-        dimensionsOf :: WHNFType Builtin -> Int
+        dimensionsOf :: VType Builtin -> Int
         dimensionsOf = \case
           IListType _ t -> 1 + dimensionsOf t
           IVectorType _ t _ -> 1 + dimensionsOf t

--- a/vehicle/src/Vehicle/Compile/Rational/LinearExpr.hs
+++ b/vehicle/src/Vehicle/Compile/Rational/LinearExpr.hs
@@ -26,7 +26,7 @@ type MonadCompileLinearExpr m =
 
 data LinearityError
   = NonLinearity
-  | UnhandlableExpr (WHNFValue Builtin)
+  | UnhandlableExpr (Value Builtin)
 
 --------------------------------------------------------------------------------
 -- Rational expression
@@ -35,8 +35,8 @@ compileRatLinearRelation ::
   (MonadLogger m) =>
   (Lv -> ExceptT LinearityError m ElementVariable) ->
   (LinearExpr -> LinearExpr -> relation) ->
-  WHNFValue Builtin ->
-  WHNFValue Builtin ->
+  Value Builtin ->
+  Value Builtin ->
   m (Either LinearityError relation)
 compileRatLinearRelation handleVar mkRelation x y = do
   runExceptT $ do
@@ -48,11 +48,11 @@ compileRatLinearExpr ::
   forall m.
   (MonadCompileLinearExpr m) =>
   (Lv -> m ElementVariable) ->
-  WHNFValue Builtin ->
+  Value Builtin ->
   m LinearExpr
 compileRatLinearExpr handleVar = go
   where
-    go :: WHNFValue Builtin -> m LinearExpr
+    go :: Value Builtin -> m LinearExpr
     go e = case e of
       ----------------
       -- Base cases --
@@ -89,8 +89,8 @@ compileRatLinearExpr handleVar = go
 compileTensorLinearRelation ::
   (MonadLogger m) =>
   (Lv -> ExceptT LinearityError m (TensorVariable, TensorShape)) ->
-  WHNFValue Builtin ->
-  WHNFValue Builtin ->
+  Value Builtin ->
+  Value Builtin ->
   m (Either LinearityError (Maybe (LinearExpr, LinearExpr)))
 compileTensorLinearRelation handleVar x y = do
   runExceptT $ do
@@ -102,11 +102,11 @@ compileTensorLinearExpr ::
   forall m.
   (MonadCompileLinearExpr m) =>
   (Lv -> m (TensorVariable, TensorShape)) ->
-  WHNFValue Builtin ->
+  Value Builtin ->
   m (Maybe LinearExpr)
 compileTensorLinearExpr handleVar = go
   where
-    go :: WHNFValue Builtin -> m (Maybe LinearExpr)
+    go :: Value Builtin -> m (Maybe LinearExpr)
     go e = case e of
       ---------------------
       -- Inductive cases --
@@ -123,10 +123,10 @@ compileTensorLinearExpr handleVar = go
         return $ Just $ singletonVarExpr shape var
       _ -> return Nothing
 
-getRationalTensor :: WHNFValue Builtin -> Maybe RationalTensor
+getRationalTensor :: Value Builtin -> Maybe RationalTensor
 getRationalTensor expr = uncurry Tensor <$> go expr
   where
-    go :: WHNFValue Builtin -> Maybe (TensorShape, Vector Rational)
+    go :: Value Builtin -> Maybe (TensorShape, Vector Rational)
     go = \case
       IRatLiteral _ r -> Just ([], Vector.singleton (fromRational r))
       IVecLiteral _ xs -> do

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -75,7 +75,7 @@ malformedConstraintError c =
 unify ::
   (MonadTypeChecker builtin m) =>
   (ConstraintContext builtin, UnificationConstraintOrigin builtin) ->
-  (WHNFValue builtin, WHNFValue builtin) ->
+  (Value builtin, Value builtin) ->
   m (WithContext (UnificationConstraint builtin))
 unify (ctx, origin) (e1, e2) =
   WithContext (Unify origin e1 e2) <$> copyContext ctx
@@ -84,8 +84,8 @@ unify (ctx, origin) (e1, e2) =
 createInstanceUnification ::
   (MonadTypeChecker builtin m) =>
   (ConstraintContext builtin, InstanceConstraintOrigin builtin) ->
-  WHNFValue builtin ->
-  WHNFValue builtin ->
+  Value builtin ->
+  Value builtin ->
   m (WithContext (Constraint builtin))
 createInstanceUnification (ctx, origin) e1 e2 = do
   let unifyOrigin = CheckingInstanceType origin
@@ -97,7 +97,7 @@ createSubInstance ::
   (MonadTypeChecker builtin m) =>
   (ConstraintContext builtin, InstanceConstraintOrigin builtin) ->
   Relevance ->
-  WHNFValue builtin ->
+  Value builtin ->
   m (Expr builtin, WithContext (Constraint builtin))
 createSubInstance (ctx, origin) r t = do
   let p = provenanceOf ctx
@@ -136,11 +136,11 @@ findInstanceGoalHead = \case
 parseInstanceGoal ::
   forall m builtin.
   (MonadCompile m, PrintableBuiltin builtin) =>
-  WHNFValue builtin ->
+  Value builtin ->
   m (InstanceGoal builtin)
 parseInstanceGoal e = go [] e
   where
-    go :: Telescope builtin -> WHNFValue builtin -> m (InstanceGoal builtin)
+    go :: Telescope builtin -> Value builtin -> m (InstanceGoal builtin)
     go telescope = \case
       VPi binder _body
         | not (isExplicit binder) -> compilerDeveloperError "Instance goals with telescopes not yet supported"

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/IndexSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/IndexSolver.hs
@@ -45,7 +45,7 @@ solveInDomain ::
   forall m.
   (MonadTypeChecker Builtin m) =>
   WithContext (InstanceConstraint Builtin) ->
-  [WHNFType Builtin] ->
+  [VType Builtin] ->
   m (Maybe MetaSet)
 solveInDomain c [value, typ] = case typ of
   (getNMeta -> Just {}) -> return $ blockOnMetas [typ]
@@ -67,7 +67,7 @@ solveInDomain c [value, typ] = case typ of
     ctx = contextOf c
 solveInDomain c _ = malformedConstraintError c
 
-blockOnMetas :: [WHNFValue Builtin] -> Maybe MetaSet
+blockOnMetas :: [Value Builtin] -> Maybe MetaSet
 blockOnMetas args = do
   let metas = mapMaybe getNMeta args
   if null metas
@@ -78,12 +78,12 @@ findLowerBound ::
   forall m.
   (MonadTypeChecker Builtin m) =>
   ConstraintContext Builtin ->
-  WHNFType Builtin ->
-  WHNFType Builtin ->
+  VType Builtin ->
+  VType Builtin ->
   m (MetaSet, Int)
 findLowerBound ctx value indexSize = go indexSize
   where
-    go :: WHNFType Builtin -> m (MetaSet, Int)
+    go :: VType Builtin -> m (MetaSet, Int)
     go = \case
       VMeta m _ ->
         return (MetaSet.singleton m, 0)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
@@ -90,14 +90,14 @@ getDefaultableConstraints maybeDecl = do
 
 data Candidate builtin = Candidate
   { candidateTypeClass :: builtin,
-    candidateMetaExpr :: WHNFValue builtin,
+    candidateMetaExpr :: Value builtin,
     candidateInfo :: InstanceConstraintInfo builtin,
-    candidateSolution :: WHNFValue builtin
+    candidateSolution :: Value builtin
   }
 
 instance (PrintableBuiltin builtin) => Pretty (Candidate builtin) where
   pretty Candidate {..} =
-    prettyVerbose candidateMetaExpr <+> "~" <+> prettyVerbose (VBuiltin @(WHNFClosure builtin) @builtin candidateTypeClass [])
+    prettyVerbose candidateMetaExpr <+> "~" <+> prettyVerbose (VBuiltin @builtin candidateTypeClass [])
 
 data CandidateStatus builtin
   = Valid (Candidate builtin)
@@ -129,7 +129,7 @@ generateConstraintUsingDefaults constraints = do
           <+> "="
           <+> prettyVerbose candidateSolution
           <+> "         "
-          <> parens ("from" <+> prettyVerbose (VBuiltin @(WHNFClosure builtin) @builtin candidateTypeClass []))
+          <> parens ("from" <+> prettyVerbose (VBuiltin @builtin candidateTypeClass []))
       newConstraint <- createInstanceUnification candidateInfo candidateMetaExpr candidateSolution
       return $ Just newConstraint
 

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaults.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaults.hs
@@ -108,8 +108,8 @@ getCandidates ctx (Resolve origin _ _ expr) = do
 getCandidatesFromArgs ::
   InstanceConstraintInfo Builtin ->
   Builtin ->
-  WHNFValue Builtin ->
-  WHNFSpine Builtin ->
+  Value Builtin ->
+  Spine Builtin ->
   [Candidate Builtin]
 getCandidatesFromArgs info tc solution ts = map mkCandidate (filter (isNMeta . argExpr) ts)
   where

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
@@ -186,7 +186,7 @@ instantiateCandidateTelescope ::
   BoundCtx (Type builtin) ->
   InstanceConstraintInfo builtin ->
   WithContext (InstanceCandidate builtin) ->
-  m (WHNFValue builtin, Expr builtin, [WithContext (Constraint builtin)])
+  m (Value builtin, Expr builtin, [WithContext (Constraint builtin)])
 instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin) candidate = do
   let WithContext InstanceCandidate {..} candidateCtx = candidate
   logCompilerSection MaxDetail "instantiating candidate telescope" $ do
@@ -226,7 +226,7 @@ prettyCandidate :: (PrintableBuiltin builtin) => WithContext (InstanceCandidate 
 prettyCandidate (WithContext candidate ctx) =
   prettyExternal (WithContext (candidateExpr candidate) (toNamedBoundCtx ctx))
 
-goalExpr :: InstanceGoal builtin -> WHNFValue builtin
+goalExpr :: InstanceGoal builtin -> Value builtin
 goalExpr InstanceGoal {..} = VBuiltin goalHead goalSpine
 
 replaceProvenance :: Provenance -> Expr builtin -> Expr builtin

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/LinearitySolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/LinearitySolver.hs
@@ -43,7 +43,7 @@ type LinearitySolver =
   forall m.
   (MonadLinearitySolver m) =>
   InstanceConstraintInfo LinearityBuiltin ->
-  [WHNFType LinearityBuiltin] ->
+  [VType LinearityBuiltin] ->
   Maybe (m (ConstraintProgress LinearityBuiltin))
 
 solve :: LinearityRelation -> LinearitySolver
@@ -155,7 +155,7 @@ handleConstraintProgress originalConstraint@(WithContext (Resolve _ m _ _) ctx) 
     solveMeta m (IUnitLiteral (provenanceOf ctx)) (boundContext ctx)
     addConstraints newConstraints
 
-getTypeClass :: (MonadCompile m) => WHNFValue LinearityBuiltin -> m (LinearityRelation, WHNFSpine LinearityBuiltin)
+getTypeClass :: (MonadCompile m) => Value LinearityBuiltin -> m (LinearityRelation, Spine LinearityBuiltin)
 getTypeClass = \case
   (VBuiltin (LinearityRelation tc) args) -> return (tc, args)
   _ -> compilerDeveloperError "Unexpected non-type-class instance argument found."

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/PolaritySolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/PolaritySolver.hs
@@ -41,7 +41,7 @@ type PolaritySolver =
   forall m.
   (MonadPolaritySolver m) =>
   InstanceConstraintInfo PolarityBuiltin ->
-  [WHNFType PolarityBuiltin] ->
+  [VType PolarityBuiltin] ->
   Maybe (m (ConstraintProgress PolarityBuiltin))
 
 solve :: PolarityRelation -> PolaritySolver
@@ -235,7 +235,7 @@ handleConstraintProgress originalConstraint@(WithContext (Resolve _ m _ _) ctx) 
     solveMeta m (IUnitLiteral (provenanceOf ctx)) (boundContext ctx)
     addConstraints newConstraints
 
-getTypeClass :: (MonadCompile m) => WHNFValue PolarityBuiltin -> m (PolarityRelation, WHNFSpine PolarityBuiltin)
+getTypeClass :: (MonadCompile m) => Value PolarityBuiltin -> m (PolarityRelation, Spine PolarityBuiltin)
 getTypeClass = \case
   (VBuiltin (PolarityRelation tc) args) -> return (tc, args)
   _ -> compilerDeveloperError "Unexpected non-type-class instance argument found."

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/StandardAnnotationRestrictions.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/StandardAnnotationRestrictions.hs
@@ -25,7 +25,7 @@ restrictStandardPropertyType ::
   m ()
 restrictStandardPropertyType decl parameterType = go (normalised parameterType)
   where
-    go :: WHNFType Builtin -> m ()
+    go :: VType Builtin -> m ()
     go = \case
       IBoolType {} -> return ()
       IVectorType _ tElem _ -> go tElem
@@ -82,7 +82,7 @@ restrictStandardDatasetType decl datasetType = do
   checkContainerType True (normalised datasetType)
   return (unnormalised datasetType)
   where
-    checkContainerType :: Bool -> WHNFType Builtin -> m ()
+    checkContainerType :: Bool -> VType Builtin -> m ()
     checkContainerType topLevel = \case
       IListType _ tElem -> checkContainerType False tElem
       IVectorType _ tElem _tDims -> checkContainerType False tElem
@@ -90,7 +90,7 @@ restrictStandardDatasetType decl datasetType = do
         | topLevel -> throwError $ DatasetTypeUnsupportedContainer decl datasetType
         | otherwise -> checkDatasetElemType remainingType
 
-    checkDatasetElemType :: WHNFType Builtin -> m ()
+    checkDatasetElemType :: VType Builtin -> m ()
     checkDatasetElemType elementType = case elementType of
       INatType {} -> return ()
       IIndexType {} -> return ()
@@ -120,10 +120,10 @@ restrictStandardNetworkType decl networkType = case normalised networkType of
         return $ unnormalised networkType
   _ -> throwError $ NetworkTypeIsNotAFunction decl networkType
   where
-    checkTensorType :: InputOrOutput -> WHNFType Builtin -> m ()
+    checkTensorType :: InputOrOutput -> VType Builtin -> m ()
     checkTensorType io = go True
       where
-        go :: Bool -> WHNFType Builtin -> m ()
+        go :: Bool -> VType Builtin -> m ()
         go topLevel = \case
           IVectorType _ tElem _ -> go False tElem
           elemType ->
@@ -131,7 +131,7 @@ restrictStandardNetworkType decl networkType = case normalised networkType of
               then throwError $ NetworkTypeIsNotOverTensors decl networkType elemType io
               else checkElementType io elemType
 
-    checkElementType :: InputOrOutput -> WHNFType Builtin -> m ()
+    checkElementType :: InputOrOutput -> VType Builtin -> m ()
     checkElementType io = \case
       IRatType {} -> return ()
       tElem -> throwError $ NetworkTypeHasUnsupportedElementType decl networkType tElem io

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -22,7 +22,7 @@ data TypingError builtin
   | FailedInstanceConstraint (ConstraintContext builtin) (InstanceConstraintOrigin builtin) (InstanceGoal builtin) [WithContext (InstanceCandidate builtin)]
   | UnsolvedConstraints (NonEmpty (WithContext (Constraint builtin)))
   | FailedIndexConstraintTooBig (ConstraintContext builtin) Int Int
-  | FailedIndexConstraintUnknown (ConstraintContext builtin) (WHNFValue builtin) (WHNFType builtin)
+  | FailedIndexConstraintUnknown (ConstraintContext builtin) (Value builtin) (VType builtin)
   deriving (Show)
 
 --------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ data InstanceConstraint builtin = Resolve
   { instanceOrigin :: InstanceConstraintOrigin builtin,
     instanceSolutionMeta :: MetaID,
     instanceRelevance :: Relevance,
-    instanceGoal :: WHNFValue builtin
+    instanceGoal :: Value builtin
   }
   deriving (Show)
 
@@ -144,7 +144,7 @@ type instance
 data InstanceGoal builtin = InstanceGoal
   { goalTelescope :: Telescope builtin,
     goalHead :: builtin,
-    goalSpine :: WHNFSpine builtin
+    goalSpine :: Spine builtin
   }
   deriving (Show)
 
@@ -187,8 +187,8 @@ data UnificationConstraintOrigin builtin
 data UnificationConstraint builtin
   = Unify
       (UnificationConstraintOrigin builtin)
-      (WHNFValue builtin)
-      (WHNFValue builtin)
+      (Value builtin)
+      (Value builtin)
   deriving (Show)
 
 type instance

--- a/vehicle/src/Vehicle/Compile/Type/Force.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Force.hs
@@ -29,8 +29,8 @@ forceHead ::
   (MonadForce builtin m) =>
   MetaSubstitution builtin ->
   ConstraintContext builtin ->
-  WHNFValue builtin ->
-  m (WHNFValue builtin, MetaSet)
+  Value builtin ->
+  m (Value builtin, MetaSet)
 forceHead subst ctx expr = do
   (maybeForcedExpr, blockingMetas) <- forceExpr subst expr
   forcedExpr <- case maybeForcedExpr of
@@ -50,8 +50,8 @@ forceHead subst ctx expr = do
 forceExpr ::
   (MonadForce builtin m) =>
   MetaSubstitution builtin ->
-  WHNFValue builtin ->
-  m (Maybe (WHNFValue builtin), MetaSet)
+  Value builtin ->
+  m (Maybe (Value builtin), MetaSet)
 forceExpr subst = \case
   VMeta m spine -> forceMeta subst m spine
   VBuiltin b spine -> forceBuiltin subst b spine
@@ -61,8 +61,8 @@ forceMeta ::
   (MonadForce builtin m) =>
   MetaSubstitution builtin ->
   MetaID ->
-  WHNFSpine builtin ->
-  m (Maybe (WHNFValue builtin), MetaSet)
+  Spine builtin ->
+  m (Maybe (Value builtin), MetaSet)
 forceMeta subst m spine = do
   case MetaMap.lookup m subst of
     Just solution -> do
@@ -75,8 +75,8 @@ forceMeta subst m spine = do
 forceArg ::
   (MonadForce builtin m) =>
   MetaSubstitution builtin ->
-  WHNFArg builtin ->
-  m (Maybe (WHNFArg builtin), MetaSet)
+  VArg builtin ->
+  m (Maybe (VArg builtin), MetaSet)
 forceArg subst arg = do
   (maybeResult, blockingMetas) <- unpairArg <$> traverse (forceExpr subst) arg
   return (sequenceA maybeResult, blockingMetas)
@@ -85,8 +85,8 @@ forceBuiltin ::
   (MonadForce builtin m) =>
   MetaSubstitution builtin ->
   builtin ->
-  WHNFSpine builtin ->
-  m (Maybe (WHNFValue builtin), MetaSet)
+  Spine builtin ->
+  m (Maybe (Value builtin), MetaSet)
 forceBuiltin subst b spine = do
   logDebug MaxDetail $ prettyVerbose spine
   (maybeUnblockedSpine, blockingMetas) <- forceBuiltinSpine subst spine 0 (blockingArgs b)
@@ -96,10 +96,10 @@ forceBuiltin subst b spine = do
 forceBuiltinSpine ::
   (MonadForce builtin m) =>
   MetaSubstitution builtin ->
-  WHNFSpine builtin ->
+  Spine builtin ->
   Int ->
   [Int] ->
-  m (Maybe (WHNFSpine builtin), MetaSet)
+  m (Maybe (Spine builtin), MetaSet)
 forceBuiltinSpine _subst [] _currentIndex _blockingArgs = return (Nothing, mempty)
 forceBuiltinSpine _subst _args _currentIndex [] = return (Nothing, mempty)
 forceBuiltinSpine subst (arg : args) currentIndex (blockingIndex : blockingIndices) = do

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -77,7 +77,7 @@ substApp s (fun@(Meta _ m), mArgs) = do
     Just value -> subst s $ substArgs (unnormalised value) mArgs
 substApp s (fun, args) = normAppList <$> subst s fun <*> subst s args
 
-instance MetaSubstitutable m builtin (WHNFValue builtin) where
+instance MetaSubstitutable m builtin (Value builtin) where
   subst s expr = case expr of
     VMeta m args -> do
       case MetaMap.lookup m s of
@@ -100,8 +100,8 @@ instance MetaSubstitutable m builtin (WHNFValue builtin) where
     VLam binder body -> VLam <$> subst s binder <*> subst s body
     VPi binder body -> VPi <$> subst s binder <*> subst s body
 
-instance MetaSubstitutable m builtin (WHNFClosure builtin) where
-  subst s (WHNFClosure env body) = WHNFClosure <$> subst s env <*> subst s body
+instance MetaSubstitutable m builtin (Closure builtin) where
+  subst s (Closure env body) = Closure <$> subst s env <*> subst s body
 
 instance MetaSubstitutable m builtin (GluedExpr builtin) where
   subst s (Glued a b) = Glued <$> subst s a <*> subst s b

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -89,7 +89,7 @@ getMetaDependencies = \case
   (ExplicitArg _ _ (BoundVar _ i)) : args -> i : getMetaDependencies args
   _ -> []
 
-getNormMetaDependencies :: [WHNFArg builtin] -> ([Lv], WHNFSpine builtin)
+getNormMetaDependencies :: [VArg builtin] -> ([Lv], Spine builtin)
 getNormMetaDependencies = \case
   (ExplicitArg _ _ (VBoundVar i [])) : args -> first (i :) $ getNormMetaDependencies args
   spine -> ([], spine)
@@ -116,7 +116,7 @@ instance HasMetas (Expr builtin) where
     Lam _ binder body -> do findMetas binder; findMetas body
     App fun args -> do findMetas fun; findMetas args
 
-instance HasMetas (WHNFValue builtin) where
+instance HasMetas (Value builtin) where
   findMetas expr = case expr of
     VMeta m spine -> do
       tell (MetaSet.singleton m)

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -478,7 +478,7 @@ copyContext (ConstraintContext _cid originProv creationProv _blockingStatus ctx)
 
 glueNBE ::
   (MonadFreeContext builtin m, NormalisableBuiltin builtin) =>
-  WHNFBoundEnv builtin ->
+  BoundEnv builtin ->
   Expr builtin ->
   m (GluedExpr builtin)
 glueNBE env e = Glued e <$> normaliseInEnv env e

--- a/vehicle/src/Vehicle/Compile/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Variable.hs
@@ -7,11 +7,9 @@ where
 import Control.Monad (when)
 import Control.Monad.Except (MonadError (..))
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.Quote (QuoteClosure)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print.Builtin
 import Vehicle.Data.Builtin.Interface (BuiltinHasNatLiterals, BuiltinHasRatType (mkRatBuiltinType), BuiltinHasVecType)
-import Vehicle.Data.Builtin.Standard (Builtin)
 import Vehicle.Data.Code.Interface
 import Vehicle.Data.Code.Value (VBinder, Value)
 import Vehicle.Data.QuantifiedVariable
@@ -21,23 +19,20 @@ import Prelude hiding (Applicative (..))
 --------------------------------------------------------------------------------
 -- Extraction
 
-type MonadCreateUserVar closure builtin m =
+type MonadCreateUserVar builtin m =
   ( MonadCompile m,
     BuiltinHasRatType builtin,
     BuiltinHasVecType builtin,
     BuiltinHasNatLiterals builtin,
     PrintableBuiltin builtin,
-    Show closure,
-    Eq closure,
-    Eq builtin,
-    QuoteClosure closure Builtin
+    Eq builtin
   )
 
 createUserVar ::
-  (MonadCreateUserVar closure builtin m) =>
+  (MonadCreateUserVar builtin m) =>
   DeclProvenance ->
   NamedBoundCtx ->
-  VBinder closure builtin ->
+  VBinder builtin ->
   m (TensorVariable, TensorShape)
 createUserVar propertyProvenance namedCtx binder = do
   let varName = getBinderName binder
@@ -58,14 +53,14 @@ checkUserVariableNameIsUnique propertyProvenance namedCtx varName = do
       DuplicateQuantifierNames propertyProvenance varName
 
 checkUserVariableType ::
-  forall m closure builtin.
-  (MonadCreateUserVar closure builtin m) =>
+  forall m builtin.
+  (MonadCreateUserVar builtin m) =>
   DeclProvenance ->
-  VBinder closure builtin ->
+  VBinder builtin ->
   m TensorShape
 checkUserVariableType propertyProvenance binder = go (typeOf binder)
   where
-    go :: Value closure builtin -> m TensorShape
+    go :: Value builtin -> m TensorShape
     go = \case
       IRatType {} -> return []
       IVectorType _ tElem (INatLiteral _ d) -> do

--- a/vehicle/src/Vehicle/Data/Builtin/Linearity.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Linearity.hs
@@ -186,7 +186,7 @@ instance BuiltinHasRatLiterals LinearityBuiltin where
 pattern LinearityExpr :: Provenance -> Linearity -> Expr LinearityBuiltin
 pattern LinearityExpr p lin = Builtin p (Linearity lin)
 
-pattern VLinearityExpr :: Linearity -> WHNFValue LinearityBuiltin
+pattern VLinearityExpr :: Linearity -> Value LinearityBuiltin
 pattern VLinearityExpr l <- VBuiltin (Linearity l) []
   where
     VLinearityExpr l = VBuiltin (Linearity l) []

--- a/vehicle/src/Vehicle/Data/Builtin/Polarity.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Polarity.hs
@@ -167,7 +167,7 @@ instance BuiltinHasRatLiterals PolarityBuiltin where
 pattern PolarityExpr :: Provenance -> Polarity -> Expr PolarityBuiltin
 pattern PolarityExpr p pol = Builtin p (Polarity pol)
 
-pattern VPolarityExpr :: Polarity -> WHNFValue PolarityBuiltin
+pattern VPolarityExpr :: Polarity -> Value PolarityBuiltin
 pattern VPolarityExpr l <- VBuiltin (Polarity l) []
   where
     VPolarityExpr l = VBuiltin (Polarity l) []

--- a/vehicle/src/Vehicle/Data/Hashing.hs
+++ b/vehicle/src/Vehicle/Data/Hashing.hs
@@ -5,16 +5,16 @@ module Vehicle.Data.Hashing () where
 import Data.Hashable (Hashable (..))
 import GHC.Generics (Generic)
 import Vehicle.Data.Code.Expr (Expr)
-import Vehicle.Data.Code.Value (Value, WHNFClosure)
+import Vehicle.Data.Code.Value (Closure, Value)
 import Vehicle.Prelude
 
 -- We used to have full blown alpha-equivalence based on co-deBruijn indices
 -- but this proved to be unnecessary. It's still in the repo's history if
 -- need be though.
 
-instance (Hashable builtin, Generic builtin) => Hashable (WHNFClosure builtin)
+instance (Hashable builtin, Generic builtin) => Hashable (Closure builtin)
 
-instance (Hashable closure, Hashable builtin) => Hashable (Value closure builtin)
+instance (Hashable builtin, Generic builtin) => Hashable (Value builtin)
 
 instance (Hashable expr) => Hashable (GenericArg expr)
 

--- a/vehicle/src/Vehicle/Data/QuantifiedVariable.hs
+++ b/vehicle/src/Vehicle/Data/QuantifiedVariable.hs
@@ -37,10 +37,10 @@ reduceTensorVariable ::
   Lv ->
   TensorVariable ->
   TensorShape ->
-  ([(Lv, ElementVariable)], WHNFValue Builtin)
+  ([(Lv, ElementVariable)], Value Builtin)
 reduceTensorVariable dbLevel var shape = runSupply (go shape []) [dbLevel ..]
   where
-    createRatVar :: TensorIndices -> Lv -> ([(Lv, ElementVariable)], WHNFValue Builtin)
+    createRatVar :: TensorIndices -> Lv -> ([(Lv, ElementVariable)], Value Builtin)
     createRatVar indices lv = do
       let name = var <> Text.pack (showTensorIndices indices)
       ([(lv, name)], VBoundVar lv [])
@@ -48,7 +48,7 @@ reduceTensorVariable dbLevel var shape = runSupply (go shape []) [dbLevel ..]
     go ::
       TensorShape ->
       TensorIndices ->
-      Supply Lv ([(Lv, ElementVariable)], WHNFValue Builtin)
+      Supply Lv ([(Lv, ElementVariable)], Value Builtin)
     go dims indices = case dims of
       [] -> createRatVar (reverse indices) <$> demand
       d : ds -> do
@@ -73,7 +73,7 @@ data TensorVariableInfo = TensorVariableInfo
   { -- | Variables for each of it's elements
     elementVariables :: [NetworkElementVariable],
     -- | The tensor literal expression containing the element variables above.
-    reducedVarExpr :: WHNFValue Builtin,
+    reducedVarExpr :: Value Builtin,
     -- The shape of the tensor
     tensorVariableShape :: TensorShape
   }

--- a/vehicle/src/Vehicle/Prelude/Warning.hs
+++ b/vehicle/src/Vehicle/Prelude/Warning.hs
@@ -53,7 +53,7 @@ data CombiningState = CombiningState
     unsoundStrictnessConversions :: Map (QueryFormatID, PropertyAddress) Int,
     allConstantNetworkInputVars :: Map (QueryFormatID, PropertyAddress) (NonEmpty QueryID),
     unboundedNetworkInputs :: Map (QueryFormatID, PropertyAddress) (Map UnderConstrainedSignature (NonEmpty QueryID)),
-    inefficientTensorCode :: Map Name [(Builtin, NamedBoundCtx, WHNFValue TensorBuiltin)]
+    inefficientTensorCode :: Map Name [(Builtin, NamedBoundCtx, Value TensorBuiltin)]
   }
 
 emptyState :: CombiningState

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/Normalisation.hs
@@ -93,10 +93,10 @@ p = mempty
 binding :: Type Builtin -> Binder Builtin
 binding = Binder p (BinderDisplayForm (OnlyName "x") False) Explicit Relevant
 
-mkNoOpEnv :: Lv -> WHNFBoundEnv builtin
+mkNoOpEnv :: Lv -> BoundEnv builtin
 mkNoOpEnv boundCtxSize = reverse [mkDefaultEnvEntry "_" (VBoundVar i []) | i <- [0 .. boundCtxSize - 1]]
   where
-    mkDefaultEnvEntry :: Name -> Value closure builtin -> EnvEntry closure builtin
+    mkDefaultEnvEntry :: Name -> Value builtin -> EnvEntry closure builtin
     mkDefaultEnvEntry name value = (Binder mempty displayForm Explicit Relevant (), value)
       where
         displayForm = BinderDisplayForm (OnlyName name) True


### PR DESCRIPTION
Used to think we needed a full normal form, not just a weak normal form, for loss function translation, but as of a few months ago we no longer need it.