### PR TITLE
Allow type-checker to postpone arg insertion problem

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Relevance.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Relevance.hs
@@ -5,6 +5,7 @@ import Data.Aeson (ToJSON)
 import Data.Hashable (Hashable)
 import Data.Serialize (Serialize)
 import GHC.Generics (Generic)
+import Prettyprinter (Pretty (..))
 
 --------------------------------------------------------------------------------
 -- Data
@@ -28,6 +29,11 @@ instance Semigroup Relevance where
 
 instance Monoid Relevance where
   mempty = Relevant
+
+instance Pretty Relevance where
+  pretty = \case
+    Relevant -> "relevant"
+    Irrelevant -> "irrelevant"
 
 --------------------------------------------------------------------------------
 -- Type class

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -9,6 +9,7 @@ module Vehicle.Compile.Normalise.NBE
     normaliseClosure,
     eval,
     evalApp,
+    evalClosure,
     traverseClosure,
     traverseClosureGeneric,
   )

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -24,7 +24,7 @@ import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap (assocs)
 import Data.Text (Text)
 import GHC.TypeLits (ErrorMessage (..), TypeError)
-import Prettyprinter (list)
+import Prettyprinter (fill, list)
 import Vehicle.Compile.Descope
 import Vehicle.Compile.Normalise.Quote (unnormalise)
 import Vehicle.Compile.Prelude
@@ -160,8 +160,10 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   -----------------
   -- Constraints --
   -----------------
+  StrategyFor tags (ArgInsertionProblem builtin `In` NamedBoundCtx) = StrategyFor tags (Expr builtin `In` NamedBoundCtx)
   StrategyFor tags (InstanceConstraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
   StrategyFor tags (UnificationConstraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
+  StrategyFor tags (ApplicationConstraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
   StrategyFor tags (Constraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
   ------------
   -- Pretty --
@@ -448,11 +450,36 @@ instance
     let e' = unnormalise @(Value builtin) @(Expr Builtin) (Lv $ length ctx) e
     prettyUsing @rest (e', ctx)
 
+instance
+  (PrettyUsing rest (Arg builtin `In` NamedBoundCtx), ConvertableBuiltin builtin Builtin) =>
+  PrettyUsing ('QuoteValue rest) (Arg builtin `In` NamedBoundCtx)
+  where
+  prettyUsing (e, ctx) = prettyUsing @rest (e, ctx)
+
+instance
+  (PrettyUsing rest (Expr builtin `In` NamedBoundCtx), ConvertableBuiltin builtin Builtin) =>
+  PrettyUsing ('QuoteValue rest) (Expr builtin `In` NamedBoundCtx)
+  where
+  prettyUsing (e, ctx) = prettyUsing @rest (e, ctx)
+
 instance PrettyUsing rest (GenericBinder ()) where
   prettyUsing b = maybe "_" pretty (nameOf b)
 
 --------------------------------------------------------------------------------
 -- Instances for constraints
+
+instance
+  ( PrettyUsing rest (Expr builtin `In` NamedBoundCtx),
+    PrettyUsing rest (Arg builtin `In` NamedBoundCtx)
+  ) =>
+  PrettyUsing rest (ArgInsertionProblem builtin `In` NamedBoundCtx)
+  where
+  prettyUsing (problem, ctx) = do
+    let checkedExpr = solutionSoFar problem
+    let checkedExprDoc = prettyUsing @rest (checkedExpr, ctx)
+    let expectedTypeDoc = prettyUsing @rest (currentExpectedType problem, ctx)
+    let uncheckedArgsDoc = prettyUsing @rest (uncheckedArgs problem, ctx)
+    parens (checkedExprDoc <+> ":" <+> expectedTypeDoc) <+> "@" <+> uncheckedArgsDoc
 
 prettyConstraintContext :: ConstraintContext builtin -> Doc a
 prettyConstraintContext ctx =
@@ -476,14 +503,24 @@ instance
     prettyConstraintContext ctx <+> pretty m <+> "<=" <+> expr'
 
 instance
+  (PrettyUsing rest (ArgInsertionProblem builtin `In` NamedBoundCtx)) =>
+  PrettyUsing rest (ApplicationConstraint builtin `In` ConstraintContext builtin)
+  where
+  prettyUsing (InferArgs {..}, ctx) = do
+    let problemDoc = prettyUsing @rest (argInsertionProblem, namedBoundCtxOf ctx)
+    prettyConstraintContext ctx <+> parens (pretty exprSolutionMeta <+> "=" <+> problemDoc) <+> ":" <+> pretty typeSolutionMeta
+
+instance
   ( PrettyUsing rest (UnificationConstraint builtin `In` ctx),
-    PrettyUsing rest (InstanceConstraint builtin `In` ctx)
+    PrettyUsing rest (InstanceConstraint builtin `In` ctx),
+    PrettyUsing rest (ApplicationConstraint builtin `In` ctx)
   ) =>
   PrettyUsing rest (Constraint builtin `In` ctx)
   where
   prettyUsing (c, ctx) = case c of
     UnificationConstraint uc -> prettyUsing @rest (uc, ctx)
     InstanceConstraint tc -> prettyUsing @rest (tc, ctx)
+    ApplicationConstraint tc -> prettyUsing @rest (tc, ctx)
 
 --------------------------------------------------------------------------------
 -- Assertions
@@ -545,7 +582,7 @@ instance
 instance (PrettyUsing rest (a `In` ctx)) => PrettyUsing rest (MetaMap a `In` ctx) where
   prettyUsing (MetaMap m, ctx) = prettyMapEntries entries
     where
-      entries = fmap (bimap MetaID (prettyUsing @rest . (,ctx))) (IntMap.assocs m)
+      entries = fmap (bimap (fill 3 . pretty . MetaID) (prettyUsing @rest . (,ctx))) (IntMap.assocs m)
 
 instance (PrettyUsing rest (a `In` ctx)) => PrettyUsing rest (MaybeTrivial a `In` ctx) where
   prettyUsing (e, ctx) = case e of

--- a/vehicle/src/Vehicle/Compile/Print/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Print/Error.hs
@@ -405,6 +405,8 @@ instance MeaningfulError CompileError where
           InstanceConstraint (Resolve InstanceConstraintOrigin {..} _ _ _) ->
             "insufficient information to find a valid type for the overloaded expression"
               <+> squotes (prettyTypeClassConstraintOriginExpr ctx checkedInstanceOp checkedInstanceOpArgs)
+          ApplicationConstraint {} ->
+            "unsolved application constraint: " <+> prettyFriendly (WithContext constraint ctx)
     UnsolvedMetas ms ->
       UError $
         UserError

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -1,6 +1,6 @@
 module Vehicle.Compile.Type
   ( typeCheckProg,
-    typeCheckExpr,
+    typeCheckSolitaryExpr,
   )
 where
 
@@ -15,6 +15,7 @@ import Vehicle.Compile.Normalise.Builtin (NormalisableBuiltin)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Bidirectional
+import Vehicle.Compile.Type.Constraint.ApplicationSolver (runApplicationSolver)
 import Vehicle.Compile.Type.Constraint.Core (runConstraintSolver)
 import Vehicle.Compile.Type.Constraint.UnificationSolver
 import Vehicle.Compile.Type.Core
@@ -43,17 +44,17 @@ typeCheckProg instanceCandidates freeCtx (Main uncheckedProg) =
       xs <- typeCheckDecls uncheckedProg
       return $ Main xs
 
-typeCheckExpr ::
+typeCheckSolitaryExpr ::
   forall builtin m.
   (HasTypeSystem builtin, NormalisableBuiltin builtin, MonadCompile m) =>
   InstanceDatabase builtin ->
   FreeCtx builtin ->
   Expr Builtin ->
   m (Expr builtin)
-typeCheckExpr instanceCandidates freeCtx expr1 = do
+typeCheckSolitaryExpr instanceCandidates freeCtx expr1 = do
   runTypeCheckerTInitially freeCtx instanceCandidates $ do
     expr2 <- convertExprFromStandardTypes expr1
-    (expr3, _exprType) <- runMonadBidirectional (Proxy @builtin) $ inferExpr expr2
+    (expr3, _exprType) <- inferExprType mempty Relevant expr2
     solveConstraints @builtin Nothing
     expr4 <- substMetas expr3
     checkAllUnknownsSolved (Proxy @builtin)
@@ -134,8 +135,9 @@ typeCheckFunction p ident anns typ body = do
 
   -- Type check the body.
   let pass = bidirectionalPassDoc <+> "body of" <+> quotePretty ident
-  checkedBody <- logCompilerPass MidDetail pass $ do
-    runMonadBidirectional (Proxy @builtin) $ checkExpr checkedType body
+  checkedBody <-
+    logCompilerPass MidDetail pass $
+      checkExprType mempty Relevant checkedType body
 
   -- Reconstruct the function.
   let checkedDecl = DefFunction p ident anns checkedType checkedBody
@@ -167,7 +169,7 @@ checkDeclType :: forall builtin m. (TCM builtin m) => Identifier -> Expr builtin
 checkDeclType ident declType = do
   let pass = bidirectionalPassDoc <+> "type of" <+> quotePretty ident
   logCompilerPass MidDetail pass $ do
-    runMonadBidirectional (Proxy @builtin) $ checkExpr (TypeUniverse mempty 0) declType
+    checkExprType mempty Relevant (TypeUniverse mempty 0) declType
 
 restrictAbstractDefType ::
   (TCM builtin m) =>
@@ -216,16 +218,21 @@ solveConstraints d = logCompilerPass MidDetail "constraint solving" $ do
             -- If we have made useful progress then start a new pass
             let passDoc = "constraint solving pass" <+> pretty loopNumber
             newMetasSolved <- logCompilerPass MaxDetail passDoc $ do
+              metasSolvedDuringApplications <-
+                trackSolvedMetas (Proxy @builtin) $
+                  runApplicationSolver (Proxy @builtin) recentlySolvedMetas
+
               metasSolvedDuringUnification <-
                 trackSolvedMetas (Proxy @builtin) $
-                  runUnificationSolver (Proxy @builtin) recentlySolvedMetas
+                  runUnificationSolver (Proxy @builtin) (metasSolvedDuringApplications <> recentlySolvedMetas)
 
               logUnsolvedUnknowns updatedDecl (Just recentlySolvedMetas)
 
               metasSolvedDuringInstanceResolution <-
                 trackSolvedMetas (Proxy @builtin) $
-                  runInstanceSolver (Proxy @builtin) metasSolvedDuringUnification
-              return metasSolvedDuringInstanceResolution
+                  runInstanceSolver (Proxy @builtin) (metasSolvedDuringUnification <> metasSolvedDuringApplications)
+
+              return (metasSolvedDuringInstanceResolution <> metasSolvedDuringUnification)
 
             loopOverConstraints newMetasSolved (loopNumber + 1) updatedDecl
 
@@ -318,7 +325,7 @@ logUnsolvedUnknowns maybeDecl maybeSolvedMetas = do
     return $
       "current-solution:"
         <> line
-        <> prettyVerbose (fmap unnormalised updatedSubst)
+        <> indent 2 (prettyVerbose (fmap unnormalised updatedSubst))
         <> line
         <> "unsolved-metas:"
         <> line

--- a/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
@@ -1,7 +1,7 @@
 module Vehicle.Compile.Type.Bidirectional
-  ( checkExpr,
-    inferExpr,
-    runMonadBidirectional,
+  ( checkExprType,
+    inferExprType,
+    solveArgInsertionProblem,
   )
 where
 
@@ -13,10 +13,15 @@ import Data.Maybe (fromMaybe)
 import Vehicle.Compile.Context.Bound
 import Vehicle.Compile.Context.Free.Class
 import Vehicle.Compile.Error
+import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
+import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Builtin (TypableBuiltin (..))
 import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Type.Force (forceHead)
+import Vehicle.Compile.Type.Meta (MetaSet)
+import Vehicle.Compile.Type.Meta.Set qualified as MetaSet
 import Vehicle.Compile.Type.Monad
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Universe (UniverseLevel (..))
@@ -40,14 +45,29 @@ type MonadBidirectional builtin m =
 runMonadBidirectional ::
   forall m builtin a.
   (MonadTypeChecker builtin m) =>
-  Proxy builtin ->
+  BoundCtx (Type builtin) ->
+  Relevance ->
   BoundContextT (Type builtin) (ReaderT Relevance m) a ->
   m a
-runMonadBidirectional _ x =
-  runReaderT (runFreshBoundContextT (Proxy @(Type builtin)) x) Relevant
+runMonadBidirectional ctx relevance x =
+  runReaderT (runBoundContextT ctx x) relevance
 
 --------------------------------------------------------------------------------
 -- Checking
+
+-- | Checks that the given expression is of the provided type while
+-- generating the necessary constraints along the way, returning a well-typed
+-- version of the expression with the necessary implicit and instance arguments
+-- inserted.
+checkExprType ::
+  (MonadTypeChecker builtin m) =>
+  BoundCtx (Type builtin) ->
+  Relevance ->
+  Type builtin ->
+  Expr builtin ->
+  m (Expr builtin)
+checkExprType boundCtx relevance expectedType expr = do
+  runMonadBidirectional boundCtx relevance $ checkExpr expectedType expr
 
 -- | Checks that the given expression is of the provided type while
 -- generating the necessary constraints along the way, returning a well-typed
@@ -123,6 +143,15 @@ viaInfer expectedType expr = do
 --------------------------------------------------------------------------------
 -- Inference
 
+inferExprType ::
+  (MonadTypeChecker builtin m) =>
+  BoundCtx (Type builtin) ->
+  Relevance ->
+  Expr builtin ->
+  m (Expr builtin, Type builtin)
+inferExprType boundCtx relevance expr = do
+  runMonadBidirectional boundCtx relevance $ inferExpr expr
+
 -- | Takes in an unchecked expression and attempts to infer it's type.
 -- Returns the expression annotated with its type as well as the type itself.
 inferExpr ::
@@ -178,26 +207,13 @@ inferExpr e = do
       checkExprTypesEqual p typeOfBoundExpr (TypeUniverse p 0) typeOfBoundExprType
       let checkedBinder = replaceBinderType typeOfBoundExpr binder
 
+      -- Check that the expression being bound is correct.
+      checkedBoundExpr <- checkExpr typeOfBoundExpr boundExpr
+
       -- Check the type of the body, with the bound variable added to the context.
       (checkedBody, typeOfBody) <- addBinderToContext checkedBinder $ inferExpr body
 
-      -- Pretend the let expression is really a lambda application and use
-      -- the application machinary to infer the result type and the type of the bound expression.
-      (resultType, boundArgs) <-
-        inferArgs
-          (Lam p checkedBinder body, [Arg p Explicit Relevant boundExpr], Pi p checkedBinder typeOfBody)
-          (Pi p checkedBinder typeOfBody)
-          [Arg p Explicit Relevant boundExpr]
-
-      -- Extract the type of the bound expression
-      checkedBoundExpr <- case boundArgs of
-        [arg] -> return (argExpr arg)
-        _ ->
-          compilerDeveloperError $
-            "inference of type of let expression returned more than one argument:"
-              <+> prettyVerbose boundArgs
-
-      return (Let p checkedBoundExpr checkedBinder checkedBody, resultType)
+      return (Let p checkedBoundExpr checkedBinder checkedBody, typeOfBody)
     Lam p binder body -> do
       -- Infer the type of the bound variable from the binder
       (typeOfBinder, typeOfBinderType) <- inferExpr (typeOf binder)
@@ -220,84 +236,27 @@ inferExpr e = do
 -- or instance arguments and then returns the function applied to the full
 -- list of arguments as well as the result type.
 inferApp ::
+  forall builtin m.
   (MonadBidirectional builtin m) =>
   Expr builtin ->
   Type builtin ->
   [Arg builtin] ->
   m (Expr builtin, Type builtin)
 inferApp fun funType args = do
-  (appliedFunType, checkedArgs) <- inferArgs (fun, args, funType) funType args
-  return (normAppList fun checkedArgs, appliedFunType)
-
--- | Takes the expected type of a function and the user-provided arguments
--- and traverses through checking each argument type against the type of the
--- matching pi binder and inserting any required implicit/instance arguments.
--- Returns the type of the function when applied to the full list of arguments
--- (including inserted arguments) and that list of arguments.
-inferArgs ::
-  forall builtin m.
-  (MonadBidirectional builtin m) =>
-  (Expr builtin, [Arg builtin], Type builtin) -> -- The original function and its arguments
-  Type builtin -> -- Type of the function
-  [Arg builtin] -> -- User-provided arguments of the function
-  m (Type builtin, [Arg builtin])
-inferArgs original@(fun, _, _) piT@(Pi _ binder resultType) args
-  | isExplicit binder && null args = return (piT, [])
-  | otherwise = do
-      let p = provenanceOf fun
-      let visibility = visibilityOf binder
-
-      -- Determine whether we have an arg that matches the binder
-      (matchedUncheckedArg, remainingUncheckedArgs) <- case args of
-        [] -> return (Nothing, args)
-        (arg : remainingArgs)
-          | visibilityOf arg == visibility -> return (Just arg, remainingArgs)
-          | isExplicit binder -> do
-              boundCtx <- getNamedBoundCtx (Proxy @(Type builtin))
-              throwError $ TypingError $ MissingExplicitArgument boundCtx binder arg
-          | otherwise -> return (Nothing, args)
-
-      -- Calculate what the new checked arg should be, create a fresh meta
-      -- if no arg was matched above
-      checkedArg <- case matchedUncheckedArg of
-        Just arg -> do
-          let relevance = relevanceOf binder
-          checkedArgExpr <-
-            setCurrentRelevance (Proxy @builtin) relevance $
-              checkExpr (typeOf binder) (argExpr arg)
-          return $ Arg p visibility relevance checkedArgExpr
-        Nothing -> do
-          boundCtx <- getBoundCtx (Proxy @(Type builtin))
-          newArg <- instantiateArgForNonExplicitBinder boundCtx p original binder
-          return $ fmap unnormalised newArg
-
-      -- Substitute the checked arg through the result of the Pi type.
-      let substResultType = argExpr checkedArg `substDBInto` resultType
-
-      -- Recurse if necessary to check the remaining unchecked args
-      let needToRecurse = not (null remainingUncheckedArgs) || visibility /= Explicit
-      (typeAfterApplication, checkedArgs) <-
-        if needToRecurse
-          then inferArgs original substResultType remainingUncheckedArgs
-          else return (substResultType, [])
-
-      -- Return the result
-      return (typeAfterApplication, checkedArg : checkedArgs)
-inferArgs origin@(fun, originalArgs, _) nonPiType args =
-  case (nonPiType, args) of
-    (_, []) -> return (nonPiType, [])
-    (Meta {}, a : _) -> do
-      ctx <- getBoundCtx (Proxy @(Type builtin))
-      let p = provenanceOf nonPiType
-      typeMeta <- unnormalised <$> freshMetaExpr p (TypeUniverse p 0) ctx
-      let newBinder = Binder p (BinderDisplayForm OnlyType False) (visibilityOf a) (relevanceOf a) typeMeta
-      resultMeta <- unnormalised <$> freshMetaExpr p (TypeUniverse p 0) (newBinder : ctx)
-      let newType = Pi p newBinder resultMeta
-      checkExprTypesEqual p (argExpr a) nonPiType newType
-      inferArgs origin newType args
-    _ -> do
-      ctx <- getNamedBoundCtx (Proxy @(Type builtin))
-      throwError $ TypingError $ FunctionTypeMismatch ctx fun originalArgs nonPiType args
+  ctx <- getBoundCtx (Proxy @(Type builtin))
+  let insertionProblem =
+        ArgInsertionProblem
+          { originalFun = fun,
+            originalArgs = args,
+            originalType = funType,
+            checkedArgs = mempty,
+            currentExpectedType = funType,
+            uncheckedArgs = args
+          }
+  result <- solveArgInsertionProblem ctx insertionProblem
+  case result of
+    Left (problem, blockingMetas) -> createFreshApplicationConstraint ctx problem blockingMetas
+    Right r -> return r
 
 -------------------------------------------------------------------------------
 -- Utility functions
@@ -343,13 +302,108 @@ checkBinderTypesEqual p binderName expectedType actualType = do
 getCurrentRelevance :: (MonadBidirectional builtin m) => Proxy builtin -> m Relevance
 getCurrentRelevance _ = ask
 
-setCurrentRelevance ::
-  (MonadBidirectional builtin m) =>
-  Proxy builtin ->
-  Relevance ->
-  m c ->
-  m c
-setCurrentRelevance _ relevance = local (relevance <>)
+-------------------------------------------------------------------------------
+-- Arg insertion problem
+
+type ArgInsertionProblemSolution builtin =
+  Either (ArgInsertionProblem builtin, MetaSet) (Expr builtin, Type builtin)
+
+-- | Deals with insertion of missing implicits and instance arguments
+solveArgInsertionProblem ::
+  (MonadTypeChecker builtin m) =>
+  BoundCtx (Type builtin) ->
+  ArgInsertionProblem builtin ->
+  m (ArgInsertionProblemSolution builtin)
+solveArgInsertionProblem ctx problem@ArgInsertionProblem {..} = do
+  logDebug MaxDetail (line <> "checking-args" <+> prettyExternal (WithContext problem (toNamedBoundCtx ctx)))
+  -- First see if the unnormalised type is correct. Don't pre-emptively normalise as we want to keep as much
+  -- type information as we can.
+  case currentExpectedType of
+    -- If a standard Pi type then proceed to check against it (need to do this first before we check if args
+    -- are null, as it may be a non-explicit binder for which we do need to insert arguments even if the user
+    -- hasn't provided any)
+    Pi _ binder resultType -> checkArgsAgainstPiType ctx problem binder resultType
+    -- Otherwise if there are no unchecked arguments we have nothing to do.
+    _
+      | null uncheckedArgs -> argInsertionProblemSolved problem
+      | otherwise -> do
+          -- Force the current expected type to normalise
+          (forcedExpectedType, blockingMetas) <- forceApplicationHeadType ctx currentExpectedType
+          case forcedExpectedType of
+            -- If the forced expression is a `Pi` then well we've lost the user's types but we can proceed
+            Pi _ binder resultType -> checkArgsAgainstPiType ctx problem binder resultType
+            -- Otherwise if we are blocked on metas then we can postpone the problem until these metas are solved
+            _
+              | not (MetaSet.null blockingMetas) -> do
+                  let newProblem = ArgInsertionProblem {currentExpectedType = forcedExpectedType, ..}
+                  return $ Left (newProblem, blockingMetas)
+              -- Otherwise we're truely stuck and we error.
+              | otherwise -> do
+                  let boundCtx = toNamedBoundCtx ctx
+                  throwError $ TypingError $ FunctionTypeMismatch boundCtx originalFun originalArgs currentExpectedType uncheckedArgs
+
+forceApplicationHeadType ::
+  (MonadTypeChecker builtin m) =>
+  BoundCtx (Type builtin) ->
+  Type builtin ->
+  m (Type builtin, MetaSet)
+forceApplicationHeadType ctx typ = do
+  normType <- normaliseInEnv (boundContextToEnv ctx) typ
+  (forcedType, blockingMetas) <- forceHead (toNamedBoundCtx ctx) normType
+  return (quote (provenanceOf typ) (boundCtxLv ctx) forcedType, blockingMetas)
+
+checkArgsAgainstPiType ::
+  (MonadTypeChecker builtin m) =>
+  BoundCtx (Type builtin) ->
+  ArgInsertionProblem builtin ->
+  Binder builtin ->
+  Type builtin ->
+  m (ArgInsertionProblemSolution builtin)
+checkArgsAgainstPiType ctx problem binder resultType
+  | isExplicit binder && null (uncheckedArgs problem) = argInsertionProblemSolved problem
+  | otherwise = do
+      let visibility = visibilityOf binder
+
+      -- Determine whether we have an arg that matches the binder
+      let args = uncheckedArgs problem
+      (matchedUncheckedArg, remainingUncheckedArgs) <- case args of
+        [] -> return (Nothing, args)
+        (arg : remainingArgs)
+          | visibilityOf arg == visibility -> return (Just arg, remainingArgs)
+          | isExplicit binder -> throwError $ TypingError $ MissingExplicitArgument (toNamedBoundCtx ctx) binder arg
+          | otherwise -> return (Nothing, args)
+
+      -- Calculate what the new checked arg should be, create a fresh meta
+      -- if no arg was matched above
+      let originalFunction = originalFun problem
+      let p = provenanceOf originalFunction
+      checkedArg <- case matchedUncheckedArg of
+        Just arg -> do
+          logDebug MaxDetail $ "checking existing argument for binder" <+> prettyVerbose binder
+          let relevance = relevanceOf binder
+          checkedArgExpr <- checkExprType ctx relevance (typeOf binder) (argExpr arg)
+          return $ Arg p visibility relevance checkedArgExpr
+        Nothing -> do
+          logDebug MaxDetail $ "inserting argument for binder" <+> prettyVerbose binder
+          let original = (originalFunction, originalArgs problem, originalType problem)
+          newArg <- instantiateArgForNonExplicitBinder ctx p original binder
+          return $ fmap unnormalised newArg
+
+      -- Recurse if necessary to check the remaining unchecked args
+      let newProblem =
+            problem
+              { checkedArgs = checkedArg : checkedArgs problem,
+                currentExpectedType = argExpr checkedArg `substDBInto` resultType,
+                uncheckedArgs = remainingUncheckedArgs
+              }
+      solveArgInsertionProblem ctx newProblem
+
+argInsertionProblemSolved ::
+  (MonadTypeChecker builtin m) =>
+  ArgInsertionProblem builtin ->
+  m (ArgInsertionProblemSolution builtin)
+argInsertionProblemSolved problem@ArgInsertionProblem {..} =
+  return $ Right (solutionSoFar problem, currentExpectedType)
 
 --------------------------------------------------------------------------------
 -- Debug functions
@@ -359,20 +413,24 @@ currentPass = "bidirectional type-checking"
 
 showCheckEntry :: forall builtin m. (MonadBidirectional builtin m) => Type builtin -> Expr builtin -> m ()
 showCheckEntry t e = do
-  logDebug MaxDetail $ "check-entry" <+> prettyVerbose e <+> ":" <+> prettyVerbose t -- <+> "::::" <+> prettyVerbose ctx)
+  ctx <- getNamedBoundCtx (Proxy @(Type builtin))
+  logDebug MaxDetail $ "check-entry" <+> prettyExternal (WithContext e ctx) <+> ":" <+> prettyExternal (WithContext t ctx) -- <+> "::::" <+> prettyVerbose ctx)
   incrCallDepth
 
-showCheckExit :: (MonadBidirectional builtin m) => Expr builtin -> m ()
+showCheckExit :: forall builtin m. (MonadBidirectional builtin m) => Expr builtin -> m ()
 showCheckExit e = do
   decrCallDepth
-  logDebug MaxDetail $ "check-exit " <+> prettyVerbose e
+  ctx <- getNamedBoundCtx (Proxy @(Type builtin))
+  logDebug MaxDetail $ "check-exit " <+> prettyExternal (WithContext e ctx)
 
-showInferEntry :: (MonadBidirectional builtin m) => Expr builtin -> m ()
+showInferEntry :: forall builtin m. (MonadBidirectional builtin m) => Expr builtin -> m ()
 showInferEntry e = do
-  logDebug MaxDetail $ "infer-entry" <+> prettyVerbose e
+  ctx <- getNamedBoundCtx (Proxy @(Type builtin))
+  logDebug MaxDetail $ "infer-entry" <+> prettyExternal (WithContext e ctx)
   incrCallDepth
 
-showInferExit :: (MonadBidirectional builtin m) => (Expr builtin, Type builtin) -> m ()
+showInferExit :: forall builtin m. (MonadBidirectional builtin m) => (Expr builtin, Type builtin) -> m ()
 showInferExit (e, t) = do
   decrCallDepth
-  logDebug MaxDetail $ "infer-exit " <+> prettyVerbose e <+> ":" <+> prettyVerbose t
+  ctx <- getNamedBoundCtx (Proxy @(Type builtin))
+  logDebug MaxDetail $ "infer-exit " <+> prettyExternal (WithContext e ctx) <+> ":" <+> prettyExternal (WithContext t ctx)

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/ApplicationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/ApplicationSolver.hs
@@ -1,0 +1,41 @@
+module Vehicle.Compile.Type.Constraint.ApplicationSolver
+  ( runApplicationSolver,
+  )
+where
+
+import Data.Proxy (Proxy)
+import Vehicle.Compile.Prelude
+import Vehicle.Compile.Type.Bidirectional (solveArgInsertionProblem)
+import Vehicle.Compile.Type.Constraint.Core
+import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Type.Meta (MetaSet)
+import Vehicle.Compile.Type.Monad.Class
+import Vehicle.Compile.Type.System
+
+-- | Attempts to solve as many type-class constraints as possible. Takes in
+-- the set of meta-variables solved since the solver was last run and outputs
+-- the set of meta-variables solved during this run.
+runApplicationSolver :: forall builtin m. (TCM builtin m) => Proxy builtin -> MetaSet -> m ()
+runApplicationSolver _ metasSolved = do
+  logCompilerPass MaxDetail ("application solver run" <> line) $
+    runConstraintSolver @builtin
+      getActiveApplicationConstraints
+      setApplicationConstraints
+      solveApplicationConstraint
+      metasSolved
+
+solveApplicationConstraint ::
+  (TCM builtin m) =>
+  WithContext (ApplicationConstraint builtin) ->
+  m ()
+solveApplicationConstraint (WithContext InferArgs {..} ctx) = do
+  let boundCtx = boundContextOf ctx
+  result <- solveArgInsertionProblem boundCtx argInsertionProblem
+  case result of
+    Right (finalExpr, finalType) -> do
+      solveMeta typeSolutionMeta finalType boundCtx
+      solveMeta exprSolutionMeta finalExpr boundCtx
+    Left (blockedProblem, blockingMetas) -> do
+      let newConstraint = InferArgs {argInsertionProblem = blockedProblem, ..}
+      let finalConstraint = WithContext newConstraint (blockCtxOn blockingMetas ctx)
+      addApplicationConstraint finalConstraint

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -76,11 +76,10 @@ createInstanceUnification ::
   (ConstraintContext builtin, InstanceConstraintOrigin builtin) ->
   Value builtin ->
   Value builtin ->
-  m (WithContext (Constraint builtin))
+  m (WithContext (UnificationConstraint builtin))
 createInstanceUnification (ctx, origin) e1 e2 = do
   let unifyOrigin = CheckingInstanceType origin
-  constraint <- WithContext (Unify unifyOrigin e1 e2) <$> copyContext ctx
-  return $ mapObject UnificationConstraint constraint
+  WithContext (Unify unifyOrigin e1 e2) <$> copyContext ctx
 
 -- | Creates an instance constraint as a subgoal of an existing instance constraint.
 createSubInstance ::
@@ -88,14 +87,14 @@ createSubInstance ::
   (ConstraintContext builtin, InstanceConstraintOrigin builtin) ->
   Relevance ->
   Value builtin ->
-  m (Expr builtin, WithContext (Constraint builtin))
+  m (Expr builtin, WithContext (InstanceConstraint builtin))
 createSubInstance (ctx, origin) r t = do
   let p = provenanceOf ctx
   newCtx <- copyContext ctx
   let dbLevel = contextDBLevel ctx
   let newTypeClassExpr = quote p dbLevel t
   (meta, metaExpr) <- freshMetaIdAndExpr p newTypeClassExpr (boundContext ctx)
-  let newConstraint = InstanceConstraint (Resolve origin meta r t)
+  let newConstraint = Resolve origin meta r t
   return (unnormalised metaExpr, WithContext newConstraint newCtx)
 
 extractHeadFromInstanceCandidate ::

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/IndexSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/IndexSolver.hs
@@ -38,8 +38,8 @@ solveIndexConstraint constraint = do
           let solution = IUnitLiteral (provenanceOf ctx)
           solveMeta meta solution (boundContext ctx)
         Just metas -> do
-          let blockedConstraint = blockConstraintOn (mapObject InstanceConstraint normConstraint) metas
-          addConstraints [blockedConstraint]
+          let blockedConstraint = blockConstraintOn normConstraint metas
+          addInstanceConstraints [blockedConstraint]
     _ -> compilerDeveloperError $ "Malformed instance goal" <+> prettyFriendly normConstraint
 
 -- | Function signature for constraints solved by type class resolution.
@@ -126,6 +126,6 @@ solveDefaultIndexConstraint constraint = do
 
       let constraintInfo = (contextOf constraint, instanceOrigin $ objectIn constraint)
       newSizeConstraint <- createInstanceUnification constraintInfo size succN
-      addConstraints [newSizeConstraint]
+      addUnificationConstraints [newSizeConstraint]
       return True
     _ -> return False

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
@@ -68,7 +68,7 @@ getDefaultableConstraints ::
   Maybe (Decl builtin) ->
   m [WithContext (InstanceConstraint builtin)]
 getDefaultableConstraints maybeDecl = do
-  typeClassConstraints <- getActiveInstanceConstraints
+  instanceConstraints <- getActiveInstanceConstraints
   case maybeDecl of
     Just decl | not (isAbstractDecl decl) -> do
       -- We only want to generate default solutions for constraints
@@ -83,10 +83,10 @@ getDefaultableConstraints maybeDecl = do
         unsolvedMetasInTypeDoc <- prettyMetas (Proxy @builtin) typeMetas
         return $ "Metas transitively related to type-signature:" <+> unsolvedMetasInTypeDoc
 
-      flip filterM typeClassConstraints $ \tc -> do
+      flip filterM instanceConstraints $ \tc -> do
         constraintMetas <- metasIn (objectIn tc)
         return $ MetaSet.disjoint constraintMetas typeMetas
-    _ -> return typeClassConstraints
+    _ -> return instanceConstraints
 
 chooseDefaultConstraint ::
   forall builtin m.

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
@@ -18,6 +18,7 @@ import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Constraint.UnificationSolver (runUnificationSolver)
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
+import Vehicle.Compile.Type.Monad.Class (addInstanceConstraints)
 import Vehicle.Data.Code.Value
 import Vehicle.Data.DeBruijn (dbLevelToIndex)
 
@@ -91,10 +92,9 @@ solveInstanceGoal constraint rawBuiltinCandidates goal = do
     -- Otherwise there are still multiple valid candidates so we're forced to block.
     _ -> do
       logDebug MaxDetail "Multiple possible candidates found so deferring."
-      let newConstraint = mapObject InstanceConstraint constraint
       -- TODO can we be more precise with the set of blocking metas?
-      blockedConstraint <- blockConstraintOn newConstraint <$> getUnsolvedMetas (Proxy @builtin)
-      addConstraints [blockedConstraint]
+      blockedConstraint <- blockConstraintOn constraint <$> getUnsolvedMetas (Proxy @builtin)
+      addInstanceConstraints [blockedConstraint]
 
 -- | Locates any more candidates that are in the bound context of the constraint
 findCandidatesInBoundCtx ::
@@ -164,9 +164,11 @@ acceptCandidate (WithContext Resolve {..} constraintCtx) goal candidate = do
   -- Instantiate the candidate telescope with metas and subst into body.
   (substCandidateExpr, substCandidateSolution, recInstanceConstraints) <-
     instantiateCandidateTelescope goalCtxExtension (constraintCtx, instanceOrigin) candidate
+  addInstanceConstraints recInstanceConstraints
 
   -- Unify the goal and candidate bodies
   unificationConstraint <- createInstanceUnification extendedGoalInfo (goalExpr goal) substCandidateExpr
+  addUnificationConstraints [unificationConstraint]
 
   -- Replace the provenance of the final solution with the provenance of where the
   -- constraint was generated. This is needed to get the information to propagate
@@ -178,8 +180,6 @@ acceptCandidate (WithContext Resolve {..} constraintCtx) goal candidate = do
   -- then we wouldn't need to do this manually).
   solveMeta instanceSolutionMeta finalCandidateSolution extendedGoalCtx
 
-  addConstraints (unificationConstraint : recInstanceConstraints)
-
 -- | Generate meta variables for each binder in the telescope of the candidate
 -- and then substitute them into the candidate expression.
 instantiateCandidateTelescope ::
@@ -188,7 +188,7 @@ instantiateCandidateTelescope ::
   BoundCtx (Type builtin) ->
   InstanceConstraintInfo builtin ->
   WithContext (InstanceCandidate builtin) ->
-  m (Value builtin, Expr builtin, [WithContext (Constraint builtin)])
+  m (Value builtin, Expr builtin, [WithContext (InstanceConstraint builtin)])
 instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin) candidate = do
   let WithContext InstanceCandidate {..} candidateCtx = candidate
   logCompilerSection MaxDetail "instantiating candidate telescope" $ do
@@ -200,8 +200,8 @@ instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin)
   where
     go ::
       (MonadInstance builtin m) =>
-      (Type builtin, Expr builtin, [WithContext (Constraint builtin)], BoundCtx (Type builtin)) ->
-      m (Type builtin, Expr builtin, [WithContext (Constraint builtin)], BoundCtx (Type builtin))
+      (Type builtin, Expr builtin, [WithContext (InstanceConstraint builtin)], BoundCtx (Type builtin)) ->
+      m (Type builtin, Expr builtin, [WithContext (InstanceConstraint builtin)], BoundCtx (Type builtin))
     go = \case
       (Pi _ exprBinder exprBody, Lam _ _solutionBinder solutionBody, constraints, boundCtx) -> do
         let binderType = typeOf exprBinder

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/LinearitySolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/LinearitySolver.hs
@@ -10,8 +10,8 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
-import Vehicle.Compile.Type.Monad (MonadTypeChecker)
-import Vehicle.Compile.Type.Monad.Class (addConstraints, solveMeta, substMetas)
+import Vehicle.Compile.Type.Monad (MonadTypeChecker, addUnificationConstraints)
+import Vehicle.Compile.Type.Monad.Class (addInstanceConstraints, solveMeta, substMetas)
 import Vehicle.Data.Builtin.Core
 import Vehicle.Data.Builtin.Linearity
 import Vehicle.Data.Code.Interface
@@ -64,7 +64,7 @@ solveQuantifierLinearity _ info@(ctx, _) [VPi binder closure, res] = Just $ do
   domEq <- createInstanceUnification info (typeOf binder) domainLin
   resultType <- normaliseClosure (contextDBLevel ctx) binder closure
   resEq <- createInstanceUnification info res resultType
-  return $ Progress [domEq, resEq]
+  return $ Progress [domEq, resEq] []
 solveQuantifierLinearity _ _ _ = Nothing
 
 solveOp2Linearity ::
@@ -81,15 +81,15 @@ solveOp2Linearity shortCircuitLHS shortCircuitRHS combine info@(ctx, _) [lin1, l
       logDebug MaxDetail $ pretty $ show l2
       logDebug MaxDetail $ pretty $ show $ combine p l1 l2
       resEq <- createInstanceUnification info res linRes
-      return $ Progress [resEq]
+      return $ Progress [resEq] []
     (VLinearityExpr Constant, _)
       | shortCircuitLHS -> Just $ do
           resEq <- createInstanceUnification info lin2 res
-          return $ Progress [resEq]
+          return $ Progress [resEq] []
     (_, VLinearityExpr Constant)
       | shortCircuitRHS -> Just $ do
           resEq <- createInstanceUnification info lin1 res
-          return $ Progress [resEq]
+          return $ Progress [resEq] []
     (getNMeta -> Just m1, _) -> blockOn [m1]
     (_, getNMeta -> Just m2) -> blockOn [m2]
     _ -> Nothing
@@ -103,7 +103,7 @@ solveFunctionLinearity functionPosition info@(ctx, _) [arg, res] = case arg of
     let addFuncProv pp = LinFunctionProvenance p pp functionPosition
     let resLin = VLinearityExpr $ mapLinearityProvenance addFuncProv lin
     resEq <- createInstanceUnification info res resLin
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   _ -> Nothing
 solveFunctionLinearity _ _ _ = Nothing
 
@@ -150,12 +150,11 @@ handleConstraintProgress ::
   ConstraintProgress LinearityBuiltin ->
   m ()
 handleConstraintProgress originalConstraint@(WithContext (Resolve _ m _ _) ctx) = \case
-  Stuck metas -> do
-    let blockedConstraint = blockConstraintOn (mapObject InstanceConstraint originalConstraint) metas
-    addConstraints [blockedConstraint]
-  Progress newConstraints -> do
+  Stuck metas -> addInstanceConstraints [blockConstraintOn originalConstraint metas]
+  Progress newUnificationConstraints newInstanceConstraints -> do
     solveMeta m (IUnitLiteral (provenanceOf ctx)) (boundContext ctx)
-    addConstraints newConstraints
+    addUnificationConstraints newUnificationConstraints
+    addInstanceConstraints newInstanceConstraints
 
 getTypeClass :: (MonadCompile m) => Value LinearityBuiltin -> m (LinearityRelation, Spine LinearityBuiltin)
 getTypeClass = \case

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/PolaritySolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/PolaritySolver.hs
@@ -12,6 +12,7 @@ import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Constraint.Core
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
+import Vehicle.Compile.Type.Monad.Class (addInstanceConstraints)
 import Vehicle.Data.Builtin.Core
 import Vehicle.Data.Builtin.Polarity
 import Vehicle.Data.Code.Interface
@@ -62,7 +63,7 @@ solveNegPolarity info@(ctx, _) [arg1, res] = case arg1 of
   VPolarityExpr pol -> Just $ do
     let resPol = VPolarityExpr $ negatePolarity (provenanceOf ctx) pol
     resEq <- createInstanceUnification info res resPol
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   _ -> Nothing
 solveNegPolarity _ _ = Nothing
 
@@ -75,7 +76,7 @@ solveQuantifierPolarity q info@(ctx, _) [lam, res] = case lam of
     let lv = contextDBLevel ctx
     resultPolarity <- normaliseClosure lv binder resPol
     (_, addConstraint) <- createSubInstance info Irrelevant (VBuiltin tc (explicit <$> [resultPolarity, res]))
-    return $ Progress [binderEq, addConstraint]
+    return $ Progress [binderEq] [addConstraint]
   _ -> Nothing
 solveQuantifierPolarity _ _c _ = Nothing
 
@@ -86,7 +87,7 @@ solveAddPolarityOp q info@(ctx, _) [arg, res] = case arg of
     let p = originalProvenance ctx
     let resPol = VPolarityExpr $ addPolarityOp p q inputPol
     domEq <- createInstanceUnification info res resPol
-    return $ Progress [domEq]
+    return $ Progress [domEq] []
   _ -> Nothing
 solveAddPolarityOp _ _ _ = Nothing
 
@@ -95,13 +96,13 @@ solveMaxPolarityOp info [arg1, arg2, res] = case (arg1, arg2) of
   (VPolarityExpr pol1, VPolarityExpr pol2) -> Just $ do
     let pol3 = VPolarityExpr $ maxPolarityOp pol1 pol2
     resEq <- createInstanceUnification info res pol3
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   (_, VPolarityExpr Unquantified) -> Just $ do
     resEq <- createInstanceUnification info arg1 res
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   (VPolarityExpr Unquantified, _) -> Just $ do
     resEq <- createInstanceUnification info arg2 res
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   (getNMeta -> Just m1, _) -> blockOn [m1]
   (_, getNMeta -> Just m2) -> blockOn [m2]
   _ -> Nothing
@@ -112,7 +113,7 @@ solveEqPolarity eq info@(ctx, _) [arg1, arg2, res] = case (arg1, arg2) of
   (VPolarityExpr pol1, VPolarityExpr pol2) -> Just $ do
     let pol3 = VPolarityExpr $ eqPolarityOp eq (provenanceOf ctx) pol1 pol2
     resEq <- createInstanceUnification info res pol3
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   (getNMeta -> Just m1, _) -> blockOn [m1]
   (_, getNMeta -> Just m2) -> blockOn [m2]
   _ -> Nothing
@@ -123,7 +124,7 @@ solveImplPolarity info@(ctx, _) [arg1, arg2, res] = case (arg1, arg2) of
   (VPolarityExpr pol1, VPolarityExpr pol2) -> Just $ do
     let pol3 = VPolarityExpr $ implPolarityOp (provenanceOf ctx) pol1 pol2
     resEq <- createInstanceUnification info res pol3
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   (getNMeta -> Just m1, _) -> blockOn [m1]
   (_, getNMeta -> Just m2) -> blockOn [m2]
   _ -> Nothing
@@ -137,7 +138,7 @@ solveFunctionPolarity functionPosition info@(ctx, _) [arg, res] = case (arg, res
     let addFuncProv pp = PolFunctionProvenance p pp functionPosition
     let pol3 = VPolarityExpr $ mapPolarityProvenance addFuncProv pol
     resEq <- createInstanceUnification info res pol3
-    return $ Progress [resEq]
+    return $ Progress [resEq] []
   (VPi binder1 closure1, VPi binder2 closure2) -> Just $ do
     let tc = PolarityRelation $ FunctionPolarity functionPosition
     (_, binderConstraint) <- createSubInstance info Irrelevant (VBuiltin tc (explicit <$> [typeOf binder1, typeOf binder2]))
@@ -145,7 +146,7 @@ solveFunctionPolarity functionPosition info@(ctx, _) [arg, res] = case (arg, res
     body1 <- normaliseClosure lv binder1 closure1
     body2 <- normaliseClosure lv binder2 closure2
     (_, bodyConstraint) <- createSubInstance info Irrelevant (VBuiltin tc (explicit <$> [body1, body2]))
-    return $ Progress [binderConstraint, bodyConstraint]
+    return $ Progress [] [binderConstraint, bodyConstraint]
   _ -> Nothing
 solveFunctionPolarity _ _ _ = Nothing
 
@@ -234,12 +235,11 @@ handleConstraintProgress ::
   ConstraintProgress PolarityBuiltin ->
   m ()
 handleConstraintProgress originalConstraint@(WithContext (Resolve _ m _ _) ctx) = \case
-  Stuck metas -> do
-    let blockedConstraint = blockConstraintOn (mapObject InstanceConstraint originalConstraint) metas
-    addConstraints [blockedConstraint]
-  Progress newConstraints -> do
+  Stuck metas -> addInstanceConstraints [blockConstraintOn originalConstraint metas]
+  Progress newUnificationConstraints newInstanceConstraints -> do
     solveMeta m (IUnitLiteral (provenanceOf ctx)) (boundContext ctx)
-    addConstraints newConstraints
+    addUnificationConstraints newUnificationConstraints
+    addInstanceConstraints newInstanceConstraints
 
 getTypeClass :: (MonadCompile m) => Value PolarityBuiltin -> m (PolarityRelation, Spine PolarityBuiltin)
 getTypeClass = \case

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -76,9 +76,9 @@ solve ::
   m (UnificationResult builtin)
 solve (WithContext (Unify origin e1 e2) ctx) = do
   -- Force the heads of both expressions
-  metaSubst <- getMetaSubstitution (Proxy @builtin)
-  (ne1, e1BlockingMetas) <- forceHead metaSubst ctx e1
-  (ne2, e2BlockingMetas) <- forceHead metaSubst ctx e2
+  let namedCtx = namedBoundCtxOf ctx
+  (ne1, e1BlockingMetas) <- forceHead namedCtx e1
+  (ne2, e2BlockingMetas) <- forceHead namedCtx e2
 
   -- Construct the new constraint information
   let blockingMetas = e1BlockingMetas <> e2BlockingMetas
@@ -211,20 +211,17 @@ solveClosure ::
   (VBinder builtin, Closure builtin) ->
   (VBinder builtin, Closure builtin) ->
   m (UnificationResult builtin)
-solveClosure info@(WithContext constraint ctx, blockingMeta) (binder1, Closure env1 body1) (binder2, Closure env2 body2) = do
+solveClosure info@(constraint, _) (binder1, Closure env1 body1) (binder2, Closure env2 body2) = do
   -- Unify binder constraints
   binderConstraint <- subUnify info (typeOf binder1, typeOf binder2)
 
   -- Evaluate the normalised bodies of the lambdas
-  let lv = contextDBLevel ctx
+  let lv = contextDBLevel (contextOf constraint)
   nbody1 <- normaliseInEnv (extendEnvWithBound lv binder1 env1) body1
   nbody2 <- normaliseInEnv (extendEnvWithBound lv binder2 env2) body2
 
   -- Update the context.
-  -- NOTE: that we have to unnormalise here indicates something is wrong.
-  let unnormBinder = fmap (unnormalise lv) binder1
-  let newCtx = updateConstraintBoundCtx ctx (unnormBinder :)
-  let updatedInfo = (WithContext constraint newCtx, blockingMeta)
+  let updatedInfo = updateInfoUnderBinder info (binder1, binder2)
 
   -- Unify the two bodies
   bodyConstraint <- subUnify updatedInfo (nbody1, nbody2)
@@ -354,6 +351,17 @@ createMetaWithRestrictedDependencies ctx meta newDependencies = do
     solveMeta meta substMetaExpr (boundContext ctx)
 
     return $ normalised newMetaExpr
+
+updateInfoUnderBinder ::
+  ConstraintInfo builtin ->
+  (VBinder builtin, VBinder builtin) ->
+  ConstraintInfo builtin
+updateInfoUnderBinder (WithContext constraint ctx, blockingMeta) (binder1, _binder2) = do
+  -- Update the context.
+  -- NOTE: that we have to unnormalise here indicates something is wrong.
+  let unnormBinder = fmap (unnormalise (contextDBLevel ctx)) binder1
+  let newCtx = updateConstraintBoundCtx ctx (unnormBinder :)
+  (WithContext constraint newCtx, blockingMeta)
 
 --------------------------------------------------------------------------------
 -- Argument patterns

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -2,7 +2,6 @@
 
 module Vehicle.Compile.Type.Core where
 
-import Data.Bifunctor (Bifunctor (..))
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as Map (findWithDefault, lookup)
 import Data.Hashable (Hashable)
@@ -111,6 +110,36 @@ contextDBLevel :: ConstraintContext builtin -> Lv
 contextDBLevel = Lv . length . boundContext
 
 --------------------------------------------------------------------------------
+-- Application constraints
+
+-- | A constraint that says when the unchecked arguments to the function are correctly
+-- augmented with the suitable missing implicits and instance arguments, then it has
+-- the current expected type.
+data ArgInsertionProblem builtin = ArgInsertionProblem
+  { originalFun :: Expr builtin,
+    originalArgs :: [Arg builtin],
+    originalType :: Type builtin,
+    checkedArgs :: [Arg builtin],
+    currentExpectedType :: Type builtin,
+    uncheckedArgs :: [Arg builtin]
+  }
+  deriving (Show)
+
+data ApplicationConstraint builtin = InferArgs
+  { typeSolutionMeta :: MetaID,
+    exprSolutionMeta :: MetaID,
+    argInsertionProblem :: ArgInsertionProblem builtin
+  }
+  deriving (Show)
+
+solutionSoFar :: ArgInsertionProblem builtin -> Expr builtin
+solutionSoFar ArgInsertionProblem {..} = normAppList originalFun (reverse checkedArgs)
+
+type instance
+  WithContext (ApplicationConstraint builtin) =
+    Contextualised (ApplicationConstraint builtin) (ConstraintContext builtin)
+
+--------------------------------------------------------------------------------
 -- Instance constraints
 
 data InstanceConstraintOrigin builtin = InstanceConstraintOrigin
@@ -217,6 +246,8 @@ data Constraint builtin
     UnificationConstraint (UnificationConstraint builtin)
   | -- | Represents that the provided type must have the required functionality
     InstanceConstraint (InstanceConstraint builtin)
+  | -- | Represents that
+    ApplicationConstraint (ApplicationConstraint builtin)
   deriving (Show)
 
 type instance
@@ -227,12 +258,6 @@ getTypeClassConstraint :: WithContext (Constraint builtin) -> Maybe (WithContext
 getTypeClassConstraint (WithContext constraint ctx) = case constraint of
   InstanceConstraint tc -> Just (WithContext tc ctx)
   _ -> Nothing
-
-separateConstraints :: [WithContext (Constraint builtin)] -> ([WithContext (UnificationConstraint builtin)], [WithContext (InstanceConstraint builtin)])
-separateConstraints [] = ([], [])
-separateConstraints (WithContext c ctx : cs) = case c of
-  UnificationConstraint uc -> first (WithContext uc ctx :) (separateConstraints cs)
-  InstanceConstraint tc -> second (WithContext tc ctx :) (separateConstraints cs)
 
 blockConstraintOn ::
   Contextualised c (ConstraintContext builtin) ->
@@ -251,11 +276,11 @@ constraintIsBlocked solvedMetas c = isBlocked solvedMetas (contextOf c)
 
 data ConstraintProgress builtin
   = Stuck MetaSet
-  | Progress [WithContext (Constraint builtin)]
+  | Progress [WithContext (UnificationConstraint builtin)] [WithContext (InstanceConstraint builtin)]
   deriving (Show)
 
 instance Semigroup (ConstraintProgress builtin) where
   Stuck m1 <> Stuck m2 = Stuck (m1 <> m2)
   Stuck {} <> x@Progress {} = x
   x@Progress {} <> Stuck {} = x
-  Progress r1 <> Progress r2 = Progress (r1 <> r2)
+  Progress u1 r1 <> Progress u2 r2 = Progress (u1 <> u2) (r1 <> r2)

--- a/vehicle/src/Vehicle/Compile/Type/Force.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Force.hs
@@ -3,45 +3,45 @@
 {-# HLINT ignore "Use <|>" #-}
 module Vehicle.Compile.Type.Force where
 
+import Data.Data (Proxy (..))
 import Data.Maybe (fromMaybe)
-import Vehicle.Compile.Context.Free
 import Vehicle.Compile.Normalise.Builtin (NormalisableBuiltin (..))
 import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Print (prettyFriendly, prettyVerbose)
-import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Meta.Map qualified as MetaMap (lookup)
 import Vehicle.Compile.Type.Meta.Set qualified as MetaSet (singleton, unions)
+import Vehicle.Compile.Type.Monad (MonadTypeChecker)
+import Vehicle.Compile.Type.Monad.Class (getMetaSubstitution)
 import Vehicle.Data.Code.Value
 
 -----------------------------------------------------------------------------
 -- Meta-variable forcing
 
 type MonadForce builtin m =
-  ( MonadFreeContext builtin m,
+  ( MonadTypeChecker builtin m,
     NormalisableBuiltin builtin
   )
 
 -- | Recursively forces the evaluation of any meta-variables at the head
 -- of the expresson.
 forceHead ::
+  forall builtin m.
   (MonadForce builtin m) =>
-  MetaSubstitution builtin ->
-  ConstraintContext builtin ->
+  NamedBoundCtx ->
   Value builtin ->
   m (Value builtin, MetaSet)
-forceHead subst ctx expr = do
-  (maybeForcedExpr, blockingMetas) <- forceExpr subst expr
+forceHead ctx expr = do
+  (maybeForcedExpr, blockingMetas) <- forceExpr expr
   forcedExpr <- case maybeForcedExpr of
     Nothing -> return expr
     Just forcedExpr -> do
-      let dbCtx = namedBoundCtxOf ctx
       logDebug MaxDetail $
         "forced"
-          <+> prettyFriendly (WithContext expr dbCtx)
+          <+> prettyFriendly (WithContext expr ctx)
           <+> "to"
-          <+> prettyFriendly (WithContext forcedExpr dbCtx)
+          <+> prettyFriendly (WithContext forcedExpr ctx)
       return forcedExpr
   return (forcedExpr, blockingMetas)
 
@@ -49,66 +49,62 @@ forceHead subst ctx expr = do
 -- evaluation.
 forceExpr ::
   (MonadForce builtin m) =>
-  MetaSubstitution builtin ->
   Value builtin ->
   m (Maybe (Value builtin), MetaSet)
-forceExpr subst = \case
-  VMeta m spine -> forceMeta subst m spine
-  VBuiltin b spine -> forceBuiltin subst b spine
+forceExpr = \case
+  VMeta m spine -> forceMeta m spine
+  VBuiltin b spine -> forceBuiltin b spine
   _ -> return (Nothing, mempty)
 
 forceMeta ::
+  forall builtin m.
   (MonadForce builtin m) =>
-  MetaSubstitution builtin ->
   MetaID ->
   Spine builtin ->
   m (Maybe (Value builtin), MetaSet)
-forceMeta subst m spine = do
+forceMeta m spine = do
+  subst <- getMetaSubstitution (Proxy @builtin)
   case MetaMap.lookup m subst of
     Just solution -> do
       normMetaExpr <- normaliseApp (normalised solution) spine
-      (maybeForcedExpr, blockingMetas) <- forceExpr subst normMetaExpr
+      (maybeForcedExpr, blockingMetas) <- forceExpr normMetaExpr
       let forcedExpr = maybe (Just normMetaExpr) Just maybeForcedExpr
       return (forcedExpr, blockingMetas)
     Nothing -> return (Nothing, MetaSet.singleton m)
 
 forceArg ::
   (MonadForce builtin m) =>
-  MetaSubstitution builtin ->
   VArg builtin ->
   m (Maybe (VArg builtin), MetaSet)
-forceArg subst arg = do
-  (maybeResult, blockingMetas) <- unpairArg <$> traverse (forceExpr subst) arg
+forceArg arg = do
+  (maybeResult, blockingMetas) <- unpairArg <$> traverse forceExpr arg
   return (sequenceA maybeResult, blockingMetas)
 
 forceBuiltin ::
   (MonadForce builtin m) =>
-  MetaSubstitution builtin ->
   builtin ->
   Spine builtin ->
   m (Maybe (Value builtin), MetaSet)
-forceBuiltin subst b spine = do
-  (maybeUnblockedSpine, blockingMetas) <- forceBuiltinSpine subst spine 0 (blockingArgs b)
+forceBuiltin b spine = do
+  (maybeUnblockedSpine, blockingMetas) <- forceBuiltinSpine spine 0 (blockingArgs b)
   finalValue <- traverse (normaliseBuiltin b) maybeUnblockedSpine
   return (finalValue, blockingMetas)
 
 forceBuiltinSpine ::
   (MonadForce builtin m) =>
-  MetaSubstitution builtin ->
   Spine builtin ->
   Int ->
   [Int] ->
   m (Maybe (Spine builtin), MetaSet)
-forceBuiltinSpine _subst [] _currentIndex _blockingArgs = return (Nothing, mempty)
-forceBuiltinSpine _subst _args _currentIndex [] = return (Nothing, mempty)
-forceBuiltinSpine subst (arg : args) currentIndex (blockingIndex : blockingIndices) = do
-  (maybeUnblockedArgs, argsBlockingMetas) <- forceBuiltinSpine subst args (currentIndex + 1) (blockingIndex : blockingIndices)
-  logDebug MaxDetail $ pretty currentIndex <+> pretty blockingIndex <+> prettyVerbose arg
+forceBuiltinSpine [] _currentIndex _blockingArgs = return (Nothing, mempty)
+forceBuiltinSpine _args _currentIndex [] = return (Nothing, mempty)
+forceBuiltinSpine (arg : args) currentIndex (blockingIndex : blockingIndices) = do
+  (maybeUnblockedArgs, argsBlockingMetas) <- forceBuiltinSpine args (currentIndex + 1) (blockingIndex : blockingIndices)
 
   if currentIndex /= blockingIndex
     then return ((arg :) <$> maybeUnblockedArgs, argsBlockingMetas)
     else do
-      (maybeUnblockedArg, argBlockingMetas) <- forceArg subst arg
+      (maybeUnblockedArg, argBlockingMetas) <- forceArg arg
       let newBlockingMetas = MetaSet.unions [argBlockingMetas, argsBlockingMetas]
       let newFinalArgs = case maybeUnblockedArg of
             Just unblockedArg -> Just (unblockedArg : fromMaybe args maybeUnblockedArgs)

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -112,6 +112,9 @@ instance (MetaSubstitutable m builtin expr) => MetaSubstitutable m builtin (Gene
 instance (MetaSubstitutable m builtin expr) => MetaSubstitutable m builtin (GenericProg expr) where
   subst s (Main ds) = Main <$> traverse (subst s) ds
 
+instance MetaSubstitutable m builtin (ApplicationConstraint builtin) where
+  subst s (InferArgs m1 m2 insertionProblem) = InferArgs m1 m2 <$> subst s insertionProblem
+
 instance MetaSubstitutable m builtin (UnificationConstraint builtin) where
   subst s (Unify origin e1 e2) = Unify <$> subst s origin <*> subst s e1 <*> subst s e2
 
@@ -133,11 +136,22 @@ instance MetaSubstitutable m builtin (Constraint builtin) where
   subst s = \case
     UnificationConstraint c -> UnificationConstraint <$> subst s c
     InstanceConstraint c -> InstanceConstraint <$> subst s c
+    ApplicationConstraint c -> ApplicationConstraint <$> subst s c
 
 instance (MetaSubstitutable m builtin constraint) => MetaSubstitutable m builtin (Contextualised constraint (ConstraintContext builtin)) where
   subst s (WithContext constraint context) = do
     newConstraint <- subst s constraint
     return $ WithContext newConstraint context
+
+instance MetaSubstitutable m builtin (ArgInsertionProblem builtin) where
+  subst s (ArgInsertionProblem originalFun originalArgs originalType checkedArgs currentExpectedType uncheckedArgs) =
+    ArgInsertionProblem
+      <$> subst s originalFun
+      <*> subst s originalArgs
+      <*> subst s originalType
+      <*> subst s checkedArgs
+      <*> subst s currentExpectedType
+      <*> subst s uncheckedArgs
 
 instance MetaSubstitutable m builtin (InstanceConstraintOrigin builtin) where
   subst s (InstanceConstraintOrigin tcOp tcOpArgs tcOpType tc) =

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -149,7 +149,17 @@ instance HasMetas (InstanceConstraint builtin) where
 instance HasMetas (UnificationConstraint builtin) where
   findMetas (Unify _ e1 e2) = do findMetas e1; findMetas e2
 
+instance HasMetas (ArgInsertionProblem builtin) where
+  findMetas ArgInsertionProblem {..} = do
+    findMetas originalFun
+    findMetas checkedArgs
+    findMetas uncheckedArgs
+
+instance HasMetas (ApplicationConstraint builtin) where
+  findMetas (InferArgs _ _ insertionProblem) = findMetas insertionProblem
+
 instance HasMetas (Constraint builtin) where
   findMetas = \case
     UnificationConstraint c -> findMetas c
     InstanceConstraint c -> findMetas c
+    ApplicationConstraint c -> findMetas c

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -24,12 +24,12 @@ module Vehicle.Compile.Type.Monad
     copyContext,
     createFreshUnificationConstraint,
     createFreshInstanceConstraint,
+    createFreshApplicationConstraint,
     getActiveConstraints,
     getActiveUnificationConstraints,
     getActiveInstanceConstraints,
     setInstanceConstraints,
     setUnificationConstraints,
-    addConstraints,
     addUnificationConstraints,
     -- Other
     clearMetaCtx,
@@ -47,6 +47,7 @@ import Vehicle.Compile.Normalise.NBE
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Builtin (TypableBuiltin (..))
 import Vehicle.Compile.Type.Core
+import Vehicle.Compile.Type.Meta (MetaSet)
 import Vehicle.Compile.Type.Monad.Class
 import Vehicle.Compile.Type.Monad.Instance
 import Vehicle.Data.Code.Value
@@ -106,6 +107,51 @@ freshMetaExpr ::
   m (GluedExpr builtin)
 freshMetaExpr p t boundCtx = snd <$> freshMetaIdAndExpr p t boundCtx
 
+-- | Adds an entirely new unification constraint (as opposed to one
+-- derived from another constraint).
+createFreshUnificationConstraint ::
+  forall builtin m.
+  (MonadTypeChecker builtin m) =>
+  Provenance ->
+  BoundCtx (Type builtin) ->
+  UnificationConstraintOrigin builtin ->
+  Type builtin ->
+  Type builtin ->
+  m ()
+createFreshUnificationConstraint p ctx origin expectedType actualType = do
+  let env = boundContextToEnv ctx
+  normExpectedType <- normaliseInEnv env expectedType
+  normActualType <- normaliseInEnv env actualType
+  context <- createFreshConstraintCtx p p ctx
+  let unification = Unify origin normExpectedType normActualType
+  let constraint = WithContext unification context
+
+  addUnificationConstraints [constraint]
+
+createFreshApplicationConstraint ::
+  forall builtin m.
+  (MonadTypeChecker builtin m) =>
+  BoundCtx (Type builtin) ->
+  ArgInsertionProblem builtin ->
+  MetaSet ->
+  m (Expr builtin, Type builtin)
+createFreshApplicationConstraint ctx problem blockingMetas = do
+  let p = provenanceOf $ originalFun problem
+  (typeMeta, finalType) <- freshMetaIdAndExpr p (TypeUniverse p 0) ctx
+  (exprMeta, finalExpr) <- freshMetaIdAndExpr p (unnormalised finalType) ctx
+
+  let constraint =
+        InferArgs
+          { exprSolutionMeta = exprMeta,
+            typeSolutionMeta = typeMeta,
+            argInsertionProblem = problem
+          }
+
+  context <- createFreshConstraintCtx p p ctx
+  let blockedConstraint = WithContext constraint (blockCtxOn blockingMetas context)
+  addApplicationConstraint blockedConstraint
+  return (unnormalised finalExpr, unnormalised finalType)
+
 -- | Adds an entirely new type-class constraint (as opposed to one
 -- derived from another constraint).
 createFreshInstanceConstraint ::
@@ -131,8 +177,7 @@ createFreshInstanceConstraint boundCtx (fun, funArgs, funType) relevance tcExpr 
   (meta, metaExpr) <- freshMetaIdAndExpr p tcExpr boundCtx
 
   let originProvenance = provenanceOf tcExpr
-  cid <- generateFreshConstraintID (Proxy @builtin)
-  let context = ConstraintContext cid originProvenance p unknownBlockingStatus boundCtx
+  context <- createFreshConstraintCtx originProvenance p boundCtx
   nTCExpr <- normaliseInEnv env tcExpr
   let constraint = WithContext (Resolve origin meta relevance nTCExpr) context
 

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -7,6 +7,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Writer (WriterT (..))
 import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
+import Prettyprinter (fill)
 import Vehicle.Compile.Context.Bound.Instance
 import Vehicle.Compile.Context.Free.Class (MonadFreeContext)
 import Vehicle.Compile.Error (MonadCompile, compilerDeveloperError)
@@ -69,8 +70,9 @@ data TypeCheckerState builtin = TypeCheckerState
     -- NB: these are stored in *reverse* order from which they were created.
     metaInfo :: [MetaInfo builtin],
     currentSubstitution :: MetaSubstitution builtin,
+    applicationConstraints :: [WithContext (ApplicationConstraint builtin)],
     unificationConstraints :: [WithContext (UnificationConstraint builtin)],
-    typeClassConstraints :: [WithContext (InstanceConstraint builtin)],
+    instanceConstraints :: [WithContext (InstanceConstraint builtin)],
     freshNameState :: FreshNameState,
     solvedMetaState :: SolvedMetaState,
     nextConstraintID :: ConstraintID
@@ -81,8 +83,9 @@ emptyTypeCheckerState =
   TypeCheckerState
     { metaInfo = mempty,
       currentSubstitution = mempty,
+      applicationConstraints = mempty,
       unificationConstraints = mempty,
-      typeClassConstraints = mempty,
+      instanceConstraints = mempty,
       freshNameState = 0,
       solvedMetaState = SolvedMetaState mempty,
       nextConstraintID = 0
@@ -372,7 +375,7 @@ prettyMetas _ metas = do
   return $ prettySetLike docs
 
 prettyMeta :: forall builtin m a. (MonadTypeChecker builtin m) => Proxy builtin -> MetaID -> m (Doc a)
-prettyMeta _ meta = prettyMetaInternal meta <$> getMetaType @builtin meta
+prettyMeta _ meta = fill 3 . prettyMetaInternal meta <$> getMetaType @builtin meta
 
 prettyMetaInternal :: (PrintableBuiltin builtin) => MetaID -> Type builtin -> Doc a
 prettyMetaInternal m t = pretty m <+> ":" <+> prettyVerbose t
@@ -396,43 +399,50 @@ generateFreshConstraintID _ = do
     TypeCheckerState {nextConstraintID = nextConstraintID + 1, ..}
   return freshID
 
+createFreshConstraintCtx ::
+  forall builtin m.
+  (MonadTypeChecker builtin m) =>
+  Provenance ->
+  Provenance ->
+  BoundCtx (Type builtin) ->
+  m (ConstraintContext builtin)
+createFreshConstraintCtx originalProvenance creationProvenance ctx = do
+  cid <- generateFreshConstraintID (Proxy @builtin)
+  return $ ConstraintContext cid originalProvenance creationProvenance unknownBlockingStatus ctx
+
 getActiveConstraints :: (MonadTypeChecker builtin m) => m [WithContext (Constraint builtin)]
 getActiveConstraints = do
   us <- fmap (mapObject UnificationConstraint) <$> getActiveUnificationConstraints
   ts <- fmap (mapObject InstanceConstraint) <$> getActiveInstanceConstraints
-  return $ us <> ts
+  as <- fmap (mapObject ApplicationConstraint) <$> getActiveApplicationConstraints
+  return $ us <> ts <> as
 
 getActiveUnificationConstraints :: (MonadTypeChecker builtin m) => m [WithContext (UnificationConstraint builtin)]
 getActiveUnificationConstraints = getsMetaCtx unificationConstraints
 
 getActiveInstanceConstraints :: (MonadTypeChecker builtin m) => m [WithContext (InstanceConstraint builtin)]
-getActiveInstanceConstraints = getsMetaCtx typeClassConstraints
+getActiveInstanceConstraints = getsMetaCtx instanceConstraints
 
-setConstraints :: (MonadTypeChecker builtin m) => [WithContext (Constraint builtin)] -> m ()
-setConstraints constraints = do
-  let (us, ts) = separateConstraints constraints
-  setUnificationConstraints us
-  setInstanceConstraints ts
+getActiveApplicationConstraints :: (MonadTypeChecker builtin m) => m [WithContext (ApplicationConstraint builtin)]
+getActiveApplicationConstraints = getsMetaCtx applicationConstraints
 
 setInstanceConstraints :: (MonadTypeChecker builtin m) => [WithContext (InstanceConstraint builtin)] -> m ()
 setInstanceConstraints newConstraints = modifyMetaCtx $ \TypeCheckerState {..} ->
-  TypeCheckerState {typeClassConstraints = newConstraints, ..}
+  TypeCheckerState {instanceConstraints = newConstraints, ..}
+
+setApplicationConstraints :: (MonadTypeChecker builtin m) => [WithContext (ApplicationConstraint builtin)] -> m ()
+setApplicationConstraints newConstraints = modifyMetaCtx $ \TypeCheckerState {..} ->
+  TypeCheckerState {applicationConstraints = newConstraints, ..}
 
 removeInstanceConstraint :: forall builtin m. (MonadTypeChecker builtin m) => WithContext (InstanceConstraint builtin) -> m ()
 removeInstanceConstraint constraint = modifyMetaCtx @builtin $ \TypeCheckerState {..} -> do
   let idOf = constraintID . contextOf
-  let newConstraints = filter (\c -> idOf constraint /= idOf c) typeClassConstraints
-  TypeCheckerState {typeClassConstraints = newConstraints, ..}
+  let newConstraints = filter (\c -> idOf constraint /= idOf c) instanceConstraints
+  TypeCheckerState {instanceConstraints = newConstraints, ..}
 
 setUnificationConstraints :: (MonadTypeChecker builtin m) => [WithContext (UnificationConstraint builtin)] -> m ()
 setUnificationConstraints newConstraints = modifyMetaCtx $ \TypeCheckerState {..} ->
   TypeCheckerState {unificationConstraints = newConstraints, ..}
-
-addConstraints :: (MonadTypeChecker builtin m) => [WithContext (Constraint builtin)] -> m ()
-addConstraints constraints = do
-  let (us, ts) = separateConstraints constraints
-  addUnificationConstraints us
-  addInstanceConstraints ts
 
 addUnificationConstraints :: (MonadTypeChecker builtin m) => [WithContext (UnificationConstraint builtin)] -> m ()
 addUnificationConstraints constraints = do
@@ -448,29 +458,14 @@ addInstanceConstraints constraints = do
     logDebug MaxDetail ("add-constraints:" <> line <> indent 2 (vcat (fmap prettyExternal constraints)))
 
   modifyMetaCtx $ \TypeCheckerState {..} ->
-    TypeCheckerState {typeClassConstraints = typeClassConstraints ++ constraints, ..}
+    TypeCheckerState {instanceConstraints = instanceConstraints ++ constraints, ..}
 
--- | Adds an entirely new unification constraint (as opposed to one
--- derived from another constraint).
-createFreshUnificationConstraint ::
-  forall builtin m.
-  (MonadTypeChecker builtin m) =>
-  Provenance ->
-  BoundCtx (Type builtin) ->
-  UnificationConstraintOrigin builtin ->
-  Type builtin ->
-  Type builtin ->
-  m ()
-createFreshUnificationConstraint p ctx origin expectedType actualType = do
-  let env = boundContextToEnv ctx
-  normExpectedType <- normaliseInEnv env expectedType
-  normActualType <- normaliseInEnv env actualType
-  cid <- generateFreshConstraintID (Proxy @builtin)
-  let context = ConstraintContext cid p p unknownBlockingStatus ctx
-  let unification = Unify origin normExpectedType normActualType
-  let constraint = WithContext unification context
+addApplicationConstraint :: (MonadTypeChecker builtin m) => WithContext (ApplicationConstraint builtin) -> m ()
+addApplicationConstraint constraint = do
+  logDebug MaxDetail ("add-constraints:" <> line <> indent 2 (prettyExternal constraint))
 
-  addUnificationConstraints [constraint]
+  modifyMetaCtx $ \TypeCheckerState {..} ->
+    TypeCheckerState {applicationConstraints = applicationConstraints ++ [constraint], ..}
 
 -- | Create a new fresh copy of the context for a new constraint
 copyContext :: forall builtin m. (MonadTypeChecker builtin m) => ConstraintContext builtin -> m (ConstraintContext builtin)

--- a/vehicle/src/Vehicle/Prelude/Prettyprinter.hs
+++ b/vehicle/src/Vehicle/Prelude/Prettyprinter.hs
@@ -6,12 +6,13 @@ module Vehicle.Prelude.Prettyprinter
   )
 where
 
+-- This stuff we re-export
+
+import Data.Bifunctor (Bifunctor (..))
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap (toAscList)
 import Data.IntSet (IntSet)
 import Data.IntSet qualified as IntSet (toAscList)
--- This stuff we re-export
-
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
@@ -109,26 +110,14 @@ quotePretty = squotes . pretty
 --------------------------------------------------------------------------------
 -- Pretty printing of datatypes
 
-prettyIntMap :: IntMap (Doc a) -> Doc a
-prettyIntMap = prettyMapEntries . IntMap.toAscList
-
 prettyMap :: (Pretty key, Pretty value) => Map key value -> Doc a
-prettyMap = prettyMapEntries . Map.toAscList . fmap pretty
+prettyMap = prettyMapEntries . fmap (bimap pretty pretty) . Map.toAscList
 
-prettyMapEntries :: (Pretty key) => [(key, Doc a)] -> Doc a
-prettyMapEntries entries = result
+prettyMapEntries :: [(Doc a, Doc a)] -> Doc a
+prettyMapEntries entries = prettySetLike entries'
   where
     (keys, values) = unzip entries
-    keys' = fmap pretty keys
-    entries' = zipWith (\k v -> k <+> ":=" <+> v) keys' values
-    result =
-      "{"
-        <+> align
-          ( group
-              (concatWith (\x y -> x <> ";" <> line <> y) entries')
-              <> softline
-              <> "}"
-          )
+    entries' = zipWith (\k v -> k <+> ":=" <+> v) keys values
 
 prettySet :: (Pretty value) => Set value -> Doc b
 prettySet xs = prettySetLike (pretty <$> Set.toList xs)
@@ -136,18 +125,15 @@ prettySet xs = prettySetLike (pretty <$> Set.toList xs)
 prettySetLike :: [Doc a] -> Doc a
 prettySetLike xs =
   "{"
-    <+> align
-      ( group
-          (concatWith (\x y -> x <> ";" <> line <> y) xs)
-          <> softline
-          <> "}"
-      )
+    <+> group (concatWith (\x y -> x <> line <> ";" <+> y) xs)
+    <> line
+    <> "}"
 
 instance Pretty IntSet where
   pretty m = pretty (IntSet.toAscList m)
 
 instance (Pretty a) => Pretty (IntMap a) where
-  pretty = prettyIntMap . fmap pretty
+  pretty = prettyMapEntries . fmap (bimap pretty pretty) . IntMap.toAscList
 
 instance Pretty Version where
   pretty = pretty . showVersion

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -1,7 +1,7 @@
 module Vehicle.TypeCheck
   ( TypeCheckOptions (..),
     typeCheck,
-    typeCheckExpr,
+    typeCheckSolitaryExpr,
     parseAndTypeCheckExpr,
     typeCheckUserProg,
     loadLibrary,
@@ -21,7 +21,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Print.Error
 import Vehicle.Compile.Scope (scopeCheck, scopeCheckClosedExpr)
-import Vehicle.Compile.Type (typeCheckExpr, typeCheckProg)
+import Vehicle.Compile.Type (typeCheckProg, typeCheckSolitaryExpr)
 import Vehicle.Compile.Type.Constraint.InstanceBuiltins
 import Vehicle.Compile.Type.Core (emptyInstanceDatabase)
 import Vehicle.Compile.Type.Subsystem
@@ -60,7 +60,7 @@ parseAndTypeCheckExpr expr = do
   freeCtx <- createFreeCtx [standardLibraryProg]
   vehicleExpr <- parseExprText expr
   scopedExpr <- scopeCheckClosedExpr vehicleExpr
-  typedExpr <- typeCheckExpr standardBuiltinInstances freeCtx scopedExpr
+  typedExpr <- typeCheckSolitaryExpr standardBuiltinInstances freeCtx scopedExpr
   convertBackToStandardBuiltin typedExpr
 
 parseExprText :: (MonadCompile m) => (FilePath, Text) -> m S.Expr

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -219,6 +219,7 @@ library
     Vehicle.Compile.Type.Builtin.Polarity
     Vehicle.Compile.Type.Builtin.Standard
     Vehicle.Compile.Type.Builtin.Tensor
+    Vehicle.Compile.Type.Constraint.ApplicationSolver
     Vehicle.Compile.Type.Constraint.Core
     Vehicle.Compile.Type.Constraint.IndexSolver
     Vehicle.Compile.Type.Constraint.InstanceBuiltins


### PR DESCRIPTION
This adds the ability for the type-checker to postpone inserting implicit and instance arguments if the type of an application is currently not yet known. This is in order to support a) overloading the `App` constructor as proposed in https://github.com/vehicle-lang/vehicle/issues/860 and b) n-ary function types for `Stack` also in https://github.com/vehicle-lang/vehicle/issues/860