### PR TITLE
Extend stable Python API

### DIFF
--- a/vehicle-python/src/vehicle_lang/__init__.py
+++ b/vehicle-python/src/vehicle_lang/__init__.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from ._version import VERSION as VERSION
+from .compile import compile_to_query as compile_to_query
 from .compile.error import VehicleBuiltinUnsupported as VehicleBuiltinUnsupported
 from .compile.error import VehiclePropertyNotFound as VehiclePropertyNotFound
 
@@ -13,20 +14,25 @@ from .typing import AnyOptimiser as AnyOptimiser
 from .typing import AnyOptimisers as AnyOptimisers
 from .typing import DeclarationName as DeclarationName
 from .typing import DifferentiableLogic as DifferentiableLogic
-from .typing import QueryFormat as QueryFormat
 from .typing import Optimiser as Optimiser
 from .typing import QuantifiedVariableName as QuantifiedVariableName
+from .typing import QueryFormat as QueryFormat
 from .typing import Verifier as Verifier
 from .verify import verify as verify
-from .compile import compile_to_query as compile_to_query
 
 __all__: List[str] = [
     "VERSION",
+    # Check
+    "check",
     # Compile
     "load_loss_function",
-	"compile_to_query",
+    "compile_to_query",
     # Verify
     "verify",
+    # Validate,
+    "validate",
+    # export
+    "export_to_solver",
     # Error types
     "VehicleError",
     "VehicleSessionClosed",
@@ -41,6 +47,6 @@ __all__: List[str] = [
     "AnyOptimiser",
     "AnyOptimisers",
     "DifferentiableLogic",
-	"QueryFormat",
+    "QueryFormat",
     "Verifier",
 ]

--- a/vehicle-python/src/vehicle_lang/__init__.py
+++ b/vehicle-python/src/vehicle_lang/__init__.py
@@ -13,15 +13,18 @@ from .typing import AnyOptimiser as AnyOptimiser
 from .typing import AnyOptimisers as AnyOptimisers
 from .typing import DeclarationName as DeclarationName
 from .typing import DifferentiableLogic as DifferentiableLogic
+from .typing import QueryFormat as QueryFormat
 from .typing import Optimiser as Optimiser
 from .typing import QuantifiedVariableName as QuantifiedVariableName
 from .typing import Verifier as Verifier
 from .verify import verify as verify
+from .compile import compile_to_query as compile_to_query
 
 __all__: List[str] = [
     "VERSION",
     # Compile
     "load_loss_function",
+	"compile_to_query",
     # Verify
     "verify",
     # Error types
@@ -38,5 +41,6 @@ __all__: List[str] = [
     "AnyOptimiser",
     "AnyOptimisers",
     "DifferentiableLogic",
+	"QueryFormat",
     "Verifier",
 ]

--- a/vehicle-python/src/vehicle_lang/check/__init__.py
+++ b/vehicle-python/src/vehicle_lang/check/__init__.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from typing import Union
+
+from .. import session
+from ..error import VehicleError
+from ..typing import TypeSystem
+
+
+def check(
+    specification: Union[str, Path], typeSystem: TypeSystem = TypeSystem.Standard
+) -> str:
+    """
+    Type-check a .vcl specification file.
+
+    :param specification: The path to the Vehicle specification file to verify.
+    :param typeSystem: The typing system that should be used.
+    """
+    args = ["check", "--check", str(specification)]
+    args.extend(["--typeSystem", typeSystem._vehicle_option_name])
+
+    # Call Vehicle
+    exc, out, err, _ = session.check_output(args)
+
+    # Check for errors
+    if exc != 0:
+        raise VehicleError(f"{err}")
+    elif not out:
+        return ""
+
+    return out

--- a/vehicle-python/src/vehicle_lang/compile/__init__.py
+++ b/vehicle-python/src/vehicle_lang/compile/__init__.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Union
+
+from .. import session
+from ..typing import DeclarationName, DifferentiableLogic, QueryFormat
+from .error import VehicleError as VehicleError
+
+
+def compile_to_query(
+    path: Union[str, Path],
+    target: Union[DifferentiableLogic, QueryFormat],
+    declarations: Optional[Iterable[DeclarationName]] = None,
+    networks: Dict[DeclarationName, Union[str, Path]] = {},
+    datasets: Dict[DeclarationName, Union[str, Path]] = {},
+    parameters: Dict[DeclarationName, Any] = {},
+    output_file: Optional[Union[str, Path]] = None,
+    module_name: Optional[str] = None,
+    cache: Optional[Union[str, Path]] = None,
+) -> str:
+    """
+    Compile a Vehicle specification to a query language (e.g., Marabou, VNNLIB etc.)
+
+    :param specification: The path to the Vehicle specification file to compile.
+    :param target: The target language to compile to (e.g., QueryFormat.Marabou).
+    :param declarations: The names of the declarations to compile, defaults to all declarations.
+    :param networks: A map from the network names in the specification to files containing the networks.
+    :param datasets: A map from the dataset names in the specification to files containing the datasets.
+    :param parameters: A map from the parameter names in the specification to the values to be used in compilation.
+    :param output_file: Output location for the compiled file(s). Defaults to stdout if not provided.
+    :param module_name: Override the name of the exported module (for ITP targets).
+    :param cache: The location of the verification cache for ITP compilation.
+    """
+
+    args = ["compile", "--specification", str(path), "--target", target._vehicle_option_name]
+
+    # Add declarations if specified
+    if declarations is not None:
+        for declaration_name in set(declarations):
+            args.extend(["--declaration", declaration_name])
+
+    # Add networks, datasets, and parameters
+    for network_name, network_path in networks.items():
+        args.extend(["--network", f"{network_name}:{network_path}"])
+
+    for dataset_name, dataset_path in datasets.items():
+        args.extend(["--dataset", f"{dataset_name}:{dataset_path}"])
+
+    for parameter_name, parameter_value in parameters.items():
+        args.extend(["--parameter", f"{parameter_name}:{parameter_value}"])
+
+    # Add output file if specified
+    if output_file is not None:
+        args.extend(["--output", str(output_file)])
+
+    # Add module name if specified
+    if module_name is not None:
+        args.extend(["--module-name", module_name])
+
+    # Add cache if specified
+    if cache is not None:
+        args.extend(["--cache", str(cache)])
+
+    # Call Vehicle
+    exec, out, err, _ = session.check_output(args)
+
+    if exec != 0:
+        raise VehicleError(f"{err}")
+    elif not out:
+        raise VehicleError(f"Vehicle produced no output")
+
+    return out

--- a/vehicle-python/src/vehicle_lang/compile/__init__.py
+++ b/vehicle-python/src/vehicle_lang/compile/__init__.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
 
 from .. import session
+from ..error import VehicleError as VehicleError
 from ..typing import DeclarationName, DifferentiableLogic, QueryFormat
-from .error import VehicleError as VehicleError
 
 
 def compile_to_query(
@@ -31,7 +31,13 @@ def compile_to_query(
     :param cache: The location of the verification cache for ITP compilation.
     """
 
-    args = ["compile", "--specification", str(path), "--target", target._vehicle_option_name]
+    args = [
+        "compile",
+        "--specification",
+        str(path),
+        "--target",
+        target._vehicle_option_name,
+    ]
 
     # Add declarations if specified
     if declarations is not None:

--- a/vehicle-python/src/vehicle_lang/export/__init__.py
+++ b/vehicle-python/src/vehicle_lang/export/__init__.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from typing import Optional, Union
+
+from .. import session
+from ..error import VehicleError as VehicleError
+from ..typing import ExportTarget
+
+
+def export_to_solver(
+    target: ExportTarget,
+    output_file: Optional[Union[str, Path]] = None,
+    module_name: Optional[str] = None,
+    cache: Optional[Union[str, Path]] = None,
+) -> str:
+    """
+    Export a.vcl specification file to an interactive theorem prover.
+
+    :param target: The target format to export to (only Agda supported currently).
+    :param output_file: Output location for the compiled file(s). Defaults to stdout if not provided.
+    :param module_name: Override the name of the exported module (for ITP targets).
+    :param cache: The location of the verification cache for ITP compilation.
+    """
+
+    args = ["export", "--target", str(target._vehicle_option_name)]
+
+    # Add output file if specified
+    if output_file is not None:
+        args.extend(["--output", str(output_file)])
+
+    # Add module name if specified
+    if module_name is not None:
+        args.extend(["--module-name", module_name])
+
+    # Add cache if specified
+    if cache is not None:
+        args.extend(["--cache", str(cache)])
+
+    # Call Vehicle
+    exc, out, err, log = session.check_output(args)
+
+    # Check for errors or return
+    if exc != 0:
+        raise VehicleError(err or out or log or "unknown error")
+    elif not out:
+        raise VehicleError("no output")
+    else:
+        return out

--- a/vehicle-python/src/vehicle_lang/session/__init__.py
+++ b/vehicle-python/src/vehicle_lang/session/__init__.py
@@ -1,8 +1,8 @@
 import atexit
-import pty
-import os
-import sys
 import io
+import os
+import pty
+import sys
 from contextlib import AbstractContextManager, redirect_stderr, redirect_stdout
 from types import TracebackType
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Sequence, Tuple, Type
@@ -75,7 +75,7 @@ class Session(SessionContextManager):
             return _unsafe_vehicle_main(args)
         else:
             raise VehicleSessionClosed()
-        
+
     def check_output(
         self,
         args: Sequence[str],
@@ -95,35 +95,32 @@ class Session(SessionContextManager):
                         err.getvalue() or None,
                         log.read_text(),
                     )
-                
+
     def check_output_pty(
-        self, 
-        args: Sequence[str]
+        self, args: Sequence[str]
     ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:
         stdout_fd = sys.stdout.fileno()
         stderr_fd = sys.stderr.fileno()
 
         # Create a pseudo-terminal pair to capture stdout
-        master_fd, slave_fd = pty.openpty() 
+        master_fd, slave_fd = pty.openpty()
         # Create a pipe to capture stderr
         pread_fd, pwrite_fd = os.pipe()
 
-        saved_stdout_fd = os.dup(stdout_fd) 
+        saved_stdout_fd = os.dup(stdout_fd)
         saved_stderr_fd = os.dup(stderr_fd)
 
         try:
             # Redirect stdout and stderr
-            os.dup2(slave_fd, stdout_fd)  
+            os.dup2(slave_fd, stdout_fd)
             os.dup2(pwrite_fd, stderr_fd)
 
             # Close unused write ends
-            os.close(slave_fd)  
+            os.close(slave_fd)
             os.close(pwrite_fd)
 
             with temporary_files("log", prefix="vehicle") as (log,):
-                exitCode = self.check_call(
-                    [f"--redirect-logs={log}", *args]
-                )
+                exitCode = self.check_call([f"--redirect-logs={log}", *args])
 
             sys.stdout.flush()
 
@@ -138,22 +135,22 @@ class Session(SessionContextManager):
 
         out_lines = []
 
-        with os.fdopen(master_fd, "r") as f:    
+        with os.fdopen(master_fd, "r") as f:
             try:
                 while line := f.readline():
                     out_lines.append(line)
             except OSError:
                 pass
 
-        with os.fdopen(pread_fd, "r") as f:  
+        with os.fdopen(pread_fd, "r") as f:
             err = f.read()
 
         return (
-                exitCode,
-                "".join(out_lines) or None,
-                err or None,
-                log.read_text(),
-            )
+            exitCode,
+            "".join(out_lines) or None,
+            err or None,
+            log.read_text(),
+        )
 
     def close(self) -> None:
         if not self.closed:
@@ -181,7 +178,7 @@ def check_call(args: Sequence[str]) -> int:
 def check_output(
     args: Sequence[str],
 ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:
-    return Session().__enter__().check_output(args)
+    return Session().__enter__().check_output_pty(args)
 
 
 def close() -> None:

--- a/vehicle-python/src/vehicle_lang/session/__init__.py
+++ b/vehicle-python/src/vehicle_lang/session/__init__.py
@@ -1,6 +1,8 @@
 import atexit
-import io
+import pty
+import os
 import sys
+import io
 from contextlib import AbstractContextManager, redirect_stderr, redirect_stdout
 from types import TracebackType
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Sequence, Tuple, Type
@@ -73,7 +75,7 @@ class Session(SessionContextManager):
             return _unsafe_vehicle_main(args)
         else:
             raise VehicleSessionClosed()
-
+        
     def check_output(
         self,
         args: Sequence[str],
@@ -93,6 +95,65 @@ class Session(SessionContextManager):
                         err.getvalue() or None,
                         log.read_text(),
                     )
+                
+    def check_output_pty(
+        self, 
+        args: Sequence[str]
+    ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:
+        stdout_fd = sys.stdout.fileno()
+        stderr_fd = sys.stderr.fileno()
+
+        # Create a pseudo-terminal pair to capture stdout
+        master_fd, slave_fd = pty.openpty() 
+        # Create a pipe to capture stderr
+        pread_fd, pwrite_fd = os.pipe()
+
+        saved_stdout_fd = os.dup(stdout_fd) 
+        saved_stderr_fd = os.dup(stderr_fd)
+
+        try:
+            # Redirect stdout and stderr
+            os.dup2(slave_fd, stdout_fd)  
+            os.dup2(pwrite_fd, stderr_fd)
+
+            # Close unused write ends
+            os.close(slave_fd)  
+            os.close(pwrite_fd)
+
+            with temporary_files("log", prefix="vehicle") as (log,):
+                exitCode = self.check_call(
+                    [f"--redirect-logs={log}", *args]
+                )
+
+            sys.stdout.flush()
+
+        finally:
+            # Restore stdout and stderr
+            os.dup2(saved_stdout_fd, stdout_fd)
+            os.dup2(saved_stderr_fd, stderr_fd)
+
+            # Cleanup
+            os.close(saved_stdout_fd)
+            os.close(saved_stderr_fd)
+
+        out_lines = []
+
+        with os.fdopen(master_fd, "r") as f:    
+            try:
+                while line := f.readline():
+                    out_lines.append(line)
+            except OSError:
+                pass
+
+        with os.fdopen(pread_fd, "r") as f:  
+            err = f.read()
+
+        return (
+                exitCode,
+                "".join(out_lines) or None,
+                err or None,
+                log.read_text(),
+            )
 
     def close(self) -> None:
         if not self.closed:

--- a/vehicle-python/src/vehicle_lang/typing.py
+++ b/vehicle-python/src/vehicle_lang/typing.py
@@ -86,7 +86,7 @@ class DifferentiableLogic(Enum):
             DifferentiableLogic.Product: "ProductLoss",
             DifferentiableLogic.Yager: "YagerLoss",
         }[self]
-    
+
 
 class QueryFormat(Enum):
     """
@@ -102,7 +102,7 @@ class QueryFormat(Enum):
         return {
             QueryFormat.VNNLib: "VNNLibQueries",
             QueryFormat.Marabou: "MarabouQueries",
-            QueryFormat.Agda: "Agda"
+            QueryFormat.Agda: "Agda",
         }[self]
 
 
@@ -123,3 +123,33 @@ class Verifier(Enum):
         return {
             Verifier.Marabou: "Marabou",
         }[self]
+
+
+class TypeSystem(Enum):
+    """
+    The type system supported used to check a vehicle specification
+    """
+
+    Standard = 1
+    Polarity = 2
+    Linearity = 3
+
+    @property
+    def _vehicle_option_name(self) -> str:
+        return {
+            TypeSystem.Standard: "Standard",
+            TypeSystem.Polarity: "Polarity",
+            TypeSystem.Linearity: "Linearity",
+        }[self]
+
+
+class ExportTarget(Enum):
+    """
+    The target to export to. Only Agda is currently supported.
+    """
+
+    Agda = 1
+
+    @property
+    def _vehicle_option_name(self) -> str:
+        return {ExportTarget.Agda: "Agda"}[self]

--- a/vehicle-python/src/vehicle_lang/typing.py
+++ b/vehicle-python/src/vehicle_lang/typing.py
@@ -86,6 +86,24 @@ class DifferentiableLogic(Enum):
             DifferentiableLogic.Product: "ProductLoss",
             DifferentiableLogic.Yager: "YagerLoss",
         }[self]
+    
+
+class QueryFormat(Enum):
+    """
+    The query formats supported by Vehicle.
+    """
+
+    VNNLib = 1
+    Marabou = 2
+    Agda = 3
+
+    @property
+    def _vehicle_option_name(self) -> str:
+        return {
+            QueryFormat.VNNLib: "VNNLibQueries",
+            QueryFormat.Marabou: "MarabouQueries",
+            QueryFormat.Agda: "Agda"
+        }[self]
 
 
 class Verifier(Enum):

--- a/vehicle-python/src/vehicle_lang/validate/__init__.py
+++ b/vehicle-python/src/vehicle_lang/validate/__init__.py
@@ -4,9 +4,8 @@ from typing import Union
 from .. import session
 from ..error import VehicleError
 
-def validate(
-    cache: Union[str, Path]
-) -> str:
+
+def validate(cache: Union[str, Path]) -> str:
     """
     Validate a verification result to check whether it still holds.
 
@@ -21,6 +20,6 @@ def validate(
     if exc != 0:
         raise VehicleError(f"{err}")
     elif not out:
-        return ''
+        return ""
 
     return out

--- a/vehicle-python/src/vehicle_lang/validate/__init__py
+++ b/vehicle-python/src/vehicle_lang/validate/__init__py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Union
+
+from .. import session
+from ..error import VehicleError
+
+def validate(
+    cache: Union[str, Path]
+) -> str:
+    """
+    Validate a verification result to check whether it still holds.
+
+    :param cache: The path to the proof cache used by Vehicle.
+    """
+    args = ["validate", "--cache", str(cache)]
+
+    # Call Vehicle
+    exc, out, err, _ = session.check_output(args)
+
+    # Check for errors
+    if exc != 0:
+        raise VehicleError(f"{err}")
+    elif not out:
+        return ''
+
+    return out

--- a/vehicle-python/src/vehicle_lang/verify/__init__.py
+++ b/vehicle-python/src/vehicle_lang/verify/__init__.py
@@ -15,7 +15,7 @@ def verify(
     verifier: Verifier = Verifier.Marabou,
     verifier_location: Optional[Union[str, Path]] = None,
     cache: Optional[Union[str, Path]] = None,
-) -> None:
+) -> str:
     """
     Check whether properties in a Vehicle specification hold.
 
@@ -56,7 +56,8 @@ def verify(
 
     # Check for errors
     if exc != 0:
-        raise VehicleError(err or out or log or "unknown error")
-    if out is None:
-        raise VehicleError("no output")
-    return None
+        raise VehicleError(f"{err}")
+    elif not out:
+        raise VehicleError(f"Vehicle produced no output")
+
+    return out


### PR DESCRIPTION
# Description of Changes
- #877: python bindings for `compile`, `export`, `validate` and `check` using implemented infrastructure and only adding `__init__.py` for each function
- #879: uses `os.dup2()` to redirect correctly (for python bindings)