### PR TITLE
Extend stable Python API - fixes and `list`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,6 @@
   - `export_to_solver`
   - `list_resources` and `list_properties` which output as JSON
 
-
 ## Version 0.16.1
 
 * Fixed detection of Marabou timeouts.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,18 @@
 # Changelog for Vehicle
 
+## Version 0.17
+
+* A new command `list` with sub-commands `resources` and `properties`, to list resources and properties in a vehicle.
+  specification.
+
+* Exposed the other modes' functionality in Python in the `vehicle_lang` module as:
+  - `check`
+  - `compile_to_query`
+  - `validate`
+  - `export_to_solver`
+  - `list_resources` and `list_properties` which output as JSON
+
+
 ## Version 0.16.1
 
 * Fixed detection of Marabou timeouts.

--- a/vehicle-python/src/vehicle_lang/__init__.py
+++ b/vehicle-python/src/vehicle_lang/__init__.py
@@ -10,6 +10,8 @@ from .compile.error import VehiclePropertyNotFound as VehiclePropertyNotFound
 from .error import VehicleError as VehicleError
 from .error import VehicleInternalError as VehicleInternalError
 from .export import export_to_solver as export_to_solver
+from .list import list_properties as list_properties
+from .list import list_resources as list_resources
 from .session.error import VehicleSessionClosed as VehicleSessionClosed
 from .session.error import VehicleSessionUsed as VehicleSessionUsed
 from .typing import AnyOptimiser as AnyOptimiser
@@ -36,8 +38,11 @@ __all__: List[str] = [
     "verify",
     # Validate,
     "validate",
-    # export
+    # Export
     "export_to_solver",
+    # List
+    "list_resources",
+    "list_properties",
     # Error types
     "VehicleError",
     "VehicleSessionClosed",

--- a/vehicle-python/src/vehicle_lang/__init__.py
+++ b/vehicle-python/src/vehicle_lang/__init__.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from ._version import VERSION as VERSION
+from .check import check as check
 from .compile import compile_to_query as compile_to_query
 from .compile.error import VehicleBuiltinUnsupported as VehicleBuiltinUnsupported
 from .compile.error import VehiclePropertyNotFound as VehiclePropertyNotFound
@@ -8,16 +9,20 @@ from .compile.error import VehiclePropertyNotFound as VehiclePropertyNotFound
 # from .compile.python import load_loss_function as load_loss_function
 from .error import VehicleError as VehicleError
 from .error import VehicleInternalError as VehicleInternalError
+from .export import export_to_solver as export_to_solver
 from .session.error import VehicleSessionClosed as VehicleSessionClosed
 from .session.error import VehicleSessionUsed as VehicleSessionUsed
 from .typing import AnyOptimiser as AnyOptimiser
 from .typing import AnyOptimisers as AnyOptimisers
 from .typing import DeclarationName as DeclarationName
 from .typing import DifferentiableLogic as DifferentiableLogic
+from .typing import ExportTarget as ExportTarget
 from .typing import Optimiser as Optimiser
 from .typing import QuantifiedVariableName as QuantifiedVariableName
 from .typing import QueryFormat as QueryFormat
+from .typing import TypeSystem as TypeSystem
 from .typing import Verifier as Verifier
+from .validate import validate as validate
 from .verify import verify as verify
 
 __all__: List[str] = [
@@ -49,4 +54,6 @@ __all__: List[str] = [
     "DifferentiableLogic",
     "QueryFormat",
     "Verifier",
+    "TypeSystem",
+    "ExportTarget",
 ]

--- a/vehicle-python/src/vehicle_lang/check/__init__.py
+++ b/vehicle-python/src/vehicle_lang/check/__init__.py
@@ -15,8 +15,13 @@ def check(
     :param specification: The path to the Vehicle specification file to verify.
     :param typeSystem: The typing system that should be used.
     """
-    args = ["check", "--check", str(specification)]
-    args.extend(["--typeSystem", typeSystem._vehicle_option_name])
+    args = [
+        "check",
+        "--specification",
+        str(specification),
+        "--typeSystem",
+        typeSystem._vehicle_option_name,
+    ]
 
     # Call Vehicle
     exc, out, err, _ = session.check_output(args)

--- a/vehicle-python/src/vehicle_lang/list/__init__.py
+++ b/vehicle-python/src/vehicle_lang/list/__init__.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from typing import Union
+
+from .. import session
+from ..error import VehicleError
+
+
+def list_resources(specification: Union[str, Path]) -> str:
+    """
+    List all networks, datasets, and parameters in the specification.
+
+    :param specification: The path to the Vehicle specification file to list resources for.
+    :return: list of entities as JSON.
+    """
+    args = ["list", "resources", "--specification", str(specification), "--json"]
+
+    # Call Vehicle
+    exc, out, err, _ = session.check_output(args)
+
+    # Check for errors
+    if exc != 0:
+        raise VehicleError(f"{err}")
+    elif not out:
+        return ""
+
+    return out
+
+
+def list_properties(specification: Union[str, Path]) -> str:
+    """
+    List all properties in the specification.
+
+    :param specification: The path to the Vehicle specification file to list properties for.
+    :return: list of entities as JSON.
+    """
+    args = ["list", "properties", "--specification", str(specification), "--json"]
+
+    # Call Vehicle
+    exc, out, err, _ = session.check_output(args)
+
+    # Check for errors
+    if exc != 0:
+        raise VehicleError(f"{err}")
+    elif not out:
+        return ""
+
+    return out


### PR DESCRIPTION
# Description of Changes
- Fixes #883 (imports) to correctly export added functions and classes, and `check` option
- Added Python Bindings for `list`command - to `list_resources` and `list_properties`