### PR TITLE
Issue 892 : Validate enhancements

### DIFF
--- a/vehicle-python/src/vehicle_lang/validate/__init__.py
+++ b/vehicle-python/src/vehicle_lang/validate/__init__.py
@@ -5,13 +5,17 @@ from .. import session
 from ..error import VehicleError
 
 
-def validate(cache: Union[str, Path]) -> str:
+def validate(cache: Union[str, Path], counter_examples: bool = False) -> str:
     """
     Validate a verification result to check whether it still holds.
 
     :param cache: The path to the proof cache used by Vehicle.
+    :param counter_examples: If True, return counterexamples in the cache.
     """
-    args = ["validate", "--cache", str(cache)]
+    args = ["validate", "--cache", str(cache), "--json"]
+
+    if counter_examples:
+        args.extend(["--counter-examples"])
 
     # Call Vehicle
     exc, out, err, _ = session.check_output(args)

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -501,7 +501,7 @@ outputCounterExamplesParser =
   switch $
     long "counter-examples"
       <> short 'x'
-      <> help "Output the counter-examples in the validate cache."
+      <> help "Output the counter-examples in the proof cache."
       <> internal
 
 propertyParser :: Parser [Text]

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -501,7 +501,7 @@ outputCounterExamplesParser =
   switch $
     long "counter-examples"
       <> short 'x'
-      <> help "Decode the counter-examples in the validate cache."
+      <> help "Output the counter-examples in the validate cache."
       <> internal
 
 propertyParser :: Parser [Text]

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -276,6 +276,8 @@ validateParser :: Parser ValidateOptions
 validateParser =
   ValidateOptions
     <$> validateCacheParser
+    <*> outputAsJSONParser
+    <*> outputCounterExamplesParser
 
 validateParserInfo :: ParserInfo ModeOptions
 validateParserInfo = info (Validate <$> validateParser) validateDescription
@@ -492,6 +494,14 @@ outputAsJSONParser =
     long "json"
       <> short 'j'
       <> help "Output the program as JSON instead of text."
+      <> internal
+
+outputCounterExamplesParser :: Parser Bool
+outputCounterExamplesParser =
+  switch $
+    long "counter-examples"
+      <> short 'x'
+      <> help "Decode the counter-examples in the validate cache."
       <> internal
 
 propertyParser :: Parser [Text]

--- a/vehicle/src/Vehicle/Validate.hs
+++ b/vehicle/src/Vehicle/Validate.hs
@@ -4,19 +4,27 @@ module Vehicle.Validate
   )
 where
 
-import Control.Monad (forM)
+import Control.Monad (forM, when)
 import Control.Monad.Trans (MonadIO (liftIO))
+import Data.Aeson (ToJSON (..), Value (Object), object, (.=))
+import Data.Aeson.Encode.Pretty (encodePretty')
+import Data.Aeson.Key (fromString)
+import Data.ByteString.Lazy.Char8 (unpack)
+import System.FilePath ((</>))
+import Vehicle.Data.Tensor (RationalTensor)
 import Vehicle.Prelude
 import Vehicle.Prelude.Logging
 import Vehicle.Resource
 import Vehicle.Verify.Specification (SpecificationCacheIndex (..), multiPropertyAddresses, properties)
-import Vehicle.Verify.Specification.IO (readPropertyResult, readSpecificationCacheIndex, specificationCacheIndexFileName)
+import Vehicle.Verify.Specification.IO (readAssignmentsFromFolder, readPropertyResult, readSpecificationCacheIndex, specificationCacheIndexFileName)
 
 --------------------------------------------------------------------------------
 -- Proof validation
 
-newtype ValidateOptions = ValidateOptions
-  { verificationCache :: FilePath
+data ValidateOptions = ValidateOptions
+  { verificationCache :: FilePath,
+    outputAsJSON :: Bool,
+    outputCounterExamples :: Bool
   }
   deriving (Eq, Show)
 
@@ -25,7 +33,22 @@ validate loggingSettings checkOptions = runLoggerT loggingSettings $ do
   -- If the user has specified no logging target for check mode then
   -- default to command-line.
   status <- checkSpecificationStatus checkOptions
-  programOutput $ pretty status
+  counterExamples <- collectCounterexamples checkOptions
+
+  if outputAsJSON checkOptions
+    then do
+      let statusJSON =
+            if outputCounterExamples checkOptions
+              then case toJSON status of
+                Object o -> Object (o <> case toJSON (object ["counter-examples" .= toJSON counterExamples]) of Object o' -> o'; _ -> mempty)
+                v -> v
+              else toJSON status
+      programOutput $ pretty $ unpack $ encodePretty' prettyJSONConfig statusJSON
+    else do
+      -- Pretty print the status and counter-examples
+      programOutput $ pretty status
+      when (outputCounterExamples checkOptions) $ do
+        programOutput $ line <> "Counterexamples:" <> line <> pretty counterExamples
 
 checkSpecificationStatus ::
   (MonadIO m, MonadLogger m) =>
@@ -44,6 +67,18 @@ checkSpecificationStatus ValidateOptions {..} = do
         then return Verified
         else return Unverified
 
+-- | Collect counterexamples for all assignments in the verification cache.
+collectCounterexamples :: (MonadStdIO m, MonadLogger m) => ValidateOptions -> m [CounterExampleResult]
+collectCounterexamples ValidateOptions {..} = do
+  let cacheIndexFile = specificationCacheIndexFileName verificationCache
+  SpecificationCacheIndex {..} <- readSpecificationCacheIndex cacheIndexFile
+  let propertyAddresses = concatMap (multiPropertyAddresses . snd) properties
+  results <- forM propertyAddresses $ \addr -> do
+    let assignmentsFolder = verificationCache </> layoutAsString (pretty addr) <> "-assignments"
+    assignments <- readAssignmentsFromFolder assignmentsFolder
+    return $ CounterExampleResult assignments (show $ pretty addr)
+  return results
+
 data ValidateResult
   = Verified
   | Unverified
@@ -53,3 +88,33 @@ instance Pretty ValidateResult where
   pretty Verified = "Status: verified"
   pretty Unverified = "Status: unverified"
   pretty (IntegrityError err) = "Status: unknown" <> line <> line <> pretty err
+
+instance ToJSON ValidateResult where
+  toJSON validateResult = case validateResult of
+    Verified -> object ["status" .= ("verified" :: String)]
+    Unverified -> object ["status" .= ("unverified" :: String)]
+    IntegrityError err ->
+      object
+        [ "status" .= ("unknown" :: String),
+          "error" .= (show $ pretty err :: String)
+        ]
+
+data CounterExampleResult
+  = CounterExampleResult
+  { assignments :: [(String, RationalTensor)],
+    property :: String
+  }
+  deriving (Show, Eq)
+
+instance Pretty CounterExampleResult where
+  pretty (CounterExampleResult assignments propertyName) =
+    pretty propertyName
+      <> line
+      <> vsep (map (\(name, tensor) -> indent 2 $ pretty name <> ": " <> pretty tensor) assignments)
+
+instance ToJSON CounterExampleResult where
+  toJSON (CounterExampleResult assignments propertyName) =
+    object
+      [ "property" .= (propertyName :: String),
+        "assignments" .= map (\(name, tensor) -> object [fromString name .= (show $ pretty tensor :: String)]) assignments
+      ]

--- a/vehicle/src/Vehicle/Validate.hs
+++ b/vehicle/src/Vehicle/Validate.hs
@@ -91,6 +91,8 @@ instance Pretty ValidateResult where
   pretty Unverified = "Status: unverified"
   pretty (IntegrityError err) = "Status: unknown" <> line <> line <> pretty err
 
+-- | Cannot be derivied generically as ResourceIntegrityError (for IntegrityError) is not
+-- | a generic type or has a toJSON instance.
 instance ToJSON ValidateResult where
   toJSON validateResult = case validateResult of
     Verified -> object ["status" .= ("verified" :: String)]
@@ -110,11 +112,10 @@ data CounterExampleResult = CounterExampleResult
 instance Pretty CounterExampleResult where
   pretty (CounterExampleResult assignments propertyName)
     | null assignments = mempty
-    | otherwise =
-        pretty propertyName
-          <> line
-          <> vsep (map (\(name, tensor) -> indent 2 $ pretty name <> ": " <> pretty tensor) assignments)
+    | otherwise = pretty propertyName <> line <> pretty assignments
 
+-- | Won't derive generically so that the assignments "name" is the key,
+-- | and to have the pretty list of assignments rather then the entire JSON object of a tensor.
 instance ToJSON CounterExampleResult where
   toJSON (CounterExampleResult assignments propertyName)
     | null assignments = toJSON ()

--- a/vehicle/src/Vehicle/Validate.hs
+++ b/vehicle/src/Vehicle/Validate.hs
@@ -34,22 +34,23 @@ validate loggingSettings checkOptions = runLoggerT loggingSettings $ do
   -- default to command-line.
   status <- checkSpecificationStatus checkOptions
   counterExamples <- collectCounterexamples checkOptions
-  let nonEmptyCounterExamples = filter (\(CounterExampleResult assignments _) -> not (null assignments)) counterExamples
 
-  if outputAsJSON checkOptions
+  if not $ outputAsJSON checkOptions
     then do
-      let statusJSON =
-            if outputCounterExamples checkOptions
-              then case toJSON status of
-                Object o -> Object (o <> case toJSON (object ["counter-examples" .= toJSON nonEmptyCounterExamples]) of Object o' -> o'; _ -> mempty)
-                v -> v
-              else toJSON status
-      programOutput $ pretty $ unpack $ encodePretty' prettyJSONConfig statusJSON
-    else do
       -- Pretty print the status and counter-examples
       programOutput $ pretty status
       when (outputCounterExamples checkOptions) $ do
         programOutput $ line <> "Counterexamples:" <> line <> pretty counterExamples
+    else do
+      let statusJSON =
+            if not $ outputCounterExamples checkOptions
+              then toJSON status
+              else do
+                let nonEmptyCounterExamples = filter (\(CounterExampleResult assignments _) -> not (null assignments)) counterExamples
+                 in case toJSON status of
+                      Object o -> Object (o <> case toJSON (object ["counter-examples" .= toJSON nonEmptyCounterExamples]) of Object o' -> o'; _ -> mempty)
+                      v -> v
+      programOutput $ pretty $ unpack $ encodePretty' prettyJSONConfig statusJSON
 
 checkSpecificationStatus ::
   (MonadIO m, MonadLogger m) =>

--- a/vehicle/src/Vehicle/Validate.hs
+++ b/vehicle/src/Vehicle/Validate.hs
@@ -34,13 +34,14 @@ validate loggingSettings checkOptions = runLoggerT loggingSettings $ do
   -- default to command-line.
   status <- checkSpecificationStatus checkOptions
   counterExamples <- collectCounterexamples checkOptions
+  let nonEmptyCounterExamples = filter (\(CounterExampleResult assignments _) -> not (null assignments)) counterExamples
 
   if outputAsJSON checkOptions
     then do
       let statusJSON =
             if outputCounterExamples checkOptions
               then case toJSON status of
-                Object o -> Object (o <> case toJSON (object ["counter-examples" .= toJSON counterExamples]) of Object o' -> o'; _ -> mempty)
+                Object o -> Object (o <> case toJSON (object ["counter-examples" .= toJSON nonEmptyCounterExamples]) of Object o' -> o'; _ -> mempty)
                 v -> v
               else toJSON status
       programOutput $ pretty $ unpack $ encodePretty' prettyJSONConfig statusJSON
@@ -107,14 +108,18 @@ data CounterExampleResult
   deriving (Show, Eq)
 
 instance Pretty CounterExampleResult where
-  pretty (CounterExampleResult assignments propertyName) =
-    pretty propertyName
-      <> line
-      <> vsep (map (\(name, tensor) -> indent 2 $ pretty name <> ": " <> pretty tensor) assignments)
+  pretty (CounterExampleResult assignments propertyName)
+    | null assignments = mempty
+    | otherwise =
+        pretty propertyName
+          <> line
+          <> vsep (map (\(name, tensor) -> indent 2 $ pretty name <> ": " <> pretty tensor) assignments)
 
 instance ToJSON CounterExampleResult where
-  toJSON (CounterExampleResult assignments propertyName) =
-    object
-      [ "property" .= (propertyName :: String),
-        "assignments" .= map (\(name, tensor) -> object [fromString name .= (show $ pretty tensor :: String)]) assignments
-      ]
+  toJSON (CounterExampleResult assignments propertyName)
+    | null assignments = toJSON ()
+    | otherwise =
+        object
+          [ "property" .= propertyName,
+            "assignments" .= map (\(name, tensor) -> object [fromString name .= show (pretty tensor)]) assignments
+          ]

--- a/vehicle/src/Vehicle/Validate.hs
+++ b/vehicle/src/Vehicle/Validate.hs
@@ -101,8 +101,7 @@ instance ToJSON ValidateResult where
           "error" .= (show $ pretty err :: String)
         ]
 
-data CounterExampleResult
-  = CounterExampleResult
+data CounterExampleResult = CounterExampleResult
   { assignments :: [(String, RationalTensor)],
     property :: String
   }

--- a/vehicle/src/Vehicle/Verify/Specification/IO.hs
+++ b/vehicle/src/Vehicle/Verify/Specification/IO.hs
@@ -9,6 +9,7 @@ module Vehicle.Verify.Specification.IO
     verifySpecification,
     specificationCacheIndexFileName,
     isValidQueryFolder,
+    readAssignmentsFromFolder,
   )
 where
 
@@ -21,7 +22,7 @@ import Control.Monad.Writer (MonadWriter (..), WriterT (..), execWriterT)
 import Data.Aeson (decode)
 import Data.Aeson.Encode.Pretty (encodePretty')
 import Data.ByteString.Lazy qualified as BIO
-import Data.IDX (encodeIDXFile)
+import Data.IDX (decodeIDXFile, encodeIDXFile)
 import Data.IDX.Internal
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map qualified as Map
@@ -31,9 +32,9 @@ import Data.Text (intercalate, pack)
 import Data.Text.IO qualified as TIO
 import Data.Text.Lazy qualified as LazyText
 import Data.Vector qualified as BoxedVector
-import Data.Vector.Unboxed qualified as Vector (fromList)
+import Data.Vector.Unboxed qualified as Vector (fromList, toList)
 import Prettyprinter (fill)
-import System.Directory (copyFile, createDirectoryIfMissing, doesFileExist)
+import System.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory)
 import System.Exit (ExitCode (..))
 import System.FilePath (takeExtension, takeFileName, (<.>), (</>))
 import System.IO (stdout)
@@ -46,7 +47,7 @@ import Vehicle.Backend.Queries.UserVariableElimination.VariableReconstruction (r
 import Vehicle.Compile.Prelude
 import Vehicle.Data.Code.BooleanExpr
 import Vehicle.Data.QuantifiedVariable (UserVariableAssignment (..))
-import Vehicle.Data.Tensor (Tensor (..))
+import Vehicle.Data.Tensor (RationalTensor, Tensor (..))
 import Vehicle.Prelude.IO qualified as VIO (MonadStdIO (writeStdoutLn))
 import Vehicle.Verify.Core
 import Vehicle.Verify.QueryFormat
@@ -649,3 +650,23 @@ createPropertyProgressBar (PropertyAddress _ name indices) numberOfQueries = do
 
 closePropertyProgressBar :: (MonadIO m, MonadStdIO m) => PropertyProgressBar -> m ()
 closePropertyProgressBar _progressBar = VIO.writeStdoutLn ""
+
+-- | Reads (all) counter examples an assignments files folder
+readAssignmentsFromFolder ::
+  (MonadIO m) =>
+  FilePath ->
+  m [(Name, RationalTensor)]
+readAssignmentsFromFolder assignmentsFolder = do
+  exists <- liftIO $ doesDirectoryExist assignmentsFolder
+  if not exists
+    then return []
+    else do
+      files <- liftIO $ listDirectory assignmentsFolder
+      assignments <- forM files $ \file -> do
+        idxData <- liftIO $ decodeIDXFile (assignmentsFolder </> file)
+        case idxData of
+          Just (IDXDoubles _ dims values) ->
+            let boxedValues = BoxedVector.fromList (fmap realToFrac (Vector.toList values))
+             in return (pack $ show file, Tensor (Vector.toList dims) boxedValues)
+          _ -> fatalError $ "Unsupported IDX data format in file: " <+> quotePretty file
+      return assignments

--- a/vehicle/src/Vehicle/Verify/Specification/IO.hs
+++ b/vehicle/src/Vehicle/Verify/Specification/IO.hs
@@ -655,7 +655,7 @@ closePropertyProgressBar _progressBar = VIO.writeStdoutLn ""
 readAssignmentsFromFolder ::
   (MonadIO m) =>
   FilePath ->
-  m [(Name, RationalTensor)]
+  m [(String, RationalTensor)]
 readAssignmentsFromFolder assignmentsFolder = do
   exists <- liftIO $ doesDirectoryExist assignmentsFolder
   if not exists
@@ -667,6 +667,6 @@ readAssignmentsFromFolder assignmentsFolder = do
         case idxData of
           Just (IDXDoubles _ dims values) ->
             let boxedValues = BoxedVector.fromList (fmap realToFrac (Vector.toList values))
-             in return (pack $ show file, Tensor (Vector.toList dims) boxedValues)
+             in return (file, Tensor (Vector.toList dims) boxedValues)
           _ -> fatalError $ "Unsupported IDX data format in file: " <+> quotePretty file
       return assignments

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
@@ -136,7 +136,9 @@ validateModeTests =
               Just $
                 Validate $
                   ValidateOptions
-                    { verificationCache = "local/outputFolder"
+                    { verificationCache = "local/outputFolder",
+                      outputAsJSON = False,
+                      outputCounterExamples = False
                     }
           }
     ]


### PR DESCRIPTION
# Description of changes

The `--counter-examples` and `--json` options for validate and with updated python bindings.

The `--counter-examples` flag prints all the assignments for properties from the provided verification cache.
The `--json` option outputs as the following:
```
{
    "status": "<verified|unverified|unknown>",
    "error": "<error-message>",                                    (only if status is unknown)
    "counter-examples": [...]                                      (only if --counter-examples)
}
```
Where, "counter-examples" is `[]` if there are no counter-examples, or a list of results objects.
For example, a result-object has the format:
```
{
      "property": "safe",
      "assignments": [
        {
          "\"x\"": "[ -2.4, -1.6 ]"
        },
        {
          "\"y\"": "[ -2.4, -1.6 ]"
        },
      ]
    }
```