### PR TITLE
Typecheck json output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
 * Added extra option `--loggingPass` which allows you to control which compiler pass
   logging is enabled for. See `vehicle --help` for more information.
 
-* Update the `--json` option flag to be globally applicable for Vehicle to output the result of implementing commands as machine-readable JSON. It is currently implemented in the commands: `list`, `validate`, and `compile` with the `--json` or `-j` flag.
+* Update the `--json` option flag to be globally applicable for Vehicle to output the result of implementing commands as machine-readable JSON. It is currently implemented in the commands: `check`, `list`, `validate`, and `compile` with the `--json` or `-j` flag.
 
 ### Verifier backend
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@
 
 * Fixed bug where comparisons between tensors sometimes caused an error.
 
+### Python interface
+
+* The `check` function outputs as JSON.
+
 ## Version 0.18.0
 
 ### Vehicle language

--- a/vehicle-python/src/vehicle_lang/check/__init__.py
+++ b/vehicle-python/src/vehicle_lang/check/__init__.py
@@ -21,6 +21,7 @@ def check(
         str(specification),
         "--typeSystem",
         typeSystem._vehicle_option_name,
+        "--json",
     ]
 
     # Call Vehicle

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Provenance.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Provenance.hs
@@ -13,6 +13,7 @@ module Vehicle.Syntax.AST.Provenance
 where
 
 import Control.DeepSeq (NFData (..))
+import Data.Aeson (KeyValue ((.=)), Options (..), ToJSON (..), defaultOptions, genericToJSON, object)
 import Data.Hashable (Hashable (..))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
@@ -36,6 +37,13 @@ data Position = Position
     posColumn :: Int
   }
   deriving (Eq, Ord, Generic)
+
+instance ToJSON Position where
+  toJSON =
+    genericToJSON $
+      defaultOptions
+        { tagSingleConstructors = True
+        }
 
 instance Show Position where
   show (Position l c) = show (l, c)
@@ -100,6 +108,13 @@ data Provenance = Provenance
     file :: FilePath
   }
   deriving (Generic)
+
+instance ToJSON Provenance where
+  toJSON (Provenance (Range start end) _) =
+    object
+      [ "tag" .= toJSON @String "Provenance",
+        "contents" .= toJSON @[Int] [posLine start, posColumn start, posLine end, posColumn end]
+      ]
 
 noProvenance :: Provenance
 noProvenance = Provenance mempty "unknown"

--- a/vehicle/src/Vehicle/Backend/LossFunction/JSON.hs
+++ b/vehicle/src/Vehicle/Backend/LossFunction/JSON.hs
@@ -6,8 +6,7 @@ module Vehicle.Backend.LossFunction.JSON
   )
 where
 
-import Data.Aeson (KeyValue (..), ToJSON (..), genericToJSON)
-import Data.Aeson.Types (object)
+import Data.Aeson (ToJSON (..), genericToJSON)
 import Data.List (elemIndex)
 import Data.Ratio (Ratio, denominator, numerator, (%))
 import GHC.Generics (Generic)
@@ -16,7 +15,7 @@ import Vehicle.Compile.Arity
 import Vehicle.Compile.Context.Name
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.NBE (eval)
-import Vehicle.Compile.Prelude (Doc, HasProvenance (..), Ix (..), ModulePath (..), Name, Position, Provenance (..), Range (..), filterOutNonExplicitArgs, getBinderName, mkExplicitBinder, normAppList)
+import Vehicle.Compile.Prelude (Doc, HasProvenance (..), Ix (..), ModulePath (..), Name, Provenance (..), filterOutNonExplicitArgs, getBinderName, mkExplicitBinder, normAppList)
 import Vehicle.Compile.Prelude qualified as S (Binder, Decl, Expr (..), GenericDecl (..), GenericProg (..), Prog)
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Irrelevance (removeIrrelevantCodeFromProg)
@@ -24,7 +23,7 @@ import Vehicle.Data.Builtin.Loss (LossBuiltin (..), LossBuiltinConstructor, Loss
 import Vehicle.Data.Builtin.Loss qualified as L
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Tensor (Tensor, mapTensor)
-import Vehicle.Prelude (Annotation (..), GenericArg (..), HasName (..), HasType (..), Identifier (..), Position (..), explicit, indent, jsonOptions, line, resolutionError, squotes)
+import Vehicle.Prelude (Annotation (..), GenericArg (..), HasName (..), HasType (..), Identifier (..), explicit, indent, jsonOptions, line, resolutionError, squotes)
 import Vehicle.Prelude.Logging.Class
 import Vehicle.Syntax.Prelude (developerError)
 
@@ -131,16 +130,6 @@ instance ToJSON JType where
 
 instance ToJSON JBinder where
   toJSON = genericToJSON jsonOptions
-
-instance ToJSON Position where
-  toJSON = genericToJSON jsonOptions
-
-instance ToJSON Provenance where
-  toJSON (Provenance (Range start end) _) =
-    object
-      [ "tag" .= toJSON @String "Provenance",
-        "contents" .= toJSON @[Int] [posLine start, posColumn start, posLine end, posColumn end]
-      ]
 
 --------------------------------------------------------------------------------
 -- Conversion to JExpr

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -4,10 +4,14 @@ module Vehicle.Compile.Error where
 
 import Control.Exception (IOException)
 import Control.Monad.Except (MonadError, throwError)
+import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import Data.Typeable (Proxy)
 import Data.Void (Void)
+import GHC.Generics (Generic)
+import Prettyprinter (defaultLayoutOptions, layoutPretty)
+import Prettyprinter.Render.String (renderString)
 import Vehicle.Backend.LossFunction.Core (BooleanDifferentiableLogicField, TensorDifferentiableLogicField)
 import Vehicle.Backend.Prelude
 import Vehicle.Compile.Prelude
@@ -171,6 +175,9 @@ compilerDeveloperError message = throwError $ DevError message
 --  These may be either user or developer errors but in general we
 --  can't distinguish between the two.
 newtype ExternalError = ExternalError Text
+  deriving (Generic)
+
+instance ToJSON ExternalError
 
 -- | Errors that are the user's responsibility to fix.
 data UserError = UserError
@@ -179,10 +186,21 @@ data UserError = UserError
     fix :: Maybe UnAnnDoc
   }
 
+-- | Concrete instance for JSON serialization of UserError as
+-- UnAnnDoc cannot be serialized directly.
+instance ToJSON UserError where
+  toJSON (UserError p prob probFix) =
+    object
+      [ "provenance" .= toJSON p,
+        "problem" .= renderString (layoutPretty defaultLayoutOptions prob),
+        "fix" .= maybe "" (renderString . layoutPretty defaultLayoutOptions) probFix
+      ]
+
 data VehicleError
   = UError UserError
   | EError ExternalError
   | DError (Doc ())
+  deriving (Generic)
 
 instance Pretty VehicleError where
   pretty (UError (UserError p prob probFix)) =
@@ -194,6 +212,12 @@ instance Pretty VehicleError where
         <> maybe "" (\fix -> line <> fixText fix) probFix
   pretty (EError (ExternalError text)) = pretty text
   pretty (DError text) = unAnnotate text
+
+instance ToJSON VehicleError where
+  toJSON vehicleError = case vehicleError of
+    DError doc -> toJSON $ renderString $ layoutPretty defaultLayoutOptions doc
+    EError eError -> toJSON eError
+    UError uError -> toJSON uError
 
 fixText :: Doc ann -> Doc ann
 fixText t = "Fix:" <+> t

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -11,6 +11,9 @@ where
 
 import Control.Monad.Except (ExceptT, MonadError (..), runExcept)
 import Control.Monad.IO.Class (MonadIO (..))
+import Data.Aeson (ToJSON (toJSON))
+import Data.Aeson.Encode.Pretty (encodePretty')
+import Data.ByteString.Lazy.Char8 (unpack)
 import Data.Data (Proxy (..))
 import Data.Text as T (Text)
 import Vehicle.Backend.Prelude
@@ -151,13 +154,13 @@ runCompileMonad ::
   OutputAsJSON ->
   (forall n. (MonadStdIO n, MonadLogger n) => ExceptT CompileError n a) ->
   m a
-runCompileMonad loggingSettings _outputAsJSON x = do
+runCompileMonad loggingSettings outputAsJSON x = do
   errorOrResult <- runLoggerT loggingSettings (logCompileError x)
   case errorOrResult of
     Left err -> do
       let vehicleError = details err
-      -- let outputError = if outputAsJSON then pretty $ unpack $ encodePretty' prettyJSONConfig $ toJSON vehicleError else pretty vehicleError
-      fatalError $ pretty vehicleError
+      let outputError = if outputAsJSON then pretty $ unpack $ encodePretty' prettyJSONConfig $ toJSON vehicleError else pretty vehicleError
+      fatalError outputError
     Right val -> return val
 
 convertBackToStandardBuiltin ::

--- a/vehicle/tests/golden/error/externalError/syntax/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/externalError/syntax/TypeCheck.err.golden
@@ -1,0 +1,1 @@
+"syntax error at line 6, column 23 before `;'"

--- a/vehicle/tests/golden/error/externalError/syntax/syntaxError.vcl
+++ b/vehicle/tests/golden/error/externalError/syntax/syntaxError.vcl
@@ -1,0 +1,6 @@
+@network
+f : Tensor Real [1] -> Tensor Real [1]
+
+@property
+trivial : Bool
+trivial = f [0] ! 0 >

--- a/vehicle/tests/golden/error/externalError/syntax/test.json
+++ b/vehicle/tests/golden/error/externalError/syntax/test.json
@@ -1,0 +1,5 @@
+{
+  "name": "TypeCheck",
+  "run": "vehicle check -s syntaxError.vcl -j",
+  "needs": ["syntaxError.vcl"]
+}

--- a/vehicle/tests/golden/error/typing/incorrectTensorLength/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/typing/incorrectTensorLength/TypeCheck.err.golden
@@ -1,8 +1,13 @@
-Error in file 'incorrectTensorLength.vcl' at Line 2, Columns 10-11: unable to work out a valid type for the overloaded expression '[1]'.
-The possible options explored were:
-  1. List t
-    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'List ?22'.
-  2. Vector t d
-    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'Vector ?22 ?23'.
-  3. Tensor t (d :: ds)
-    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular '1' is not equal to '2'.
+{
+  "provenance": {
+    "tag": "Provenance",
+    "contents": [
+      2,
+      10,
+      2,
+      11
+    ]
+  },
+  "problem": "unable to work out a valid type for the overloaded expression '[1]'.\nThe possible options explored were:\n  1. List t\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'List ?22'.\n  2. Vector t d\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'Vector ?22 ?23'.\n  3. Tensor t (d :: ds)\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular '1' is not equal to '2'.",
+  "fix": ""
+}

--- a/vehicle/tests/golden/error/typing/incorrectTensorLength/test.json
+++ b/vehicle/tests/golden/error/typing/incorrectTensorLength/test.json
@@ -1,5 +1,5 @@
 {
   "name": "TypeCheck",
-  "run": "vehicle check -s incorrectTensorLength.vcl",
+  "run": "vehicle check -s incorrectTensorLength.vcl -j",
   "needs": ["incorrectTensorLength.vcl"]
 }

--- a/vehicle/tests/golden/error/typing/indexOutOfBoundsConcrete/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/typing/indexOutOfBoundsConcrete/TypeCheck.err.golden
@@ -1,1 +1,13 @@
-Error in file 'indexOutOfBoundsConcrete.vcl' at Line 2, Columns 21-22: the value '1' is too big to be used as an index of size '1'.
+{
+  "provenance": {
+    "tag": "Provenance",
+    "contents": [
+      2,
+      21,
+      2,
+      22
+    ]
+  },
+  "problem": "the value '1' is too big to be used as an index of size '1'.",
+  "fix": ""
+}

--- a/vehicle/tests/golden/error/typing/indexOutOfBoundsConcrete/test.json
+++ b/vehicle/tests/golden/error/typing/indexOutOfBoundsConcrete/test.json
@@ -1,5 +1,5 @@
 {
   "name": "TypeCheck",
-  "run": "vehicle check -s indexOutOfBoundsConcrete.vcl",
+  "run": "vehicle check -s indexOutOfBoundsConcrete.vcl -j",
   "needs": ["indexOutOfBoundsConcrete.vcl"]
 }


### PR DESCRIPTION
# Description of Changes
Implemented the JSON output for type check errors by toJSON for `VehicleError`.

General error schema:
```
{
 JSON or str based on Error Type
}
```