### PR TITLE
List quantified variables python

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,17 +4,13 @@
 
 ### Command-line interface
 
-* (BREAKING) For `list` the `properties` and `resources` subcommand are depreciated. The `list` command only outputs as JSON including changes to the JSON schema.
+* (BREAKING) The subcommands `properties` and `resources` for `vehicle list` have been removed. The `vehicle list` command now outputs all resources as well as quantified variables as JSON.
 
 ### Python interface
 
-* (BREAKING) Depreciated `list_resources` and `list_properties`, to instead use the `list` function.
+* (BREAKING) Removed `vehicle_lang.list_resources` and `vehicle_lang.list_properties`, in favour of the `vehicle_lang.list` function.
 
-* The `verify` command outputs as JSON.
-
-## Version 0.20.1
-
-* Changes to undocumented internal APIs.
+* The `verify` command now produces output as JSON.
 
 ## Version 0.20.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 # Changelog for Vehicle
 
+## Version 0.21.0
+
+### Command-line interface
+
+* (BREAKING) For `list` the `properties` and `resources` subcommand are depreciated. The `list` command only outputs as JSON including changes to the JSON schema.
+
+### Python interface
+
+* (BREAKING) Depreciated `list_resources` and `list_properties`, to instead use the `list` function.
+
+* The `verify` command outputs as JSON.
+
 ## Version 0.20.1
 
 * Changes to undocumented internal APIs.

--- a/vehicle-python/src/vehicle_lang/__init__.py
+++ b/vehicle-python/src/vehicle_lang/__init__.py
@@ -10,8 +10,7 @@ from .compile.error import VehiclePropertyNotFound as VehiclePropertyNotFound
 from .error import VehicleError as VehicleError
 from .error import VehicleInternalError as VehicleInternalError
 from .export import export_to_solver as export_to_solver
-from .list import list_properties as list_properties
-from .list import list_resources as list_resources
+from .list import list as list
 from .session.error import VehicleSessionClosed as VehicleSessionClosed
 from .session.error import VehicleSessionUsed as VehicleSessionUsed
 from .typing import AnyOptimiser as AnyOptimiser
@@ -41,8 +40,7 @@ __all__: List[str] = [
     # Export
     "export_to_solver",
     # List
-    "list_resources",
-    "list_properties",
+    "list",
     # Error types
     "VehicleError",
     "VehicleSessionClosed",

--- a/vehicle-python/src/vehicle_lang/list/__init__.py
+++ b/vehicle-python/src/vehicle_lang/list/__init__.py
@@ -5,35 +5,14 @@ from .. import session
 from ..error import VehicleError
 
 
-def list_resources(specification: Union[str, Path]) -> str:
+def list(specification: Union[str, Path]) -> str:
     """
-    List all networks, datasets, and parameters in the specification.
+    List all networks, datasets, parameters, and properties in the specification.
 
-    :param specification: The path to the Vehicle specification file to list resources for.
+    :param specification: The path to the Vehicle specification file to list entities for.
     :return: list of entities as JSON.
     """
-    args = ["list", "resources", "--specification", str(specification), "--json"]
-
-    # Call Vehicle
-    exc, out, err, _ = session.check_output(args)
-
-    # Check for errors
-    if exc != 0:
-        raise VehicleError(f"{err}")
-    elif not out:
-        return ""
-
-    return out
-
-
-def list_properties(specification: Union[str, Path]) -> str:
-    """
-    List all properties in the specification.
-
-    :param specification: The path to the Vehicle specification file to list properties for.
-    :return: list of entities as JSON.
-    """
-    args = ["list", "properties", "--specification", str(specification), "--json"]
+    args = ["list", "--specification", str(specification), "--json"]
 
     # Call Vehicle
     exc, out, err, _ = session.check_output(args)

--- a/vehicle/src/Vehicle/Verify/Specification/Execute.hs
+++ b/vehicle/src/Vehicle/Verify/Specification/Execute.hs
@@ -323,7 +323,7 @@ writeWitnessToFile verificationCache address (UserVariableAssignment assignments
   let witnessFolder = verificationCache </> layoutAsString (pretty address) <> "-assignments"
   liftIO $ createDirectoryIfMissing True witnessFolder
   forM_ assignments $ \(var, tensor) -> do
-    let file = witnessFolder </> show var
+    let file = witnessFolder </> layoutAsString (pretty var)
     let dims = Vector.fromList (shapeOf tensor)
     -- TODO got to be a better way to do this conversion...
     let unboxedVector = Vector.fromList $ BoxedVector.toList (fmap realToFrac (Tensor.toVector tensor))


### PR DESCRIPTION
Updating the python bindings for the `list` command.
- DEPRECIATED `list_resources`, and `list_properties` to use `list`
- Updated changelog
- FIX(?) remove outer double quotes from the filenames of saved assignments in the cache. For example, the assignment for quantified variable `x` was saved as `"x"`.

**Note: This should be merged after #950.**