### PR TITLE
Fix the parse issue due to positioning of `--json` flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for Vehicle
 
+## Version 0.21.1
+
+### Python interface
+
+* Fixes the `--json` flag parsing error when using the `verify` command.
+
 ## Version 0.21.0
 
 ### Command-line interface

--- a/vehicle-python/src/vehicle_lang/verify/__init__.py
+++ b/vehicle-python/src/vehicle_lang/verify/__init__.py
@@ -28,7 +28,7 @@ def verify(
     :param verifier_location: The path to the verifier executable, defaults to searching the system path.
     :param cache: The path to the proof cache used by Vehicle, defaults to not writing a proof cache.
     """
-    args = ["verify", "--specification", str(specification), "--json"]
+    args = ["verify", "--specification", str(specification)]
 
     if properties is not None:
         for property_name in set(properties):
@@ -50,6 +50,8 @@ def verify(
 
     if cache is not None:
         args.extend(["--cache", str(cache)])
+
+    args.extend(["--json"])
 
     # Call Vehicle
     exc, out, err, log = session.check_output(args)


### PR DESCRIPTION
Fix the positioning of the `--json` flag to fix the parsing error i.e. the `--json` flag must be before or after all the arguments for a vehicle command.

@MatthewDaggitt sorry about this, I didn't realize that the position of the `--json` flag mattered.