### PR TITLE
Fix #948 type-checking of secondary subsystems via command-line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for Vehicle
 
+## Next release
+
+### Command-line interface
+
+* The `vehicle-check` command no longer errors when you request a typing subsystem.
+
+* The `vehicle check` command now accepts the `--declaration` argument to only type-check certain declarations.
+
 ## Version 0.21.0
 
 ### Command-line interface

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Prog.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Prog.hs
@@ -10,9 +10,10 @@ import Vehicle.Syntax.AST.Decl (GenericDecl)
 -- Programs
 
 -- | Type of Vehicle internal programs.
-newtype GenericProg expr
-  = -- | List of declarations.
-    Main [GenericDecl expr]
+newtype GenericProg expr = Main
+  { -- | List of declarations.
+    declarations :: [GenericDecl expr]
+  }
   deriving (Show, Functor, Foldable, Traversable, Generic)
 
 instance (NFData expr) => NFData (GenericProg expr)

--- a/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination/Error.hs
+++ b/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination/Error.hs
@@ -4,14 +4,11 @@ module Vehicle.Backend.Solver.UserVariableElimination.Error
   )
 where
 
-import Data.List.NonEmpty qualified as NonEmpty
+import Data.Set (Set)
+import Data.Set qualified as Set (singleton)
 import Vehicle.Compile.Error
-import Vehicle.Compile.Monomorphisation (MonomorphisationSettings (MonoSettings, isMonomorphisableBinder, keepUnusedDeclaration), monomorphise)
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Print
-import Vehicle.Compile.Type.Irrelevance (removeIrrelevantCodeFromProg)
-import Vehicle.Compile.Type.Subsystem (linearityTypeCheck, polarityTypeCheck, resolveInstanceArgumentsAndCasts)
-import Vehicle.Data.Builtin.Interface.Print
+import Vehicle.Compile.Type.Subsystem (linearityTypeCheck, polarityTypeCheck)
 import Vehicle.Data.Builtin.Linearity
 import Vehicle.Data.Builtin.Linearity.Type ()
 import Vehicle.Data.Builtin.Polarity
@@ -55,9 +52,9 @@ diagnoseSpecIncompatiblility ::
   (MonadCompile m) =>
   Prog Builtin ->
   Identifier ->
-  (Prog Builtin -> m (Either CompileError (Prog builtin))) ->
+  (Prog Builtin -> Set Identifier -> m (Either CompileError (Prog builtin))) ->
   m (Either CompileError (Type builtin))
-diagnoseSpecIncompatiblility prog propertyIdentifier typeCheck = do
+diagnoseSpecIncompatiblility prog propertyIdentifier typeCheckFn = do
   setCallDepth 0
   logDebug MinDetail $
     "ERROR: found uncompilable property."
@@ -66,50 +63,10 @@ diagnoseSpecIncompatiblility prog propertyIdentifier typeCheck = do
       <> line
 
   logCompilerPass QueryError $ do
-    monomorphisedProg <-
-      monomorphise prog $
-        MonoSettings
-          { isMonomorphisableBinder = not . isExplicit,
-            keepUnusedDeclaration = (== propertyIdentifier)
-          }
-    irrelevantFreeProg <- removeIrrelevantCodeFromProg monomorphisedProg
-    implicitFreeProg <- removeImplicitArgs irrelevantFreeProg
-    instanceFreeProg <- resolveInstanceArgumentsAndCasts implicitFreeProg
-    errorOrLinearityProg <- typeCheck instanceFreeProg
-
+    errorOrLinearityProg <- typeCheckFn prog (Set.singleton propertyIdentifier)
     case errorOrLinearityProg of
       Left err -> return $ Left err
       Right linearityProg -> Right <$> findDeclType propertyIdentifier linearityProg
-
-removeImplicitArgs ::
-  forall m builtin.
-  (MonadCompile m, PrintableBuiltin builtin) =>
-  Prog builtin ->
-  m (Prog builtin)
-removeImplicitArgs prog =
-  logCompilerSection2 MaxDetail "removal of implicit arguments" $ do
-    result <- traverse go prog
-    logCompilerPassOutput $ prettyExternal result
-    return result
-  where
-    go :: Expr builtin -> m (Expr builtin)
-    go expr = case expr of
-      App fun args -> do
-        fun' <- go fun
-        let nonImplicitArgs = NonEmpty.filter (not . isImplicit) args
-        nonImplicitArgs' <- traverse (traverse go) nonImplicitArgs
-        return $ normAppList fun' nonImplicitArgs'
-      BoundVar {} -> return expr
-      FreeVar {} -> return expr
-      Universe {} -> return expr
-      Meta {} -> return expr
-      Hole {} -> return expr
-      Builtin {} -> return expr
-      Pi p binder res -> Pi p <$> traverse go binder <*> go res
-      Lam p binder body -> Lam p <$> traverse go binder <*> go body
-      Let p bound binder body -> Let p <$> go bound <*> traverse go binder <*> go body
-      Record p ident fields -> Record p ident <$> traverseRecordFields go fields
-      RecordAcc p record field -> RecordAcc p <$> go record <*> pure field
 
 findDeclType :: (MonadCompile m) => Identifier -> Prog builtin -> m (Expr builtin)
 findDeclType ident (Main decls) = do

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -198,6 +198,7 @@ typeCheckParser =
   TypeCheckOptions
     <$> specificationParser
     <*> typeSystemParser
+    <*> declarationParser
 
 typeCheckParserInfo :: ParserInfo ModeOptions
 typeCheckParserInfo = info (Check <$> typeCheckParser) typeCheckDescription

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -4,13 +4,10 @@ module Vehicle.Compile
   )
 where
 
-import Control.Monad.Except (MonadError (..))
+import Control.Monad.Writer (MonadWriter (..), WriterT (..))
 import Data.Aeson (ToJSON (..))
 import Data.Aeson.Encode.Pretty (encodePretty')
 import Data.ByteString.Lazy.Char8 (unpack)
-import Data.List.NonEmpty
-import Data.Maybe (mapMaybe)
-import Data.Set qualified as Set
 import Vehicle.Backend.Agda
 import Vehicle.Backend.LossFunction (convertToLossTensors)
 import Vehicle.Backend.LossFunction.JSON
@@ -19,10 +16,8 @@ import Vehicle.Backend.LossFunction.Logics (dslFor)
 import Vehicle.Backend.Prelude
 import Vehicle.Backend.Rocq
 import Vehicle.Backend.Solver
-import Vehicle.Compile.Dependency
 import Vehicle.Compile.Error
 import Vehicle.Compile.FunctionaliseResources (functionaliseResources)
-import Vehicle.Compile.Monomorphisation (MonomorphisationSettings (..), hoistInferableParameters, monomorphise)
 import Vehicle.Compile.Prelude as CompilePrelude
 import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Subsystem
@@ -51,71 +46,32 @@ data CompileOptions = CompileOptions
 compile :: (MonadStdIO IO) => LoggingSettings -> OutputAsJSON -> CompileOptions -> IO ()
 compile loggingSettings outputAsJSON options@CompileOptions {..} =
   runCompileMonad loggingSettings outputAsJSON $ do
-    (imports, prog) <-
+    prog <-
       typeCheckUserProg $
         TypeCheckOptions
           { specification = specification,
-            secondaryTypeSystem = Nothing
+            secondaryTypeSystem = Nothing,
+            declarationsToCompile = declarationsToCompile
           }
 
-    checkDeclarationNamesPresent prog declarationsToCompile
-    simplifiedProg <- simplifyProgram prog declarationsToCompile
-
     case target of
-      VerifierQueries queryFormatID -> do
-        let resources = Resources specification networkLocations datasetLocations parameterValues
-        let mergedProg = mergeImports imports simplifiedProg
-        compileToQueryFormat mergedProg resources queryFormatID output
-      LossFunction differentiableLogic -> do
-        let mergedProg = mergeImports imports simplifiedProg
-        compileToLossFunction differentiableLogic mergedProg output outputAsJSON
-      ITP itp ->
-        compileToITP itp options simplifiedProg
-
-simplifyProgram ::
-  (MonadCompile m) =>
-  Prog Builtin ->
-  DeclarationNames ->
-  m (Prog Builtin)
-simplifyProgram prog declarationsToCompile = do
-  let keepUnusedDeclaration =
-        if null declarationsToCompile
-          then const True
-          else do
-            let declsToCompile = Set.fromList declarationsToCompile
-            \ident -> Set.member (nameOf ident) declsToCompile
-  monomorphisedProg <-
-    monomorphise prog $
-      MonoSettings
-        { isMonomorphisableBinder = not . isExplicit,
-          keepUnusedDeclaration = keepUnusedDeclaration
-        }
-  castFreeProgram <- resolveInstanceArgumentsAndCasts monomorphisedProg
-  return castFreeProgram
-
-checkDeclarationNamesPresent :: (MonadCompile m) => Prog Builtin -> DeclarationNames -> m ()
-checkDeclarationNamesPresent (Main decls) requestedDeclNames = do
-  let actualDeclNames = Set.fromList $ fmap nameOf decls
-  let missingNames = Set.toList $ Set.fromList requestedDeclNames `Set.difference` actualDeclNames
-  case missingNames of
-    [] -> return ()
-    n : ns ->
-      throwError $
-        MissingRequestedDeclarations (n :| ns)
+      VerifierQueries queryFormat -> compileToQueryFormat options queryFormat prog
+      LossFunction logic -> compileToLossFunction logic prog output outputAsJSON
+      ITP itp -> compileToITP itp options prog
 
 --------------------------------------------------------------------------------
 -- Backend-specific compilation functions
 
 compileToQueryFormat ::
   (MonadCompile m, MonadStdIO m) =>
-  Prog Builtin ->
-  Resources ->
+  CompileOptions ->
   QueryFormatID ->
-  Maybe FilePath ->
+  Prog Builtin ->
   m ()
-compileToQueryFormat typedProg resources queryFormatID output = do
+compileToQueryFormat CompileOptions {..} queryFormatID typedProg = do
   logCompilerPass QueryBackend $ do
     let verifier = queryFormats queryFormatID
+    let resources = Resources specification networkLocations datasetLocations parameterValues
     compileToQueries verifier typedProg resources output
 
 compileToITP ::
@@ -124,15 +80,10 @@ compileToITP ::
   CompileOptions ->
   Prog Builtin ->
   m ()
-compileToITP itp CompileOptions {..} typedProg@(Main ds) =
+compileToITP itp CompileOptions {..} typedProg =
   logCompilerPass ITPBackend $ do
-    -- Prune all standard-library declarations that aren't used.
-    let declsToCompile = mapMaybe (\d -> if isUserCode d then Just (nameOf d) else Nothing) ds
-    let dependencyGraph = createDependencyGraph typedProg
-    prunedProg <- pruneUnusedDeclarations typedProg dependencyGraph declsToCompile
-
     -- Analyse the program to find out which `Bool`s are decidable and which aren't.
-    decProg <- decidabilityTypeCheck prunedProg
+    decProg <- decidabilityTypeCheck typedProg
 
     -- Compile depending on the ITP
     case itp of
@@ -164,3 +115,18 @@ compileToLossFunction logicID typedProg outputFile outputAsJSON =
           | outputAsJSON = pretty $ unpack $ encodePretty' prettyJSONConfig $ toJSON jsonProg
           | otherwise = prettyFriendly (convertFromJSONProg jsonProg)
     writeResultToFile Nothing outputFile outputText
+
+hoistInferableParameters :: (MonadCompile m) => Prog builtin -> m (Prog builtin)
+hoistInferableParameters (Main ds) = do
+  (otherDecls, inferableParameters) <- runWriterT (goDecls ds)
+  return $ Main (inferableParameters <> otherDecls)
+  where
+    goDecls :: (MonadWriter [Decl builtin] m) => [Decl builtin] -> m [Decl builtin]
+    goDecls [] = return []
+    goDecls (decl : decls) = do
+      decls' <- goDecls decls
+      case decl of
+        DefAbstract _ _ (ParameterDef Inferable) _ -> do
+          tell [decl]
+          return decls'
+        _ -> return $ decl : decls'

--- a/vehicle/src/Vehicle/Compile/Monomorphisation.hs
+++ b/vehicle/src/Vehicle/Compile/Monomorphisation.hs
@@ -1,9 +1,7 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Vehicle.Compile.Monomorphisation
-  ( MonomorphisationSettings (..),
-    monomorphise,
-    hoistInferableParameters,
+  ( monomorphise,
   )
 where
 
@@ -48,11 +46,6 @@ import Vehicle.Data.Hashing ()
 -- t : Rat
 -- t = n {{fromNatToRat}}
 
-data MonomorphisationSettings builtin = MonoSettings
-  { isMonomorphisableBinder :: Binder builtin -> Bool,
-    keepUnusedDeclaration :: Identifier -> Bool
-  }
-
 -- | Tries to monomorphise any polymorphic functions by creating a copy per
 -- concrete type each function is used with.
 -- Not very sophisticated at the moment, if this needs to be improved perhaps
@@ -62,17 +55,19 @@ monomorphise ::
   forall m builtin.
   (MonadCompile m, Hashable builtin, PrintableBuiltin builtin) =>
   Prog builtin ->
-  MonomorphisationSettings builtin ->
+  RootDeclarations ->
   m (Prog builtin)
-monomorphise prog settings =
+monomorphise prog rootDecls =
   logCompilerSection2 MinDetail "monomorphisation" $ do
-    (prog2, substitutions) <- runReaderT (evalStateT (runWriterT (monomorphiseProg prog)) mempty) settings
-    result <- runReaderT (replacePreviousApplications (isMonomorphisableBinder settings) prog2) substitutions
+    (prog2, substitutions) <- evalStateT (runWriterT (monomorphiseProg rootDecls prog)) mempty
+    result <- runReaderT (replacePreviousApplications prog2) substitutions
     logCompilerPassOutput $ prettyExternal result
     return result
 
 --------------------------------------------------------------------------------
 -- Backward pass - collects the sites for monomorphisation
+
+type RootDeclarations = Identifier -> Bool
 
 -- | Applications of monomorphisable functions
 type CandidateApplications builtin = Map Identifier (NonEmpty [Arg builtin])
@@ -84,42 +79,45 @@ type MonadCollect builtin m =
   ( MonadCompile m,
     MonadState (CandidateApplications builtin) m,
     MonadWriter (SubsitutionSolutions builtin) m,
-    MonadReader (MonomorphisationSettings builtin) m,
     Hashable builtin,
     PrintableBuiltin builtin
   )
 
 monomorphiseProg ::
   (MonadCollect builtin m) =>
+  RootDeclarations ->
   Prog builtin ->
   m (Prog builtin)
-monomorphiseProg (Main decls) = do
+monomorphiseProg rootDecls (Main decls) = do
   logCompilerSection2 MaxDetail "collecting monomorphisation sites" $ do
-    monoedDecls <- traverse monomorphiseDecls (reverse decls)
+    monoedDecls <- traverse (monomorphiseDecls rootDecls) (reverse decls)
     return $ Main $ reverse $ concat monoedDecls
 
 monomorphiseDecls ::
   (MonadCollect builtin m) =>
+  RootDeclarations ->
   Decl builtin ->
   m [Decl builtin]
-monomorphiseDecls decl = do
+monomorphiseDecls rootDecls decl = do
   let ident = identifierOf decl
   logCompilerSection2 MaxDetail (quotePretty ident) $ do
     logDebug MaxDetail $ prettyExternal decl <> line
-    newDecls <- monomorphiseDecl decl
+    newDecls <- monomorphiseDecl decl (rootDecls ident)
     forM_ newDecls collectReferences
     return newDecls
 
 monomorphiseDecl ::
   (MonadCollect builtin m) =>
   Decl builtin ->
+  Bool ->
   m [Decl builtin]
-monomorphiseDecl decl =
+monomorphiseDecl decl isRootDecl =
   logCompilerSection2 MaxDetail "monomorphising based on previous applications" $ do
     let ident = identifierOf decl
     maybeApplications <- gets (Map.lookup ident)
-    let handle = maybe handleUnusedDecl handleUsedDecl maybeApplications
-    result <- handle decl
+    result <- case maybeApplications of
+      Nothing -> handleUnusedDecl decl isRootDecl
+      Just apps -> handleUsedDecl apps decl
     modify (Map.delete ident)
     return result
 
@@ -157,23 +155,22 @@ handleUsedDecl applications decl = do
 handleUnusedDecl ::
   (MonadCollect builtin m) =>
   Decl builtin ->
+  Bool ->
   m [Decl builtin]
-handleUnusedDecl decl = do
-  MonoSettings {..} <- ask
-  logDebug MaxDetail "No applications of found."
-
-  if keepUnusedDeclaration (identifierOf decl)
+handleUnusedDecl decl isRootDecl = do
+  logDebug MaxDetail $ "No applications of declaration" <+> quotePretty (identifierOf decl) <+> "found."
+  if isRootDecl
     then do
       -- Work out if the unused declaration needs to be monomorphised
       let fakeArgs = explicit (Hole mempty "fakeArg") : fakeArgs
-      let (argsToMono, _) = obtainArgsToMonomorphise isMonomorphisableBinder (typeOf decl) fakeArgs
+      let (argsToMono, _) = obtainArgsToMonomorphise (typeOf decl) fakeArgs
       let needsToBeMonomorphised = not (null argsToMono)
 
       if needsToBeMonomorphised
         then do
           -- All unused declarations shouldn't have any implicit type-parameters as they
           -- should have been resolved by generalisation at type-checking time (special case).
-          developerError $ "Unexpected non-monomorphisable decl:" <> lineIndent (prettyExternal decl)
+          developerError $ "Unexpected unused non-monomorphisable decl:" <> lineIndent (prettyExternal decl)
         else do
           logDebug MaxDetail "Keeping declaration"
           return [decl]
@@ -187,8 +184,7 @@ calculateMonomorphisations ::
   NonEmpty [Arg builtin] ->
   m [[Arg builtin]]
 calculateMonomorphisations declType allApplications = do
-  MonoSettings {..} <- ask
-  let calculateMonomorphisation = obtainArgsToMonomorphise isMonomorphisableBinder declType
+  let calculateMonomorphisation = obtainArgsToMonomorphise declType
   let monomorphisations = fmap (fst . calculateMonomorphisation) allApplications
   -- This is inefficient and not strictly semantically correct.
   -- Semantic equality is difficult however.
@@ -279,10 +275,9 @@ type MonadInsert builtin m =
 replacePreviousApplications ::
   forall builtin m.
   (MonadInsert builtin m) =>
-  (Binder builtin -> Bool) ->
   Prog builtin ->
   m (Prog builtin)
-replacePreviousApplications shouldMonomorphiseBinder prog =
+replacePreviousApplications prog =
   logCompilerSection2 MaxDetail "applying monomorphisation sites" $ do
     traverse (traverseFreeVarsM (const id) replaceCandidateApplication) prog
   where
@@ -299,7 +294,7 @@ replacePreviousApplications shouldMonomorphiseBinder prog =
           logCompilerSection2 MaxDetail "replacing monomorphised application" $ do
             logDebug MaxDetail $ "function: " <+> pretty ident
             logDebug MaxDetail $ "arguments:" <+> prettyVerbose args
-            let (argsToMono, remainingArgs) = obtainArgsToMonomorphise shouldMonomorphiseBinder typ args
+            let (argsToMono, remainingArgs) = obtainArgsToMonomorphise typ args
             logDebug MaxDetail $ "arguments-to-mono:" <+> prettyVerbose argsToMono
             logDebug MaxDetail $ "remaining-mono:" <+> prettyVerbose remainingArgs
             case HashMap.lookup argsToMono applications of
@@ -335,31 +330,15 @@ getTypeJoiner nameJoiner = nameJoiner <> nameJoiner
 
 obtainArgsToMonomorphise ::
   forall builtin.
-  (Binder builtin -> Bool) ->
   Type builtin ->
   [Arg builtin] ->
   ([Arg builtin], [Arg builtin])
-obtainArgsToMonomorphise shouldMonomorphiseBinder typ appArgs =
+obtainArgsToMonomorphise typ appArgs =
   fromMaybe ([], appArgs) (go typ appArgs)
   where
     go :: Type builtin -> [Arg builtin] -> Maybe ([Arg builtin], [Arg builtin])
     go t args = case (t, args) of
       (Pi _ binder result, a : as)
-        | shouldMonomorphiseBinder binder ->
+        | not (isExplicit binder) ->
             Just $ maybe ([a], as) (first (a :)) (go result as)
       _ -> Nothing
-
-hoistInferableParameters :: (MonadCompile m) => Prog builtin -> m (Prog builtin)
-hoistInferableParameters (Main ds) = do
-  (otherDecls, inferableParameters) <- runWriterT (goDecls ds)
-  return $ Main (inferableParameters <> otherDecls)
-  where
-    goDecls :: (MonadWriter [Decl builtin] m) => [Decl builtin] -> m [Decl builtin]
-    goDecls [] = return []
-    goDecls (decl : decls) = do
-      decls' <- goDecls decls
-      case decl of
-        DefAbstract _ _ (ParameterDef Inferable) _ -> do
-          tell [decl]
-          return decls'
-        _ -> return $ decl : decls'

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem.hs
@@ -7,21 +7,28 @@ module Vehicle.Compile.Type.Subsystem
 where
 
 import Control.Monad.Except (MonadError (..), runExceptT)
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Maybe (mapMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Vehicle.Backend.Prelude
+import Vehicle.Compile.Dependency (createDependencyGraph, pruneUnusedDeclarations)
 import Vehicle.Compile.Error
-import Vehicle.Compile.Monomorphisation (MonomorphisationSettings (..), monomorphise)
+import Vehicle.Compile.Monomorphisation (monomorphise)
 import Vehicle.Compile.Normalise.NBE (NormalisableBuiltin, findInstanceArg)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyExternal)
 import Vehicle.Compile.Print.Error (errorInSubsystemMessage)
 import Vehicle.Compile.Type (typeCheckProg)
 import Vehicle.Compile.Type.Core (InstanceDatabase, emptyInstanceDatabase)
+import Vehicle.Compile.Type.Irrelevance
 import Vehicle.Compile.Type.System
 import Vehicle.Data.Builtin.Decidability (DecidabilityBuiltin (..))
 import Vehicle.Data.Builtin.Decidability.Instances (decidabilityBuiltinInstances)
 import Vehicle.Data.Builtin.Decidability.Type ()
 import Vehicle.Data.Builtin.Interface (BuiltinHasListLiterals)
 import Vehicle.Data.Builtin.Interface.Normalise (NormalisableBuiltin (..))
+import Vehicle.Data.Builtin.Interface.Print
 import Vehicle.Data.Builtin.Linearity (LinearityBuiltin)
 import Vehicle.Data.Builtin.Linearity.Type ()
 import Vehicle.Data.Builtin.Polarity (PolarityBuiltin)
@@ -31,38 +38,46 @@ import Vehicle.Data.Builtin.Standard
 polarityTypeCheck ::
   (MonadCompile m) =>
   Prog Builtin ->
+  Set Identifier ->
   m (Either CompileError (Prog PolarityBuiltin))
-polarityTypeCheck = typeCheckWithSubsystem PolarityTypes emptyInstanceDatabase
+polarityTypeCheck prog declarationsToCompile = do
+  let keepUnused = if Set.null declarationsToCompile then isUserCode else (`Set.member` declarationsToCompile)
+  monomorphisedProg <- monomorphise prog keepUnused
+  irrelevantFreeProg <- removeIrrelevantCodeFromProg monomorphisedProg
+  implicitFreeProg <- removeImplicitArgs irrelevantFreeProg
+  instanceFreeProg <- resolveInstanceArgumentsAndCasts implicitFreeProg
+  typeCheckWithSubsystem PolarityTypes emptyInstanceDatabase instanceFreeProg
 
 linearityTypeCheck ::
   (MonadCompile m) =>
   Prog Builtin ->
+  Set Identifier ->
   m (Either CompileError (Prog LinearityBuiltin))
-linearityTypeCheck = typeCheckWithSubsystem LinearityTypes emptyInstanceDatabase
+linearityTypeCheck prog declarationsToCompile = do
+  let keepUnused = if Set.null declarationsToCompile then isUserCode else (`Set.member` declarationsToCompile)
+  monomorphisedProg <- monomorphise prog keepUnused
+  irrelevantFreeProg <- removeIrrelevantCodeFromProg monomorphisedProg
+  implicitFreeProg <- removeImplicitArgs irrelevantFreeProg
+  instanceFreeProg <- resolveInstanceArgumentsAndCasts implicitFreeProg
+  typeCheckWithSubsystem LinearityTypes emptyInstanceDatabase instanceFreeProg
 
 decidabilityTypeCheck ::
   (MonadCompile m) =>
   Prog Builtin ->
   m (Prog DecidabilityBuiltin)
 decidabilityTypeCheck prog = do
-  errorOrDecProg <- typeCheckWithSubsystem DecidabilityTypes decidabilityBuiltinInstances prog
+  -- Prune all standard-library declarations that aren't used.
+  let declsToCompile = mapMaybe (\d -> if isUserCode d then Just (nameOf d) else Nothing) (declarations prog)
+  let dependencyGraph = createDependencyGraph prog
+  prunedProg <- pruneUnusedDeclarations prog dependencyGraph declsToCompile
+
+  errorOrDecProg <- typeCheckWithSubsystem DecidabilityTypes decidabilityBuiltinInstances prunedProg
   decProg <- case errorOrDecProg of
     Left err -> throwError $ DevError $ errorInSubsystemMessage "determine the decidability of the program for export to ITP" err
     Right decProg -> return decProg
 
-  monoDecProg <-
-    monomorphise decProg $
-      MonoSettings
-        { isMonomorphisableBinder = \binder -> not (isExplicit binder) || isDeclTypeClassBinder binder,
-          keepUnusedDeclaration = isUserCode
-        }
-  instanceFreeDecProg <- resolveInstanceArgumentsAndCasts monoDecProg
-  return instanceFreeDecProg
-  where
-    isDeclTypeClassBinder :: Binder DecidabilityBuiltin -> Bool
-    isDeclTypeClassBinder binder = case typeOf binder of
-      App (Builtin _ (DecidabilityBuiltinTypeClass {})) _ -> True
-      _ -> False
+  monoDecProg <- monomorphise decProg isUserCode
+  resolveInstanceArgumentsAndCasts monoDecProg
 
 typeCheckWithSubsystem ::
   forall builtin m.
@@ -128,3 +143,33 @@ resolveInstanceArgumentsAndCasts prog =
           Lam _ binder e -> Lam p (fmap go binder) (go e)
           Record _ ident fields -> Record p ident (mapRecordFields go fields)
           RecordAcc _ record (ident, FieldName _ name) -> RecordAcc p (go record) (ident, FieldName p name)
+
+removeImplicitArgs ::
+  forall m builtin.
+  (MonadCompile m, PrintableBuiltin builtin) =>
+  Prog builtin ->
+  m (Prog builtin)
+removeImplicitArgs prog =
+  logCompilerSection2 MaxDetail "removal of implicit arguments" $ do
+    result <- traverse go prog
+    logCompilerPassOutput $ prettyExternal result
+    return result
+  where
+    go :: Expr builtin -> m (Expr builtin)
+    go expr = case expr of
+      App fun args -> do
+        fun' <- go fun
+        let nonImplicitArgs = NonEmpty.filter (not . isImplicit) args
+        nonImplicitArgs' <- traverse (traverse go) nonImplicitArgs
+        return $ normAppList fun' nonImplicitArgs'
+      BoundVar {} -> return expr
+      FreeVar {} -> return expr
+      Universe {} -> return expr
+      Meta {} -> return expr
+      Hole {} -> return expr
+      Builtin {} -> return expr
+      Pi p binder res -> Pi p <$> traverse go binder <*> go res
+      Lam p binder body -> Lam p <$> traverse go binder <*> go body
+      Let p bound binder body -> Let p <$> go bound <*> traverse go binder <*> go body
+      Record p ident fields -> Record p ident <$> traverseRecordFields go fields
+      RecordAcc p record field -> RecordAcc p <$> go record <*> pure field

--- a/vehicle/src/Vehicle/List.hs
+++ b/vehicle/src/Vehicle/List.hs
@@ -37,13 +37,13 @@ list :: (MonadStdIO IO) => LoggingSettings -> OutputAsJSON -> ListOptions -> IO 
 list loggingSettings outputAsJSON ListOptions {..} =
   runCompileMonad loggingSettings outputAsJSON $ do
     -- Type check the program
-    (imports, typedProg) <-
+    Main decls <-
       typeCheckUserProg $
         TypeCheckOptions
           { specification = specification,
-            secondaryTypeSystem = Nothing
+            secondaryTypeSystem = Nothing,
+            declarationsToCompile = mempty
           }
-    let Main decls = mergeImports imports typedProg
 
     -- Search for entities
     entities <- runFreshFreeContextT (Proxy @Builtin) $ execWriterT $ searchDecls decls

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -15,9 +15,12 @@ import Data.Aeson (ToJSON (toJSON))
 import Data.Aeson.Encode.Pretty (encodePretty')
 import Data.ByteString.Lazy.Char8 (unpack)
 import Data.Data (Proxy (..))
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Set qualified as Set
 import Data.Text as T (Text)
 import Vehicle.Backend.Prelude
 import Vehicle.Compile.Error
+import Vehicle.Compile.Monomorphisation (monomorphise)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Print.Error
@@ -42,19 +45,21 @@ import Vehicle.Verify.Specification.IO
 
 data TypeCheckOptions = TypeCheckOptions
   { specification :: FilePath,
-    secondaryTypeSystem :: Maybe SecondaryTypeSystem
+    secondaryTypeSystem :: Maybe SecondaryTypeSystem,
+    declarationsToCompile :: DeclarationNames
   }
   deriving (Eq, Show)
 
 typeCheck :: (MonadStdIO IO) => LoggingSettings -> OutputAsJSON -> TypeCheckOptions -> IO ()
-typeCheck loggingSettings outputAsJSON options@TypeCheckOptions {..} = runCompileMonad loggingSettings outputAsJSON $ do
-  (imports, typedProg) <- typeCheckUserProg options
-  let mergedProg = mergeImports imports typedProg
-  case secondaryTypeSystem of
-    Nothing -> return ()
-    Just LinearityTypes -> printPropertyTypes =<< linearityTypeCheck mergedProg
-    Just PolarityTypes -> printPropertyTypes =<< polarityTypeCheck mergedProg
-    Just DecidabilityTypes -> printPropertyTypes . Right =<< decidabilityTypeCheck mergedProg
+typeCheck loggingSettings outputAsJSON options@TypeCheckOptions {..} =
+  runCompileMonad loggingSettings outputAsJSON $ do
+    prog <- typeCheckUserProg options
+    case secondaryTypeSystem of
+      Nothing -> return ()
+      Just typeSystem -> case typeSystem of
+        LinearityTypes -> printPropertyTypes =<< linearityTypeCheck prog mempty
+        PolarityTypes -> printPropertyTypes =<< polarityTypeCheck prog mempty
+        DecidabilityTypes -> printPropertyTypes . Right =<< decidabilityTypeCheck prog
 
 --------------------------------------------------------------------------------
 -- Useful functions that apply to multiple compiler passes
@@ -78,11 +83,33 @@ parseExprText (file, txt) = do
 typeCheckUserProg ::
   (MonadIO m, MonadCompile m) =>
   TypeCheckOptions ->
-  m (Imports, Prog Builtin)
+  m (Prog Builtin)
 typeCheckUserProg TypeCheckOptions {..} = do
   imports <- (: []) <$> loadLibrary standardLibrary
   typedProg <- typeCheckOrLoadProg User imports specification
-  return (imports, typedProg)
+
+  keepUnusedDeclarationFn <- checkDeclarationNamesPresent typedProg declarationsToCompile
+  monomorphisedProg <- monomorphise typedProg keepUnusedDeclarationFn
+  castFreeProgram <- resolveInstanceArgumentsAndCasts monomorphisedProg
+  let mergedProg = mergeImports imports castFreeProgram
+  return mergedProg
+
+checkDeclarationNamesPresent :: (MonadCompile m) => Prog Builtin -> DeclarationNames -> m (Identifier -> Bool)
+checkDeclarationNamesPresent (Main decls) requestedDeclNames = do
+  let actualDeclNames = Set.fromList $ fmap nameOf decls
+  let missingNames = Set.toList $ Set.fromList requestedDeclNames `Set.difference` actualDeclNames
+  case missingNames of
+    [] -> return ()
+    n : ns ->
+      throwError $
+        MissingRequestedDeclarations (n :| ns)
+
+  return $
+    if null requestedDeclNames
+      then isUserCode
+      else do
+        let declsToCompile = Set.fromList requestedDeclNames
+        \ident -> Set.member (nameOf ident) declsToCompile
 
 -- | Parses and type-checks the program but does
 -- not load networks and datasets from disk.
@@ -132,7 +159,10 @@ loadLibrary library = do
     libraryFile <- findLibraryContentFile library
     typeCheckOrLoadProg StdLib mempty libraryFile
 
-printPropertyTypes :: (MonadStdIO m, MonadCompile m, PrintableBuiltin builtin) => Either CompileError (Prog builtin) -> m ()
+printPropertyTypes ::
+  (MonadStdIO m, MonadCompile m, PrintableBuiltin builtin) =>
+  Either CompileError (Prog builtin) ->
+  m ()
 printPropertyTypes = \case
   Left err -> throwError err
   Right (Main decls) -> do

--- a/vehicle/tests/golden/compile/help/check.out.golden
+++ b/vehicle/tests/golden/compile/help/check.out.golden
@@ -1,4 +1,5 @@
-Usage: vehicle check (-s|--specification FILE) [-t|--typeSystem TYPE_SYSTEM]
+Usage: vehicle check (-s|--specification FILE) [-t|--typeSystem TYPE_SYSTEM] 
+                     [-e|--declaration NAME]
 
   Type-check a .vcl specification file.
 
@@ -12,4 +13,8 @@ Available options:
                            specification. 3. Decidability - check which booleans
                            are decidable and which are undecidable in the
                            context of Vehicle
+  -e,--declaration NAME    Declarations in the specification to include during
+                           compilation. Can be provided multiple times. If not
+                           provided then all declarations in the specification
+                           will be compiled.
   -h,--help                Show this help text

--- a/vehicle/tests/golden/compile/mnist-robustness/CheckDecidability.out.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/CheckDecidability.out.golden
@@ -1,0 +1,1 @@
+robust : Prop

--- a/vehicle/tests/golden/compile/mnist-robustness/CheckLinearity.out.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/CheckLinearity.out.golden
@@ -1,0 +1,1 @@
+robust : Linear

--- a/vehicle/tests/golden/compile/mnist-robustness/CheckPolarity.out.golden
+++ b/vehicle/tests/golden/compile/mnist-robustness/CheckPolarity.out.golden
@@ -1,0 +1,1 @@
+robust : Quantified forall

--- a/vehicle/tests/golden/compile/mnist-robustness/test.json
+++ b/vehicle/tests/golden/compile/mnist-robustness/test.json
@@ -5,6 +5,21 @@
     "needs": ["spec.vcl"]
   },
   {
+    "name": "CheckLinearity",
+    "run": "vehicle check -s spec.vcl -t Linearity",
+    "needs": ["spec.vcl"]
+  },
+  {
+    "name": "CheckPolarity",
+    "run": "vehicle check -s spec.vcl -t Polarity",
+    "needs": ["spec.vcl"]
+  },
+  {
+    "name": "CheckDecidability",
+    "run": "vehicle check -s spec.vcl -t Decidability",
+    "needs": ["spec.vcl"]
+  },
+  {
     "name": "List",
     "run": "vehicle list -s spec.vcl -j",
     "needs": ["spec.vcl"]

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
@@ -81,7 +81,8 @@ checkModeTests =
                 Check $
                   TypeCheckOptions
                     { specification = "test/spec.vcl",
-                      secondaryTypeSystem = Nothing
+                      secondaryTypeSystem = Nothing,
+                      declarationsToCompile = mempty
                     }
           }
     ]


### PR DESCRIPTION
Fixed by unifying where subsystem preprocessing happens