### PR TITLE
Tidy up build for vehicle-python

### DIFF
--- a/.github/workflows/build-vehicle-python.yml
+++ b/.github/workflows/build-vehicle-python.yml
@@ -32,7 +32,7 @@ jobs:
             plat: "musllinux"
             test: "test"
           - name: "macOS"
-            type: "macOS-13"
+            type: "macos-15-intel"
             arch: "x86_64"
             plat: "macosx"
             test: "test,tensorflow"

--- a/vehicle-python/MANIFEST.in
+++ b/vehicle-python/MANIFEST.in
@@ -7,7 +7,6 @@ global-include *.vcl
 
 include cabal.project
 include cabal.project.config
-include cabal.project.freeze
 
 graft tests/data
 graft vendor/vehicle

--- a/vehicle-python/pyproject.toml
+++ b/vehicle-python/pyproject.toml
@@ -12,7 +12,8 @@ name = 'vehicle_lang'
 authors = [{ name = 'Wen Kokke', email = 'wenkokke@users.noreply.github.com' }]
 description = 'A high-level functional language for writing mathematically-precise specifications for neural networks.'
 readme = 'README.md'
-license = { file = 'LICENSE' }
+license = 'MIT'
+license-files = [ "LICENSE" ]
 dynamic = ["version"]
 requires-python = ">=3.9,<3.14"
 dependencies = ["typing_extensions >=4.6,<5", "jaxtyping>=0.2, <0.3"]
@@ -96,9 +97,9 @@ version = { attr = "vehicle_lang._version.VERSION" }
 legacy_tox_ini = """
 [tox]
 min_version = 4
-env_list = py{39,310,311,312,313}-{lin,mac,win}
+env_list = py{310,311,312,313}-{lin,mac,win}
 
-[testenv:py{39,310,311,312,313}-{lin,mac,win}]
+[testenv:py{310,311,312,313}-{lin,mac,win}]
 package = external
 package_env = build-{env_name}
 platform =
@@ -110,7 +111,7 @@ allowlist_externals =
 extras =
   test
   pygments
-  py39,py310,py311,py312: tensorflow
+  py310,py311,py312: tensorflow
 commands =
   {env_python} -m pytest {posargs}
 
@@ -120,17 +121,14 @@ deps =
   auditwheel; sys_platform == 'linux'
   delocate; sys_platform == 'darwin'
 package_glob =
-  py39-lin: {package_root}{/}dist{/}*cp39*manylinux*.whl
   py310-lin: {package_root}{/}dist{/}*cp310*manylinux*.whl
   py311-lin: {package_root}{/}dist{/}*cp311*manylinux*.whl
   py312-lin: {package_root}{/}dist{/}*cp312*manylinux*.whl
   py313-lin: {package_root}{/}dist{/}*cp313*manylinux*.whl
-  py39-mac: {package_root}{/}dist{/}*cp39*macosx*.whl
   py310-mac: {package_root}{/}dist{/}*cp310*macosx*.whl
   py311-mac: {package_root}{/}dist{/}*cp311*macosx*.whl
   py312-mac: {package_root}{/}dist{/}*cp312*macosx*.whl
   py313-mac: {package_root}{/}dist{/}*cp313*macosx*.whl
-  py39-win: {package_root}{/}dist{/}*cp39*win*.whl
   py310-win: {package_root}{/}dist{/}*cp310*win*.whl
   py311-win: {package_root}{/}dist{/}*cp311*win*.whl
   py312-win: {package_root}{/}dist{/}*cp312*win*.whl

--- a/vehicle-python/setup.py
+++ b/vehicle-python/setup.py
@@ -1,4 +1,5 @@
 import os.path
+import shutil
 import subprocess
 import sys
 import typing
@@ -13,7 +14,6 @@ import setuptools.command.build_ext
 # isort: split
 
 import distutils.errors
-import distutils.spawn
 
 ext_module = setuptools.Extension(
     name="vehicle_lang._binding",
@@ -141,7 +141,7 @@ class cabal_build_ext(setuptools.command.build_ext.build_ext):
 
     def find_cabal(self) -> str:
         if self._cabal is None:
-            self._cabal = distutils.spawn.find_executable("cabal")
+            self._cabal = shutil.which("cabal")
             if self._cabal is None:
                 raise distutils.errors.DistutilsExecError(
                     "Could not find executable 'cabal'. "
@@ -162,7 +162,7 @@ class cabal_build_ext(setuptools.command.build_ext.build_ext):
 
     def find_ghc(self) -> str:
         if self._ghc is None:
-            self._ghc = distutils.spawn.find_executable("ghc")
+            self._ghc = shutil.which("ghc")
             if self._ghc is None:
                 raise distutils.errors.DistutilsExecError(
                     "Could not find executable 'ghc'. "

--- a/vehicle-python/src/VehiclePythonBinding.hs
+++ b/vehicle-python/src/VehiclePythonBinding.hs
@@ -4,9 +4,8 @@
 module VehiclePythonBinding where
 
 import Data.ByteString (useAsCString)
-import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
-import Foreign.C.String (CString, peekCString, withCString)
+import Foreign.C.String (CString, peekCString)
 import Foreign.C.Types (CInt (..))
 import Foreign.Marshal.Array (peekArray)
 import Foreign.Ptr (Ptr)

--- a/vehicle-python/src/vehicle_lang/ast/__init__.py
+++ b/vehicle-python/src/vehicle_lang/ast/__init__.py
@@ -5,11 +5,11 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Any, Generic, Iterable, Optional, Sequence, Tuple, Union
 
-from typing_extensions import Literal, Self, TypeAlias, TypeVar, override
+from typing_extensions import Self, TypeAlias, TypeVar, override
 
 from .. import session
 from ..error import VehicleError
-from ..typing import DeclarationName, Explicit, Target
+from ..typing import DeclarationName, DifferentiableLogic, Target
 from ._decode import JsonValue, decode
 
 Name: TypeAlias = str
@@ -496,14 +496,14 @@ def load(
     path: Union[str, Path],
     *,
     declarations: Iterable[DeclarationName] = (),
-    target: Target = Explicit.Explicit,
+    target: Target = DifferentiableLogic.Vehicle,
 ) -> Program:
     exc, out, err, log = session.check_output(
         [
+            "--json",
             "compile",
             "--target",
             target._vehicle_option_name,
-            "--json",
             f"--specification={path}",
             *[f"--declaration={declaration_name}" for declaration_name in declarations],
         ]

--- a/vehicle-python/vehicle-python-binding.cabal
+++ b/vehicle-python/vehicle-python-binding.cabal
@@ -34,6 +34,9 @@ foreign-library _binding
 
   -- 10-01-2024:
   -- Add RTS options for compilation to dynamic library.
+  -- 11-11-2025:
+  -- These have no effect and should be manually passed
+  -- in the call to `hs_init_ghc()`.
   ghc-options:
     -with-rtsopts="--install-signal-handlers=no"
     -with-rtsopts="--install-seh-handlers=no" -with-rtsopts="-V0"


### PR DESCRIPTION
This PR tidies up the vehicle-python build configuration and switches builds from macOS-13 to macOS-15-intel to boot.