### PR TITLE
Refine `FreeContext` monad

### DIFF
--- a/vehicle/src/Vehicle/Backend/Loss/Domain.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Domain.hs
@@ -197,7 +197,7 @@ compileSearch varName dims binder closure (Domain lowerBound upperBound) = do
   genericReductionOp <- getLogicField ReduceDisjunction
   -- TODO This is a complete hack. We really need the notion of an unknown dimension inside Vehicle.
   let reductionDims = IDimCons (INatLiteral (-1)) lossDims
-  reductionOp <- evalApp mempty nameCtx genericReductionOp [implicitIrrelevant reductionDims]
+  reductionOp <- normaliseAppInEmptyFreeEnv nameCtx genericReductionOp [implicitIrrelevant reductionDims]
 
   -- Reform the predicate as if we had no tensor variables at all
   let lossPredicate = VLam lossBinder closure

--- a/vehicle/src/Vehicle/Backend/Loss/JSON.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/JSON.hs
@@ -13,7 +13,7 @@ import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), (<+>))
 import Vehicle.Compile.Arity
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (eval)
+import Vehicle.Compile.Normalise.NBE (normaliseInEmptyFreeEnv)
 import Vehicle.Compile.Prelude (Doc, HasProvenance (..), Ix (..), Name, Provenance (..), getBinderName, mkExplicitBinder, normAppList)
 import Vehicle.Compile.Prelude qualified as S (Binder, Decl, Expr (..), GenericDecl (..), GenericProg (..), Prog)
 import Vehicle.Compile.Print
@@ -169,7 +169,7 @@ convertDecl = \case
 -- Types
 
 convertType :: (MonadJSON m) => BoundEnv LossBuiltin -> S.Expr LossBuiltin -> m JType
-convertType env body = convertTypeValue =<< eval mempty mempty env body
+convertType env body = convertTypeValue =<< normaliseInEmptyFreeEnv mempty env body
 
 convertTypeValue :: (MonadJSON m) => VType LossBuiltin -> m JType
 convertTypeValue expr = do
@@ -214,7 +214,7 @@ convertTensorType spine = case spine of
 
 convertExpr :: (MonadJSON m) => BoundEnv LossBuiltin -> S.Expr LossBuiltin -> m JExpr
 convertExpr env body = do
-  normBody <- eval mempty mempty env body
+  normBody <- normaliseInEmptyFreeEnv mempty env body
   debugFriendly normBody
   convertValue normBody
 

--- a/vehicle/src/Vehicle/Backend/Loss/LossCompilation.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/LossCompilation.hs
@@ -29,7 +29,7 @@ module Vehicle.Backend.Loss.LossCompilation
 where
 
 import Vehicle.Backend.Loss.Core hiding (currentPass)
-import Vehicle.Compile.Normalise.NBE (evalApp, normaliseClosure)
+import Vehicle.Compile.Normalise.NBE (normaliseAppInEmptyFreeEnv, normaliseClosure)
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Data.Builtin.Core (Builtin (..))
@@ -247,7 +247,7 @@ convertLogicField field args = do
   logDebugM MaxDetail $ do
     fnDoc <- prettyFriendlyInCtx fn
     return $ "subst-field" <+> pretty field <> ":" <+> fnDoc
-  evalApp mempty mempty fn (mkExpr accessSpine args)
+  normaliseAppInEmptyFreeEnv mempty fn (mkExpr accessSpine args)
 
 --------------------------------------------------------------------------------
 -- Index

--- a/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination.hs
@@ -35,7 +35,6 @@ import Vehicle.Data.Tensor (HasShape (..))
 import Vehicle.Data.Variable.Bound.Context.Name (getNameContext, prettyFriendlyInCtx)
 import Vehicle.Data.Variable.Bound.Context.Tensor.Class
 import Vehicle.Data.Variable.Bound.Level
-import Vehicle.Data.Variable.Free.Context (getFreeEnv)
 import Vehicle.Verify.Core (inputShape)
 import Vehicle.Verify.QueryFormat (QueryFormat (..), supportsStrictInequalities)
 import Prelude hiding (Applicative (..))
@@ -63,7 +62,7 @@ eliminateExists (QuantifyRatTensorArgs _ binder (Closure env body)) = do
 
     -- Normalise the expression
     let newEnv = extendEnvWithBound (toLv userVar) binder env
-    normExpr <- normaliseInEnv (Just userVarName : namedCtx) newEnv body
+    normExpr <- eval (Just userVarName : namedCtx) newEnv body
 
     -- Recursively compile the expression.
     (partitions, networkInputEqualities) <-
@@ -262,12 +261,11 @@ eliminateTensorAssertion ::
 eliminateTensorAssertion op (TensorOp2Args dims xs ys) =
   case dims of
     IDimCons d@(INatLiteral n) ds -> do
-      freeEnv <- getFreeEnv
       -- TODO switch to use `etaReduceTensor`?
       nameCtx <- getNameContext
       let tElem = fromTypeValue VRatType
       let d0Arg = mkDims []
-      let mkAt vs i = evalAtTensor nameCtx (evalApp freeEnv) (eval freeEnv) (AtTensorArgs tElem d ds vs (IIndexLiteral i))
+      let mkAt vs i = evalAtTensor nameCtx evalApp eval (AtTensorArgs tElem d ds vs (IIndexLiteral i))
       let mkStackElement i = do
             xsi <- mkAt xs i
             ysi <- mkAt ys i

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -94,13 +94,13 @@ data FunctionTypeMismatchError builtin = FunctionTypeMismatchError
   deriving (Show)
 
 data FailedUnificationConstraintsError builtin = FailedUnificationConstraintsError
-  { _freeEnv :: FreeEnv builtin,
+  { _freeCtx :: FreeCtx builtin,
     failedConstraints :: NonEmpty (WithContext (UnificationConstraint builtin))
   }
   deriving (Show)
 
 data FailedInstanceConstraintError builtin = FailedInstanceConstraintError
-  { _freeEnv :: FreeEnv builtin,
+  { _freeCtx :: FreeCtx builtin,
     failedConstraint :: WithContext (InstanceConstraint builtin),
     exploredCandidates :: [(WithContext (InstanceCandidate builtin), UnAnnDoc)]
   }

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -2,8 +2,10 @@ module Vehicle.Compile.Normalise.NBE
   ( MonadNorm,
     FreeEnv,
     normalise,
-    normaliseInEnv,
     normaliseInEmptyEnv,
+    normaliseInEmptyFreeEnv,
+    normaliseAppInEmptyFreeEnv,
+    normaliseInFreeCtx,
     normaliseApp,
     normaliseBuiltin,
     normaliseClosure,
@@ -31,7 +33,8 @@ import Vehicle.Data.Code.Value
 import Vehicle.Data.Variable.Bound.Context.Generic
 import Vehicle.Data.Variable.Bound.Context.Name.Class (MonadReadableNameContext (getNameContext))
 import Vehicle.Data.Variable.Bound.Context.Name.Core
-import Vehicle.Data.Variable.Free.Context.Class (MonadFreeContext (..), getFreeEnv)
+import Vehicle.Data.Variable.Free.Context.Class (MonadFreeContext (..), lookupIdentValue)
+import Vehicle.Data.Variable.Free.Context.Instance (runFreeContextT, runFreshFreeContextT)
 
 -- NOTE: there is no evaluatation to NF in this file. To do it
 -- efficiently you should just evaluate to WHNF and then recursively
@@ -49,23 +52,33 @@ normalise ::
 normalise e = do
   boundCtx <- getBoundCtx (Proxy @(Type builtin))
   let boundEnv = boundContextToEnv boundCtx
-  normaliseInEnv (toNamedBoundCtx boundCtx) boundEnv e
+  eval (toNamedBoundCtx boundCtx) boundEnv e
 
-normaliseInEnv ::
-  (MonadNorm builtin m, MonadFreeContext builtin m) =>
+normaliseInFreeCtx ::
+  (MonadNorm builtin m) =>
+  FreeCtx builtin ->
   NamedBoundCtx ->
   BoundEnv builtin ->
   Expr builtin ->
   m (Value builtin)
-normaliseInEnv ctx boundEnv expr = do
-  freeEnv <- getFreeEnv
-  eval freeEnv ctx boundEnv expr
+normaliseInFreeCtx freeCtx ctx boundEnv expr = do
+  runFreeContextT freeCtx $ eval ctx boundEnv expr
 
 normaliseInEmptyEnv ::
   (MonadNorm builtin m, MonadFreeContext builtin m) =>
   Expr builtin ->
   m (Value builtin)
-normaliseInEmptyEnv = normaliseInEnv mempty emptyBoundEnv
+normaliseInEmptyEnv = eval mempty emptyBoundEnv
+
+normaliseInEmptyFreeEnv ::
+  forall builtin m.
+  (MonadNorm builtin m) =>
+  NamedBoundCtx ->
+  BoundEnv builtin ->
+  Expr builtin ->
+  m (Value builtin)
+normaliseInEmptyFreeEnv ctx env expr =
+  runFreshFreeContextT (Proxy @builtin) $ eval ctx env expr
 
 normaliseApp ::
   (MonadNorm builtin m, MonadFreeContext builtin m) =>
@@ -74,8 +87,17 @@ normaliseApp ::
   Spine builtin ->
   m (Value builtin)
 normaliseApp ctx fn spine = do
-  freeEnv <- getFreeEnv
-  evalApp freeEnv ctx fn spine
+  evalApp ctx fn spine
+
+normaliseAppInEmptyFreeEnv ::
+  forall builtin m.
+  (MonadNorm builtin m) =>
+  NamedBoundCtx ->
+  Value builtin ->
+  Spine builtin ->
+  m (Value builtin)
+normaliseAppInEmptyFreeEnv ctx fn spine = do
+  runFreshFreeContextT (Proxy @builtin) $ evalApp ctx fn spine
 
 normaliseBuiltin ::
   (MonadNorm builtin m, MonadFreeContext builtin m) =>
@@ -84,8 +106,7 @@ normaliseBuiltin ::
   Spine builtin ->
   m (Value builtin)
 normaliseBuiltin ctx b spine = do
-  freeEnv <- getFreeEnv
-  evalBuiltin freeEnv ctx b spine
+  evalBuiltin ctx b spine
 
 normaliseClosureInCtx ::
   (MonadNorm builtin m, MonadFreeContext builtin m) =>
@@ -94,9 +115,8 @@ normaliseClosureInCtx ::
   Closure builtin ->
   m (Value builtin)
 normaliseClosureInCtx ctx binder (Closure env body) = do
-  freeEnv <- getFreeEnv
   let newEnv = extendEnvWithBound (boundCtxLv ctx) binder env
-  eval freeEnv ctx newEnv body
+  eval ctx newEnv body
 
 normaliseClosure ::
   (MonadNorm builtin m, MonadFreeContext builtin m, MonadReadableNameContext m) =>
@@ -117,21 +137,20 @@ type MonadNorm builtin m =
   )
 
 eval ::
-  (MonadNorm builtin m) =>
-  FreeEnv builtin ->
+  (MonadNorm builtin m, MonadFreeContext builtin m) =>
   NamedBoundCtx ->
   BoundEnv builtin ->
   Expr builtin ->
   m (Value builtin)
-eval freeEnv ctx boundEnv expr = do
+eval ctx boundEnv expr = do
   showEntry ctx boundEnv expr
-  let recEval = eval freeEnv ctx boundEnv
+  let recEval = eval ctx boundEnv
   result <- case expr of
     Hole {} -> resolutionError currentPass "Hole"
     Meta _ m -> return $ VMeta m []
     Universe _ u -> return $ VUniverse u
     BoundVar _ v -> return $ lookupIxInEnv boundEnv v
-    FreeVar _ v -> return $ lookupIdentValueInEnv freeEnv v
+    FreeVar _ v -> lookupIdentValue v
     Builtin _ b -> return $ VBuiltin b []
     Lam _ binder body -> do
       binder' <- traverse recEval binder
@@ -143,11 +162,11 @@ eval freeEnv ctx boundEnv expr = do
       binder' <- traverse recEval binder
       boundNormExpr <- recEval bound
       let newBoundEnv = extendEnvWithDefined boundNormExpr binder' boundEnv
-      eval freeEnv ctx newBoundEnv body
+      eval ctx newBoundEnv body
     App fun args -> do
       fun' <- recEval fun
       args' <- traverse (traverse recEval) (NonEmpty.toList args)
-      evalApp freeEnv ctx fun' args'
+      evalApp ctx fun' args'
     Record _p ident fields -> do
       fields' <- traverseRecordFields recEval fields
       return $ VRecord ident $ OMap.fromList fields'
@@ -161,27 +180,26 @@ eval freeEnv ctx boundEnv expr = do
   return result
 
 evalApp ::
-  (MonadNorm builtin m) =>
-  FreeEnv builtin ->
+  (MonadNorm builtin m, MonadFreeContext builtin m) =>
   NamedBoundCtx ->
   Value builtin ->
   Spine builtin ->
   m (Value builtin)
-evalApp _freeEnv _ctx fun [] = return fun
-evalApp freeEnv ctx fun args@(a : as) = do
+evalApp _ctx fun [] = return fun
+evalApp ctx fun args@(a : as) = do
   showApp ctx fun args
   result <- case fun of
     VMeta v spine -> return $ VMeta v (spine <> args)
     VBoundVar v spine -> return $ VBoundVar v (spine <> args)
     VFreeVar v spine -> return $ VFreeVar v (spine <> args)
-    VBuiltin b spine -> evalBuiltin freeEnv ctx b (spine <> args)
+    VBuiltin b spine -> evalBuiltin ctx b (spine <> args)
     VLam binder (Closure env body)
       | not (visibilityMatches binder a) ->
           visibilityError ctx fun a
       | otherwise -> do
           let newEnv = extendEnvWithDefined (argExpr a) binder env
-          body' <- eval freeEnv ctx newEnv body
-          evalApp freeEnv ctx body' as
+          body' <- eval ctx newEnv body
+          evalApp ctx body' as
     VUniverse {} -> unexpected "VUniverse"
     VPi {} -> unexpected "VUniverse"
     VRecord {} -> unexpected "VUniverse"
@@ -192,21 +210,22 @@ evalApp freeEnv ctx fun args@(a : as) = do
     unexpected name = unexpectedExprError currentPass (name <+> prettyVerbose args)
 
 evalBuiltin ::
-  (MonadNorm builtin m) =>
-  FreeEnv builtin ->
+  (MonadNorm builtin m, MonadFreeContext builtin m) =>
   NamedBoundCtx ->
   builtin ->
   Spine builtin ->
   m (Value builtin)
-evalBuiltin freeEnv ctx b spine
+evalBuiltin ctx b spine
   | not (isTypeClassOp b) = case evalScheme b of
       Simple evalFn -> maybe (return $ VBuiltin b spine) evalFn (getExpr accessSpine spine)
-      NonSimple evalFn -> maybe (return $ VBuiltin b spine) (evalFn ctx (evalApp freeEnv) (eval freeEnv)) (getExpr accessSpine spine)
-      Derived ident -> evalApp freeEnv ctx (lookupIdentValueInEnv freeEnv ident) spine
+      NonSimple evalFn -> maybe (return $ VBuiltin b spine) (evalFn ctx evalApp eval) (getExpr accessSpine spine)
+      Derived ident -> do
+        value <- lookupIdentValue ident
+        evalApp ctx value spine
       None -> return $ VBuiltin b spine
   | otherwise = do
       (inst, remainingArgs) <- findInstanceArg b spine
-      evalApp freeEnv ctx inst remainingArgs
+      evalApp ctx inst remainingArgs
 
 findInstanceArg :: (MonadLogger m, Show op) => op -> [GenericArg a] -> m (a, [GenericArg a])
 findInstanceArg op = \case

--- a/vehicle/src/Vehicle/Compile/Print/Error/Typing.hs
+++ b/vehicle/src/Vehicle/Compile/Print/Error/Typing.hs
@@ -11,7 +11,7 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Monoid (Endo (..))
 import Data.Text (Text, pack)
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (eval)
+import Vehicle.Compile.Normalise.NBE (normaliseInFreeCtx)
 import Vehicle.Compile.Normalise.Quote (Quote (..), unnormalise)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
@@ -186,7 +186,7 @@ failedUnificationConstraintsError (FailedUnificationConstraintsError freeEnv (er
       let namedBoundCtx = toNamedBoundCtx boundCtx
       let originMessage = case origin of
             CheckingExprType CheckingExpr {..} -> do
-              let normActualType = runNorm $ eval freeEnv namedBoundCtx (boundContextToEnv boundCtx) checkedExprActualType
+              let normActualType = runNorm $ normaliseInFreeCtx freeEnv namedBoundCtx (boundContextToEnv boundCtx) checkedExprActualType
               "expected"
                 <+> ( case checkedExpr of
                         Left binder -> "variable" <+> quotePretty binder
@@ -276,7 +276,7 @@ typeRestrictionError ctx (TypeRestrictionOrigin freeEnv (ident, p) sort typ) _ca
             <+> "to a supported type"
     }
   where
-    gluedType = Glued typ (runNorm $ eval freeEnv (namedBoundCtxOf ctx) emptyBoundEnv typ)
+    gluedType = Glued typ (runNorm $ normaliseInFreeCtx freeEnv (namedBoundCtxOf ctx) emptyBoundEnv typ)
 
     fixIdent = case sort of
       Right (FieldTypeIsAllowed f) -> quotePretty (nameOf f)
@@ -323,12 +323,12 @@ typeRestrictionError ctx (TypeRestrictionOrigin freeEnv (ident, p) sort typ) _ca
 instanceArgOriginError ::
   forall builtin.
   (PrintableBuiltin builtin, NormalisableBuiltin builtin) =>
-  FreeEnv builtin ->
+  FreeCtx builtin ->
   ConstraintContext builtin ->
   InstanceArgOrigin builtin ->
   [(WithContext (InstanceCandidate builtin), UnAnnDoc)] ->
   VehicleError
-instanceArgOriginError freeEnv ctx (ArgOrigin tcOp tcOpArgs tcOpType _tc) candidates =
+instanceArgOriginError freeCtx ctx (ArgOrigin tcOp tcOpArgs tcOpType _tc) candidates =
   VehicleError
     { provenance = Just $ provenanceOf ctx,
       problem =
@@ -353,7 +353,7 @@ instanceArgOriginError freeEnv ctx (ArgOrigin tcOp tcOpArgs tcOpType _tc) candid
     candidateOpType :: (Int, (WithContext (InstanceCandidate builtin), UnAnnDoc)) -> UnAnnDoc
     candidateOpType (no, (candidate, err)) = do
       let (candidateTypeArgs, solutionCtx) = calculateInstanceCandidateTypeArgs candidate
-      let finalTypeDoc = calculateInstanceDisplayType freeEnv solutionCtx tcOpType candidateTypeArgs actualArgs
+      let finalTypeDoc = calculateInstanceDisplayType freeCtx solutionCtx tcOpType candidateTypeArgs actualArgs
       pretty no
         <> "." <+> finalTypeDoc
         <> line
@@ -379,14 +379,14 @@ calculateInstanceCandidateTypeArgs (WithContext candidate typingCtx) =
 calculateInstanceDisplayType ::
   forall builtin a.
   (NormalisableBuiltin builtin, PrintableBuiltin builtin) =>
-  FreeEnv builtin ->
+  FreeCtx builtin ->
   BoundCtx (Type builtin) ->
   Type builtin ->
   [Arg builtin] ->
   [Arg builtin] ->
   Doc a
 calculateInstanceDisplayType freeEnv boundCtx fullType actualArgs typingArgs = do
-  let normFullType = runNorm $ eval freeEnv (toNamedBoundCtx boundCtx) (boundContextToEnv boundCtx) fullType
+  let normFullType = runNorm $ normaliseInFreeCtx freeEnv (toNamedBoundCtx boundCtx) (boundContextToEnv boundCtx) fullType
   let opArgs = mergeArgs actualArgs typingArgs
   instantiateTelescope boundCtx normFullType opArgs
   where
@@ -414,7 +414,7 @@ calculateInstanceDisplayType freeEnv boundCtx fullType actualArgs typingArgs = d
             prettyFriendly (WithContext typ (toNamedBoundCtx ctx))
       (VPi binder (Closure env body), args) -> do
         let (alterEnv, remainingArgs) = findRemainingArgs ctx binder args
-        let recType = runNorm $ eval freeEnv (toNamedBoundCtx ctx) (alterEnv env) body
+        let recType = runNorm $ normaliseInFreeCtx freeEnv (toNamedBoundCtx ctx) (alterEnv env) body
         let unnormBinder = quote mempty (boundCtxLv ctx) binder
         instantiateTelescope (unnormBinder : ctx) recType remainingArgs
       (_, []) -> prettyFriendly (WithContext typ (toNamedBoundCtx ctx))
@@ -425,7 +425,7 @@ calculateInstanceDisplayType freeEnv boundCtx fullType actualArgs typingArgs = d
       [] -> (extendEnvWithBound (boundCtxLv ctx) binder, [])
       ((arg, fromCandidate) : remainingArgs)
         | visibilityOf arg == visibilityOf binder || fromCandidate -> do
-            let normArg = runNorm $ eval freeEnv (toNamedBoundCtx ctx) (boundContextToEnv ctx) (argExpr arg)
+            let normArg = runNorm $ normaliseInFreeCtx freeEnv (toNamedBoundCtx ctx) (boundContextToEnv ctx) (argExpr arg)
             (extendEnvWithDefined normArg binder, remainingArgs)
         | isExplicit binder -> developerError "Missing explicit argument when printing"
         | otherwise -> (extendEnvWithBound (boundCtxLv ctx) binder, args)

--- a/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
@@ -12,7 +12,7 @@ import Data.Data (Proxy (..))
 import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Data.Maybe (fromMaybe)
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
+import Vehicle.Compile.Normalise.NBE (eval)
 import Vehicle.Compile.Normalise.Quote (Quote (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
@@ -342,8 +342,8 @@ createFreshUnificationConstraint ::
   m ()
 createFreshUnificationConstraint p ctx origin expectedType actualType = do
   let env = boundContextToEnv ctx
-  normExpectedType <- normaliseInEnv (toNamedBoundCtx ctx) env expectedType
-  normActualType <- normaliseInEnv (toNamedBoundCtx ctx) env actualType
+  normExpectedType <- eval (toNamedBoundCtx ctx) env expectedType
+  normActualType <- eval (toNamedBoundCtx ctx) env actualType
   context <- createFreshConstraintCtx p ctx
   let unification = Unify origin normExpectedType normActualType
   solveUnificationConstraint (WithContext unification context)
@@ -397,7 +397,7 @@ forceApplicationHeadType ::
   Type builtin ->
   m (Type builtin, MetaSet)
 forceApplicationHeadType ctx typ = do
-  normType <- normaliseInEnv (toNamedBoundCtx ctx) (boundContextToEnv ctx) typ
+  normType <- eval (toNamedBoundCtx ctx) (boundContextToEnv ctx) typ
   (forcedType, blockingMetas) <- forceHead (toNamedBoundCtx ctx) normType
   return (quote (provenanceOf typ) (boundCtxLv ctx) forcedType, blockingMetas)
 

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -14,7 +14,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.HashMap.Strict (HashMap, fromListWith, mapMaybeWithKey)
 import Data.Hashable (Hashable)
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
+import Vehicle.Compile.Normalise.NBE (eval)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Type.Core
@@ -106,6 +106,6 @@ instantiateInstanceConstraintSolution (WithContext (Resolve origin meta _ _) ctx
       logDebug MaxDetail ("solved" <+> pretty meta <+> "as" <+> prettyVerbose solution)
       logDebug MaxDetail (indent 2 ("however" <+> pretty meta <+> "=" <+> prettyVerbose (unnormalised existingSolution) <+> "already so unifying"))
       let abstractedSolution = abstractOverCtx (metaCtx metaInfo) solution
-      normSolution <- normaliseInEnv (toNamedBoundCtx boundCtx) (boundContextToEnv boundCtx) abstractedSolution
+      normSolution <- eval (toNamedBoundCtx boundCtx) (boundContextToEnv boundCtx) abstractedSolution
       newConstraint <- createInstanceUnification (ctx, origin) normSolution (normalised existingSolution)
       addUnificationConstraints [newConstraint]

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
@@ -9,7 +9,7 @@ import Data.Either (partitionEithers)
 import Data.Hashable (Hashable)
 import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Error
-import Vehicle.Compile.Normalise.NBE (normaliseInEnv)
+import Vehicle.Compile.Normalise.NBE (eval)
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (prettyExternal)
 import Vehicle.Compile.Print.Error (formatCompileError)
@@ -22,7 +22,7 @@ import Vehicle.Data.Builtin.Interface.Print
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Variable.Bound.Context.Generic
 import Vehicle.Data.Variable.Bound.Level (dbLevelToIndex)
-import Vehicle.Data.Variable.Free.Context (getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..))
 
 --------------------------------------------------------------------------------
 -- Public interface
@@ -108,9 +108,9 @@ solveInstanceGoal constraint rawBuiltinCandidates depth goal = do
 
     -- If there are no valid candidates then we fail.
     [] -> do
-      freeEnv <- getFreeEnv
+      freeCtx <- getFreeCtx (Proxy @builtin)
       finalConstraint <- substMetaVariables constraint
-      throwError $ TypingError $ FailedInstanceConstraint $ FailedInstanceConstraintError freeEnv finalConstraint unsuccessfulCandidates
+      throwError $ TypingError $ FailedInstanceConstraint $ FailedInstanceConstraintError freeCtx finalConstraint unsuccessfulCandidates
 
     -- Otherwise there are still multiple valid candidates so we're forced to block.
     _ -> do
@@ -222,7 +222,7 @@ instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin)
     let initialCtx = goalCtxExtension ++ candidateCtx
     (candidateBody, candidateSol, newInstanceConstraints, finalCtx) <-
       go (candidateExpr, candidateSolution, [], initialCtx)
-    normCandidateBody <- normaliseInEnv (toNamedBoundCtx finalCtx) (boundContextToEnv finalCtx) candidateBody
+    normCandidateBody <- eval (toNamedBoundCtx finalCtx) (boundContextToEnv finalCtx) candidateBody
     return (normCandidateBody, candidateSol, newInstanceConstraints)
   where
     go ::
@@ -242,7 +242,7 @@ instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin)
           Instance {} -> do
             let newInfo = (setConstraintBoundCtx constraintCtx boundCtx, constraintOrigin)
             -- WARNING massive hack should be traversing the normalised type here.
-            normBinderType <- normaliseInEnv (toNamedBoundCtx boundCtx) (boundContextToEnv boundCtx) binderType
+            normBinderType <- eval (toNamedBoundCtx boundCtx) (boundContextToEnv boundCtx) binderType
             (expr, constraint) <- createDerivedInstanceConstraint newInfo (relevanceOf exprBinder) normBinderType
             return (expr, [constraint])
         let exprBodyResult = newArg `substDBInto` exprBody

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -35,7 +35,7 @@ import Vehicle.Data.Builtin.Interface.Type (TypableBuiltin (..))
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Variable.Bound.Context.Generic
 import Vehicle.Data.Variable.Bound.Level
-import Vehicle.Data.Variable.Free.Context (getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..))
 
 --------------------------------------------------------------------------------
 -- Unification solver
@@ -95,8 +95,8 @@ solveUnificationConstraint (WithContext (Unify origin e1 e2) ctx) = do
     HardFailure failedProblems -> do
       finalFailedConstraints <- forM failedProblems $ \problem ->
         createNewConstraint ctx origin (problem, mempty)
-      freeEnv <- getFreeEnv
-      throwError $ TypingError $ FailedUnificationConstraints $ FailedUnificationConstraintsError freeEnv finalFailedConstraints
+      freeCtx <- getFreeCtx (Proxy @builtin)
+      throwError $ TypingError $ FailedUnificationConstraints $ FailedUnificationConstraintsError freeCtx finalFailedConstraints
 
 createNewConstraint ::
   (MonadUnify builtin m) =>
@@ -262,8 +262,8 @@ solveClosure info (binder1, Closure env1 body1) (binder2, Closure env2 body2) = 
 
   -- Evaluate the normalised bodies of the lambdas
   let lv = boundCtxLv $ infoBoundCtx info
-  nbody1 <- normaliseInEnv (toNamedBoundCtx $ infoBoundCtx info) (extendEnvWithBound lv binder1 env1) body1
-  nbody2 <- normaliseInEnv (toNamedBoundCtx $ infoBoundCtx info) (extendEnvWithBound lv binder2 env2) body2
+  nbody1 <- eval (toNamedBoundCtx $ infoBoundCtx info) (extendEnvWithBound lv binder1 env1) body1
+  nbody2 <- eval (toNamedBoundCtx $ infoBoundCtx info) (extendEnvWithBound lv binder2 env2) body2
 
   -- Update the context.
   let updatedInfo = updateInfoUnderBinder info (binder1, binder2)
@@ -426,7 +426,7 @@ createMetaWithRestrictedDependencies ctx meta newDependencies spine = do
     let substMetaExpr = substDBAll 0 (\v -> unIx v `IntMap.lookup` substitution) newMetaExpr
     solveMeta meta substMetaExpr ctx
 
-    normMetaExpr <- normaliseInEnv (toNamedBoundCtx ctx) (boundContextToEnv restrictedContext) newMetaExpr
+    normMetaExpr <- eval (toNamedBoundCtx ctx) (boundContextToEnv restrictedContext) newMetaExpr
     normaliseApp (toNamedBoundCtx ctx) normMetaExpr spine
 
 updateInfoUnderBinder ::

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -137,7 +137,7 @@ data InstanceArgOrigin builtin = ArgOrigin
   deriving (Show)
 
 data InstanceTypeRestrictionOrigin builtin = TypeRestrictionOrigin
-  { freeEnv :: FreeEnv builtin,
+  { freeEnv :: FreeCtx builtin,
     restrictedDeclProv :: DeclProvenance,
     restrictedDeclSort :: Either RestrictedDecl RestrictedRecordField,
     restrictedDeclType :: Type builtin

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -157,7 +157,7 @@ createFreshInstanceConstraint auxiliaryConstraint boundCtx p origin relevance tc
   (metaID, metaExpr) <- freshSolutionMeta p tcExpr boundCtx
 
   context <- createFreshConstraintCtx p boundCtx
-  nTCExpr <- normaliseInEnv (toNamedBoundCtx boundCtx) env tcExpr
+  nTCExpr <- eval (toNamedBoundCtx boundCtx) env tcExpr
   let goal = parseInstanceGoal nTCExpr
   let constraint = WithContext (Resolve origin metaID relevance goal) context
 
@@ -224,7 +224,7 @@ solveMeta meta solution solutionCtx = do
     Nothing -> do
       let abstractedSolution = abstractOverCtx (metaCtx metaInfo) solution
       let env = boundContextToEnv solutionCtx
-      gluedSolution <- Glued abstractedSolution <$> normaliseInEnv (toNamedBoundCtx solutionCtx) env abstractedSolution
+      gluedSolution <- Glued abstractedSolution <$> eval (toNamedBoundCtx solutionCtx) env abstractedSolution
 
       logDebug MaxDetail $
         "solved"

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Instance.hs
@@ -73,6 +73,7 @@ mapTypeCheckerT f m = TypeCheckerT (mapFreeContextT (mapStateT f) (unTypeChecker
 instance (PrintableBuiltin builtin, MonadCompile m) => MonadFreeContext builtin (TypeCheckerT builtin m) where
   addDeclEntryToContext entry = TypeCheckerT . addDeclEntryToContext entry . unTypeCheckerT
   getFreeCtx = TypeCheckerT . getFreeCtx
+  getDeclEntry proxy = TypeCheckerT . getDeclEntry proxy
 
 instance (Eq builtin, Hashable builtin, PrintableBuiltin builtin, NormalisableBuiltin builtin, TypableBuiltin builtin, MonadCompile m) => MonadTypeChecker builtin (TypeCheckerT builtin m) where
   getTypeCheckerState = TypeCheckerT get

--- a/vehicle/src/Vehicle/Compile/Unblock.hs
+++ b/vehicle/src/Vehicle/Compile/Unblock.hs
@@ -20,7 +20,7 @@ import Vehicle.Data.Code.Interface
 import Vehicle.Data.Code.TypedView
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Variable.Bound.Context.Name
-import Vehicle.Data.Variable.Free.Context (MonadFreeContext, getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext)
 
 --------------------------------------------------------------------------------
 -- Unblocking
@@ -328,9 +328,8 @@ unblockAtTensor unblock (AtTensorArgs tElem d ds xs i) = do
   i' <- unblockIndexValue i
   liftIf xs' $ \xs'' ->
     liftIf i' $ \i'' -> do
-      freeEnv <- getFreeEnv
       nameCtx <- getNameContext
-      evalAtTensor nameCtx (evalApp freeEnv) (eval freeEnv) $ AtTensorArgs tElem d ds xs'' i''
+      evalAtTensor nameCtx evalApp eval $ AtTensorArgs tElem d ds xs'' i''
 
 unblockForeachTensor ::
   (MonadUnblock m) =>
@@ -339,9 +338,8 @@ unblockForeachTensor ::
 unblockForeachTensor (ForeachTensorArgs tElem d ds fn) = do
   d' <- unblockNatValue d
   liftIf d' $ \d'' -> do
-    freeEnv <- getFreeEnv
     nameCtx <- getNameContext
-    unoptimisedEvalForeachTensor nameCtx (evalApp freeEnv) $ ForeachTensorArgs tElem d'' ds fn
+    unoptimisedEvalForeachTensor nameCtx evalApp $ ForeachTensorArgs tElem d'' ds fn
 
 --------------------------------------------------------------------------------
 -- Unblocking operations

--- a/vehicle/src/Vehicle/Data/Builtin/Decidability/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Decidability/Type.hs
@@ -15,7 +15,7 @@ import Vehicle.Data.Builtin.Interface.Type
 import Vehicle.Data.Builtin.Standard (BuiltinConstructor (..), BuiltinFunction (..), BuiltinType (..), DerivedFunction (..))
 import Vehicle.Data.Code.DSL
 import Vehicle.Data.DSL
-import Vehicle.Data.Variable.Free.Context (getDeclType, getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..), getDeclType)
 import Vehicle.Syntax.Builtin (Builtin (..))
 import Prelude hiding (iterate, pi)
 
@@ -290,7 +290,7 @@ restrictDecidabilityDeclType declSort (ident, p) declType = do
   case maybeTypeClass of
     Nothing -> return ()
     Just tc -> do
-      freeEnv <- getFreeEnv
+      freeEnv <- getFreeCtx (Proxy @DecidabilityBuiltin)
       let expr = BuiltinExpr p (DecidabilityBuiltinTypeClass tc) [explicit declType]
       let origin = InstanceTypeRestrictionOrigin $ TypeRestrictionOrigin freeEnv (ident, provenanceOf declType) (Left declSort) declType
       _ <- createFreshInstanceConstraint False mempty p origin Irrelevant expr

--- a/vehicle/src/Vehicle/Data/Builtin/Interface/InputOutputInsertion.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Interface/InputOutputInsertion.hs
@@ -4,6 +4,7 @@ module Vehicle.Data.Builtin.Interface.InputOutputInsertion
 where
 
 import Control.Monad.State (MonadState (..), evalStateT, modify)
+import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Core (InstanceConstraintOrigin (..), InstanceTypeRestrictionOrigin (..))
 import Vehicle.Compile.Type.Meta.Map (MetaMap (..))
@@ -11,7 +12,7 @@ import Vehicle.Compile.Type.Meta.Map qualified as MetaMap
 import Vehicle.Compile.Type.Monad
 import Vehicle.Data.Builtin.Core
 import Vehicle.Data.Builtin.Interface (BuiltinHasStandardData)
-import Vehicle.Data.Variable.Free.Context (getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..))
 
 -------------------------------------------------------------------------------
 -- Inserting polarity and linearity constraints to capture function application
@@ -57,6 +58,7 @@ decomposePiType mkConstraint declProv@(ident, _) inputNumber = \case
     addFunctionConstraint (mkConstraint position) declProv position outputType
 
 addFunctionConstraint ::
+  forall builtin m.
   (MonadTypeChecker builtin m, MonadState (MetaMap (Expr builtin)) m, BuiltinHasStandardData builtin) =>
   builtin ->
   DeclProvenance ->
@@ -81,7 +83,7 @@ addFunctionConstraint constraint declProv@(_, declP) position existingExpr = do
         FunctionOutput {} -> [existingExpr, newExpr]
   let tcExpr = BuiltinExpr declP constraint (explicit <$> constraintArgs)
 
-  freeEnv <- getFreeEnv
+  freeEnv <- getFreeCtx (Proxy @builtin)
   let declSort = developerError "function IO constraints should never fail"
   let origin = InstanceTypeRestrictionOrigin $ TypeRestrictionOrigin freeEnv declProv declSort existingExpr
   _ <- createFreshInstanceConstraint True mempty declP origin Irrelevant tcExpr

--- a/vehicle/src/Vehicle/Data/Builtin/Linearity/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Linearity/Type.hs
@@ -6,6 +6,7 @@ module Vehicle.Data.Builtin.Linearity.Type
   )
 where
 
+import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Bidirectional (createFreshUnificationConstraint)
 import Vehicle.Compile.Type.Core
@@ -19,7 +20,7 @@ import Vehicle.Data.Builtin.Linearity.Solver
 import Vehicle.Data.Builtin.Standard (Builtin (..))
 import Vehicle.Data.Code.DSL (iterate)
 import Vehicle.Data.DSL
-import Vehicle.Data.Variable.Free.Context (getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..))
 import Prelude hiding (iterate)
 
 --------------------------------------------------------------------------------
@@ -228,7 +229,7 @@ restrictLinearityDeclType ::
   Type LinearityBuiltin ->
   m (Type LinearityBuiltin)
 restrictLinearityDeclType rDecl declProv declType = do
-  freeEnv <- getFreeEnv
+  freeEnv <- getFreeCtx (Proxy @LinearityBuiltin)
   let origin = InstanceTypeRestrictionOrigin $ TypeRestrictionOrigin freeEnv declProv (Left rDecl) declType
   case rDecl of
     RestrictedNetwork -> restrictLinearityNetworkType origin declProv declType

--- a/vehicle/src/Vehicle/Data/Builtin/Polarity/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Polarity/Type.hs
@@ -6,6 +6,7 @@ module Vehicle.Data.Builtin.Polarity.Type
   )
 where
 
+import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Type.Bidirectional (createFreshUnificationConstraint)
 import Vehicle.Compile.Type.Core
@@ -19,7 +20,7 @@ import Vehicle.Data.Builtin.Polarity.Solver (solvePolarityConstraint)
 import Vehicle.Data.Builtin.Standard (Builtin (..))
 import Vehicle.Data.Code.DSL (iterate)
 import Vehicle.Data.DSL
-import Vehicle.Data.Variable.Free.Context (getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..))
 import Prelude hiding (iterate, pi)
 
 --------------------------------------------------------------------------------
@@ -243,7 +244,7 @@ restrictDeclPolarityType ::
   Type PolarityBuiltin ->
   m (Type PolarityBuiltin)
 restrictDeclPolarityType rDecl declProv declType = do
-  freeEnv <- getFreeEnv
+  freeEnv <- getFreeCtx (Proxy @PolarityBuiltin)
   let origin = InstanceTypeRestrictionOrigin $ TypeRestrictionOrigin freeEnv declProv (Left rDecl) declType
 
   case rDecl of

--- a/vehicle/src/Vehicle/Data/Builtin/Standard/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Standard/Type.hs
@@ -17,7 +17,7 @@ import Vehicle.Data.Builtin.Standard.IndexSolver
 import Vehicle.Data.Builtin.Standard.Normalise ()
 import Vehicle.Data.Code.DSL
 import Vehicle.Data.DSL
-import Vehicle.Data.Variable.Free.Context (MonadFreeContext, getDeclType, getFreeEnv)
+import Vehicle.Data.Variable.Free.Context (MonadFreeContext (..), getDeclType)
 import Prelude hiding (iterate, pi)
 
 --------------------------------------------------------------------------------
@@ -183,7 +183,7 @@ restrictStandardDeclType ::
   Type Builtin ->
   m (Type Builtin)
 restrictStandardDeclType declSort (ident, p) typ = do
-  env <- getFreeEnv
+  env <- getFreeCtx (Proxy @Builtin)
   let tc = case declSort of
         RestrictedProperty -> ValidPropertyType
         RestrictedParameter s -> ValidParameterType s
@@ -204,7 +204,7 @@ restrictStandardRecordAnnotatedAsTensorType ::
 restrictStandardRecordAnnotatedAsTensorType (ident, p) fields = case fields of
   [] -> return ()
   (firstFieldName, firstFieldType) : restFields -> do
-    env <- getFreeEnv
+    env <- getFreeCtx (Proxy @Builtin)
     let expr = BuiltinExpr p (TypeClass ValidTensorLikeType) [explicit firstFieldType]
     let restrictionDetails = Right (FieldTypeIsAllowed firstFieldName)
     let origin = InstanceTypeRestrictionOrigin $ TypeRestrictionOrigin env (ident, p) restrictionDetails firstFieldType
@@ -221,7 +221,7 @@ checkRecordFieldTypesMatch ::
   RecordField (Type Builtin) ->
   m ()
 checkRecordFieldTypesMatch (ident, p) (firstFieldName, firstFieldType) (currFieldName, currFieldType) = do
-  env <- getFreeEnv
+  env <- getFreeCtx (Proxy @Builtin)
   let restrictionDetails = Right (FieldTypesMatch firstFieldName currFieldName)
   let origin = InstanceTypeRestrictionOrigin $ TypeRestrictionOrigin env (ident, p) restrictionDetails firstFieldType
   _ <- createFreshUnificationConstraint p mempty (CheckingInstanceType origin) firstFieldType currFieldType

--- a/vehicle/src/Vehicle/Data/Variable/Free/Context/Class.hs
+++ b/vehicle/src/Vehicle/Data/Variable/Free/Context/Class.hs
@@ -24,60 +24,64 @@ class (PrintableBuiltin builtin, MonadLogger m) => MonadFreeContext builtin m wh
   -- | Adds a new decl to the free variable context.
   addDeclEntryToContext :: FreeCtxEntry builtin -> m a -> m a
 
-  -- | Returns the current free variable context
+  -- | Returns the current free variable context (may be expensive, so should use `getDeclEntry` in preference)
   getFreeCtx :: Proxy builtin -> m (FreeCtx builtin)
+
+  -- | Lookup the decl for a particular identifier entry
+  getDeclEntry :: Proxy builtin -> Identifier -> m (FreeCtxEntry builtin)
 
 instance (Monoid w, MonadFreeContext builtin m) => MonadFreeContext builtin (WriterT w m) where
   addDeclEntryToContext = mapWriterT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (ReaderT w m) where
   addDeclEntryToContext = mapReaderT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (StateT w m) where
   addDeclEntryToContext = mapStateT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (BoundContextT builtin2 m) where
   addDeclEntryToContext = mapBoundContextT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (TensorBoundContextT m) where
   addDeclEntryToContext = mapTensorBoundContextT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (NameBoundContextT m) where
   addDeclEntryToContext = mapNameBoundContextT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (IdentityT m) where
   addDeclEntryToContext = mapIdentityT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (SupplyT s m) where
   addDeclEntryToContext = mapSupplyT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (ExceptT s m) where
   addDeclEntryToContext = mapExceptT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 instance (MonadFreeContext builtin m) => MonadFreeContext builtin (MaybeT m) where
   addDeclEntryToContext = mapMaybeT . addDeclEntryToContext
   getFreeCtx = lift . getFreeCtx
+  getDeclEntry proxy = lift . getDeclEntry proxy
 
 --------------------------------------------------------------------------------
 -- Operations
-
-getDeclEntry ::
-  (MonadLogger m, MonadFreeContext builtin m, HasCallStack) =>
-  Proxy builtin ->
-  Identifier ->
-  m (FreeCtxEntry builtin)
-getDeclEntry proxy ident = do
-  ctx <- getFreeCtx proxy
-  return $ lookupInFreeCtx ident ctx
 
 getDeclType ::
   (MonadLogger m, MonadFreeContext builtin m, HasCallStack) =>
@@ -105,3 +109,8 @@ getFreeEnv ::
 getFreeEnv = do
   ctx <- getFreeCtx (Proxy @builtin)
   return $ fmap snd ctx
+
+lookupIdentValue :: (MonadFreeContext builtin m) => Identifier -> m (Value builtin)
+lookupIdentValue ident = do
+  env <- getFreeEnv
+  return $ lookupIdentValueInEnv env ident

--- a/vehicle/src/Vehicle/Data/Variable/Free/Context/Instance.hs
+++ b/vehicle/src/Vehicle/Data/Variable/Free/Context/Instance.hs
@@ -3,7 +3,7 @@
 module Vehicle.Data.Variable.Free.Context.Instance where
 
 import Control.Monad.Except (MonadError (..))
-import Control.Monad.Reader (MonadReader (..), ReaderT (..), mapReaderT)
+import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks, mapReaderT)
 import Control.Monad.State
 import Data.Data (Proxy (..))
 import Data.Map qualified as Map
@@ -88,3 +88,6 @@ instance
     local updateCtx (unFreeContextT cont)
 
   getFreeCtx _ = FreeContextT ask
+
+  getDeclEntry _proxy ident = FreeContextT $ do
+    asks (lookupInFreeCtx ident)


### PR DESCRIPTION
With the coming refactor of a proper module system, it will no longer be possible during type-checking to efficiently retrieve the whole free context, while it will be possible to efficiently look up an individual entry. 

This PR adds an extra method to `MonadFreeContext` that allows us to lookup an entry without having to return the whole context first.