### PR TITLE
Replace 'gitrev' with 'gitrev-typed' and fix Vehicle library caching

### DIFF
--- a/vehicle/src/Vehicle/Prelude/Git.hs
+++ b/vehicle/src/Vehicle/Prelude/Git.hs
@@ -1,0 +1,28 @@
+module Vehicle.Prelude.Git
+  ( gitChangedTreeHash,
+  )
+where
+
+import Data.Hashable (Hashable (..))
+import Development.GitRev.Typed
+import Language.Haskell.TH
+
+-- | Compute a hash reflecting the current Git:
+--     * staged changes
+--     * unstaged changes (tracked files)
+gitChangedTreeHash :: Q Exp
+gitChangedTreeHash = do
+  stagedChanges <- projectError $ runGitQ ["diff", "--name-only", "--cached"] IdxUsed
+  unstagedChanges <- projectError $ runGitQ ["diff", "--name-only"] IdxUsed
+  let changedFiles = lines stagedChanges <> lines unstagedChanges
+
+  fileInfos <- projectError $ runGitQ (["ls-files", "-s"] <> changedFiles) IdxUsed
+  let fileHashes = takeHash <$> lines fileInfos
+
+  -- Would be nice to use Git's actual hashing mechanism here but...
+  let finalHash = show (hash fileHashes)
+
+  litE (stringL finalHash)
+
+takeHash :: String -> String
+takeHash s = words s !! 2

--- a/vehicle/src/Vehicle/Prelude/Version.hs
+++ b/vehicle/src/Vehicle/Prelude/Version.hs
@@ -20,6 +20,7 @@ import Data.Version (showVersion)
 #ifdef releaseBuild
 #else
 import Development.GitRev
+import Vehicle.Prelude.Git (gitChangedTreeHash)
 #endif
 import GHC.Generics (Generic)
 import Paths_vehicle qualified as Cabal (version)
@@ -64,8 +65,8 @@ preciseVehicleVersion = showVersion Cabal.version
       hash = $(gitHash)
 
       -- Check if any tracked files have uncommitted changes
-      dirty | $(gitDirtyTracked) = ".dirty"
-            | otherwise          = ""
+      dirty | $(gitDirtyTracked) = ".dirty" <> $(gitChangedTreeHash)
+            | otherwise   = ""
 
       -- Abbreviate a commit hash while keeping it unambiguous
       abbrev = take 7

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -319,6 +319,7 @@ library
     Vehicle.Data.Variable.Free.Context.Instance
     Vehicle.Debug
     Vehicle.Prelude.Error
+    Vehicle.Prelude.Git
     Vehicle.Prelude.IO
     Vehicle.Prelude.Logging.Class
     Vehicle.Prelude.Logging.Instance
@@ -360,7 +361,7 @@ library
     , edit-distance          >=0.2.2    && <1
     , file-embed             >=0.0.15.0 && <0.1
     , filepath               >=1.4      && <2
-    , gitrev                 >=1.3      && <2
+    , gitrev-typed           >=0.1      && <1
     , hashable               >=1.3      && <2
     , mnist-idx              >=0.1.3.1  && <0.2
     , mtl                    >=2.2      && <3
@@ -371,6 +372,7 @@ library
     , random                 >=1.2
     , split                  >=0.2.3    && <0.3
     , sscript                >=0.1.0.2  && <1
+    , template-haskell       >=2.15     && <3
     , temporary              >=1.3      && <1.4
     , terminal-progress-bar  >=0.4.1    && <1
     , text                   >=1.2      && <3


### PR DESCRIPTION
`gitrev` has been deprecated as a project so switching to successor project `gitrev-typed`. This also allows us to control reinstallation of standard library better, by computing the hash of the current changes. This fixes some race conditions that were popping up.