### PR TITLE
Fix library caching issue

### DIFF
--- a/vehicle/src/Vehicle/Libraries.hs
+++ b/vehicle/src/Vehicle/Libraries.hs
@@ -99,42 +99,34 @@ ensureLatestVersionOfLibraryInstalled ::
   m ()
 ensureLatestVersionOfLibraryInstalled library libraryContent = do
   -- Check the library info file and see if it's up to date
-  libraryUpToDate <-
-    if isDirtyRepo
-      then do
-        logDebug MidDetail $
-          "Dirty repo so assuming library"
-            <+> quotePretty (libraryName library)
-            <+> "is out of date."
+  libraryUpToDate <- do
+    libraryFolder <- getLibraryPath (libraryName library)
+
+    errorOrContents <- readLibraryFile libraryFolder
+    case errorOrContents of
+      Left err -> do
+        logDebug MidDetail err
         return False
-      else do
-        libraryFolder <- getLibraryPath (libraryName library)
+      Right actualLibrary -> do
+        let actualVersion = libraryVersion actualLibrary
+        let expectedVersion = libraryVersion library
+        let versionsMatch = actualVersion == expectedVersion
 
-        errorOrContents <- readLibraryFile libraryFolder
-        case errorOrContents of
-          Left err -> do
-            logDebug MidDetail err
-            return False
-          Right actualLibrary -> do
-            let actualVersion = libraryVersion actualLibrary
-            let expectedVersion = libraryVersion library
-            let versionsMatch = actualVersion == expectedVersion
+        logDebug MidDetail $
+          if versionsMatch
+            then
+              "Found up-to-date installed version of"
+                <+> quotePretty (libraryName library)
+                <+> "at"
+                <+> quotePretty libraryFolder
+            else
+              "Installed version of"
+                <+> quotePretty (libraryName library)
+                <+> parens (pretty actualVersion)
+                <+> "does not match latest version"
+                <+> parens (pretty expectedVersion)
 
-            logDebug MidDetail $
-              if versionsMatch
-                then
-                  "Found up-to-date installed version of"
-                    <+> quotePretty (libraryName library)
-                    <+> "at"
-                    <+> quotePretty libraryFolder
-                else
-                  "Installed version of"
-                    <+> quotePretty (libraryName library)
-                    <+> parens (pretty actualVersion)
-                    <+> "does not match latest version"
-                    <+> parens (pretty expectedVersion)
-
-            return versionsMatch
+        return versionsMatch
 
   -- If not update to date then reinstall
   unless libraryUpToDate $ do

--- a/vehicle/src/Vehicle/Prelude/Version.hs
+++ b/vehicle/src/Vehicle/Prelude/Version.hs
@@ -9,7 +9,6 @@ module Vehicle.Prelude.Version
     DecodeResult (..),
     encodeAndWriteVersioned,
     readAndDecodeVersioned,
-    isDirtyRepo,
   )
 where
 
@@ -27,14 +26,6 @@ import Paths_vehicle qualified as Cabal (version)
 
 --------------------------------------------------------------------------------
 -- Current versions
-
-#ifdef releaseBuild
-isDirtyRepo :: Bool
-isDirtyRepo = False
-#else
-isDirtyRepo :: Bool
-isDirtyRepo = $(gitDirtyTracked)
-#endif
 
 -- | The imprecise current version of Vehicle. This can be used whenever the
 -- precise version doesn't really matters. This is used when writing out the
@@ -73,7 +64,7 @@ preciseVehicleVersion = showVersion Cabal.version
       hash = $(gitHash)
 
       -- Check if any tracked files have uncommitted changes
-      dirty | isDirtyRepo = ".dirty"
+      dirty | $(gitDirtyTracked) = ".dirty"
             | otherwise          = ""
 
       -- Abbreviate a commit hash while keeping it unambiguous


### PR DESCRIPTION
A cruder fix to #1023 that means we don't reinstall the library when we detect uncached files. Better than the status quo where we reinstall every single test causing race conditions.