### PR TITLE
More principled version of records

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Binder.hs
@@ -163,6 +163,9 @@ binderNamingForm = namingForm . binderDisplayForm
 setBinderRelevance :: GenericBinder expr -> Relevance -> GenericBinder expr
 setBinderRelevance (Binder u v _r x) r = Binder u v r x
 
+setBinderVisibility :: GenericBinder expr -> Visibility -> GenericBinder expr
+setBinderVisibility (Binder u _v r x) v = Binder u v r x
+
 mapBinderNamingForm :: (BinderNamingForm -> BinderNamingForm) -> GenericBinder expr -> GenericBinder expr
 mapBinderNamingForm f Binder {..} =
   Binder

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -5,9 +5,10 @@ import Data.Hashable (Hashable)
 import Data.Serialize (Serialize)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
+import Vehicle.Syntax.AST.Binder (GenericTelescope)
 import Vehicle.Syntax.AST.Name
 import Vehicle.Syntax.AST.Provenance
-import Vehicle.Syntax.AST.Type (HasType (..))
+import Vehicle.Syntax.AST.Record (GenericRecordFields)
 
 --------------------------------------------------------------------------------
 -- Declarations
@@ -27,6 +28,13 @@ data GenericDecl expr
       DefFunctionSort -- List of annotations.
       expr -- Type of the definition.
       expr -- Body of the definition.
+  | -- | Function definitions with a body
+    DefRecord
+      Provenance -- Location in source file.
+      Identifier -- Name of definition.
+      (Maybe DefRecordSort) -- List of annotations.
+      (GenericTelescope expr) -- Type parameters.
+      (GenericRecordFields expr) -- Fields.
   deriving (Show, Functor, Foldable, Traversable, Generic)
 
 instance (NFData expr) => NFData (GenericDecl expr)
@@ -37,42 +45,16 @@ instance HasProvenance (GenericDecl expr) where
   provenanceOf = \case
     DefAbstract p _ _ _ -> p
     DefFunction p _ _ _ _ -> p
+    DefRecord p _ _ _ _ -> p
 
 instance HasIdentifier (GenericDecl expr) where
   identifierOf = \case
     DefAbstract _ i _ _ -> i
     DefFunction _ i _ _ _ -> i
+    DefRecord _ i _ _ _ -> i
 
 instance HasName (GenericDecl expr) Name where
   nameOf = nameOf . identifierOf
-
-instance HasType (GenericDecl expr) expr where
-  typeOf = \case
-    DefAbstract _ _ _ t -> t
-    DefFunction _ _ _ t _ -> t
-
-bodyOf :: GenericDecl expr -> Maybe expr
-bodyOf = \case
-  DefFunction _ _ _ _ e -> Just e
-  DefAbstract {} -> Nothing
-
-abstractSortOf :: GenericDecl expr -> Maybe DefAbstractSort
-abstractSortOf decl = case decl of
-  DefAbstract _ _ sort _ -> Just sort
-  DefFunction {} -> Nothing
-
--- | Traverses the type and body of a declaration using the first and
--- second provided functions respectively.
--- Use |traverse| if you want to traverse them using the same function.
-traverseDeclTypeAndExpr ::
-  (Monad m) =>
-  (expr1 -> m expr2) ->
-  (expr1 -> m expr2) ->
-  GenericDecl expr1 ->
-  m (GenericDecl expr2)
-traverseDeclTypeAndExpr f1 f2 = \case
-  DefAbstract p n r t -> DefAbstract p n r <$> f1 t
-  DefFunction p n b t e -> DefFunction p n b <$> f1 t <*> f2 e
 
 mapIdentifier ::
   (Identifier -> Identifier) ->
@@ -81,48 +63,34 @@ mapIdentifier ::
 mapIdentifier f = \case
   DefAbstract p n r t -> DefAbstract p (f n) r t
   DefFunction p n b t e -> DefFunction p (f n) b t e
-
--- | Traverses the type of the declaration.
-traverseDeclType ::
-  (Monad m) =>
-  (expr -> m expr) ->
-  GenericDecl expr ->
-  m (GenericDecl expr)
-traverseDeclType f = traverseDeclTypeAndExpr f return
+  DefRecord p n b t e -> DefRecord p (f n) b t e
 
 isPropertyDecl :: GenericDecl expr -> Bool
 isPropertyDecl = \case
   DefAbstract {} -> False
   DefFunction _ _ anns _ _ -> isAnnotatedAsProperty anns
+  DefRecord {} -> False
+
+isTypeDecl :: GenericDecl expr -> Bool
+isTypeDecl = \case
+  DefAbstract {} -> False
+  DefFunction _ _ anns _ _ -> isDeclaredAsType anns
+  DefRecord {} -> False
 
 isAbstractDecl :: GenericDecl expr -> Bool
 isAbstractDecl = \case
   DefAbstract {} -> True
   DefFunction {} -> False
+  DefRecord {} -> False
+
+isExternalResourceDecl :: GenericDecl expr -> Bool
+isExternalResourceDecl = \case
+  DefAbstract _ _ sort _ -> isExternalResourceSort sort
+  DefFunction {} -> False
+  DefRecord {} -> False
 
 --------------------------------------------------------------------------------
--- Abstract definition types options
-
-data ParameterSort
-  = Inferable
-  | NonInferable
-  deriving (Eq, Ord, Show, Generic)
-
-instance NFData ParameterSort
-
-instance Serialize ParameterSort
-
-instance Hashable ParameterSort
-
-instance Pretty ParameterSort where
-  pretty = \case
-    Inferable -> "(infer=True)"
-    NonInferable -> ""
-
-isInferable :: ParameterSort -> Bool
-isInferable = \case
-  Inferable -> True
-  NonInferable -> False
+-- DefAbstract
 
 data DefAbstractSort
   = NetworkDef
@@ -150,11 +118,29 @@ isExternalResourceSort = \case
   ParameterDef parameterType -> parameterType == NonInferable
   BuiltinDef {} -> False
 
-isExternalResourceDecl :: GenericDecl expr -> Bool
-isExternalResourceDecl decl = maybe False isExternalResourceSort (abstractSortOf decl)
+data ParameterSort
+  = Inferable
+  | NonInferable
+  deriving (Eq, Ord, Show, Generic)
+
+instance NFData ParameterSort
+
+instance Serialize ParameterSort
+
+instance Hashable ParameterSort
+
+instance Pretty ParameterSort where
+  pretty = \case
+    Inferable -> "(infer=True)"
+    NonInferable -> ""
+
+isInferable :: ParameterSort -> Bool
+isInferable = \case
+  Inferable -> True
+  NonInferable -> False
 
 --------------------------------------------------------------------------------
--- Annotations options
+-- DefFunction
 
 -- | How many arguments the function declaration is expecting
 -- on the LHS.
@@ -170,40 +156,22 @@ type LHSBinderCount = Int
 data DefFunctionSort
   = -- | The function was declared using `type ... = ...` syntax
     TypeDecl LHSBinderCount
-  | -- | The function was declared with `record X .... where` syntax.
-    RecordDecl (Maybe RecordDeclAnnotation)
   | -- | The function was declared as a standard function
     FunctionDecl LHSBinderCount (Maybe FunctionDeclAnnotation)
+  | -- | The function was generated as a projection from a record
+    ProjectionDecl LHSBinderCount
   deriving (Eq, Show, Generic)
 
 instance NFData DefFunctionSort
 
 instance Serialize DefFunctionSort
 
--- | Possible annotations for records.
-data RecordDeclAnnotation
-  = -- | The record was annotated with @record
-    AnnTensor
-  | -- | The record was annotated with @instance
-    AnnInstance
-  | -- | The record was annotated with @typeclass
-    AnnTypeClass
-  deriving (Eq, Show, Generic)
-
-instance NFData RecordDeclAnnotation
-
-instance Serialize RecordDeclAnnotation
-
-instance Pretty RecordDeclAnnotation where
-  pretty = \case
-    AnnTensor -> "@tensor"
-    AnnInstance -> "@instance"
-    AnnTypeClass -> "@typeclass"
-
 -- | Possible annotations for ordinatary functions.
 data FunctionDeclAnnotation
   = -- | The function was annotated with @property
     AnnProperty
+  | -- | The function was annotated with @instance
+    AnnInstance
   deriving (Eq, Show, Generic)
 
 instance NFData FunctionDeclAnnotation
@@ -213,11 +181,7 @@ instance Serialize FunctionDeclAnnotation
 instance Pretty FunctionDeclAnnotation where
   pretty = \case
     AnnProperty -> "@property"
-
-isDeclaredAsRecord :: DefFunctionSort -> Bool
-isDeclaredAsRecord = \case
-  RecordDecl {} -> True
-  _ -> False
+    AnnInstance -> "@instance"
 
 isDeclaredAsType :: DefFunctionSort -> Bool
 isDeclaredAsType = \case
@@ -229,12 +193,37 @@ isAnnotatedAsProperty = \case
   FunctionDecl _ (Just AnnProperty) -> True
   _ -> False
 
-isAnnotatedAsTensor :: DefFunctionSort -> Bool
-isAnnotatedAsTensor = \case
-  RecordDecl (Just AnnTensor) -> True
-  _ -> False
-
 isAnnotatedAsInstance :: DefFunctionSort -> Bool
 isAnnotatedAsInstance = \case
-  RecordDecl (Just AnnInstance) -> True
+  FunctionDecl _ (Just AnnInstance) -> True
+  _ -> False
+
+--------------------------------------------------------------------------------
+-- DefRecord
+
+-- | Possible annotations for records.
+data DefRecordSort
+  = -- | The record definition was annotated with @record
+    AnnTensor
+  | -- | The record definition was annotated with @typeclass
+    AnnTypeClass
+  deriving (Eq, Show, Generic)
+
+instance NFData DefRecordSort
+
+instance Serialize DefRecordSort
+
+instance Pretty DefRecordSort where
+  pretty = \case
+    AnnTensor -> "@tensor"
+    AnnTypeClass -> "@typeclass"
+
+isAnnotatedAsTensor :: Maybe DefRecordSort -> Bool
+isAnnotatedAsTensor = \case
+  Just AnnTensor -> True
+  _ -> False
+
+isAnnotatedAsTypeClass :: Maybe DefRecordSort -> Bool
+isAnnotatedAsTypeClass = \case
+  Just AnnTypeClass -> True
   _ -> False

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -186,6 +186,8 @@ data RecordDeclAnnotation
     AnnTensor
   | -- | The record was annotated with @instance
     AnnInstance
+  | -- | The record was annotated with @typeclass
+    AnnTypeClass
   deriving (Eq, Show, Generic)
 
 instance NFData RecordDeclAnnotation
@@ -196,6 +198,7 @@ instance Pretty RecordDeclAnnotation where
   pretty = \case
     AnnTensor -> "@tensor"
     AnnInstance -> "@instance"
+    AnnTypeClass -> "@typeclass"
 
 -- | Possible annotations for ordinatary functions.
 data FunctionDeclAnnotation

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Expr.hs
@@ -5,6 +5,9 @@ module Vehicle.Syntax.AST.Expr
   ( -- * Generic expressions
     Arg,
     Binder,
+    Telescope,
+    RecordField,
+    RecordFields,
     Decl,
     Module,
     Expr
@@ -36,7 +39,7 @@ import Vehicle.Syntax.AST.Decl (GenericDecl)
 import Vehicle.Syntax.AST.Module (GenericModule)
 import Vehicle.Syntax.AST.Name (Name)
 import Vehicle.Syntax.AST.Provenance (HasProvenance (..), Provenance, fillInProvenance)
-import Vehicle.Syntax.AST.Record (FieldName, GenericRecordFields)
+import Vehicle.Syntax.AST.Record (FieldName, GenericRecordField, GenericRecordFields)
 import Vehicle.Syntax.Builtin (Builtin)
 
 --------------------------------------------------------------------------------
@@ -93,7 +96,7 @@ data Expr
   | -- | Records
     Record
       Provenance
-      (GenericRecordFields Expr)
+      RecordFields
   | -- | Record accessors.
     --
     -- NOTE: we could replace `RecordAcc` with `App Identifier Record`
@@ -111,7 +114,13 @@ type Type = Expr
 
 type Binder = GenericBinder Expr
 
+type Telescope = GenericTelescope Expr
+
 type Arg = GenericArg Expr
+
+type RecordField = GenericRecordField Expr
+
+type RecordFields = GenericRecordFields Expr
 
 type Decl = GenericDecl Expr
 

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Instances/NoThunks.hs
@@ -72,7 +72,7 @@ instance NoThunks expr => NoThunks (GenericDecl expr)
 instance NoThunks DefAbstractSort
 instance NoThunks ParameterSort
 instance NoThunks DefFunctionSort
-instance NoThunks RecordDeclAnnotation
+instance NoThunks DefRecordSort
 instance NoThunks FunctionDeclAnnotation
 
 -- Vehicle.Syntax.AST.Expr

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Module.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Module.hs
@@ -35,6 +35,13 @@ instance (NFData expr) => NFData (GenericModule expr)
 
 instance (Serialize expr) => Serialize (GenericModule expr)
 
+mapModuleDecls ::
+  (GenericDecl expr1 -> GenericDecl expr2) ->
+  GenericModule expr1 ->
+  GenericModule expr2
+mapModuleDecls f (Module imports ds) =
+  Module imports $ fmap f ds
+
 traverseModuleDecls ::
   (Monad m) =>
   (GenericDecl expr1 -> m (GenericDecl expr2)) ->

--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Record.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Record.hs
@@ -8,7 +8,7 @@ import Data.Map.Ordered qualified as OMap
 import Data.Serialize (Serialize)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), squotes, (<+>))
-import Vehicle.Syntax.AST.Name (HasName (..), Name)
+import Vehicle.Syntax.AST.Name (HasName (..), Identifier (..), Name)
 import Vehicle.Syntax.AST.Provenance (HasProvenance (..), Provenance)
 import Vehicle.Syntax.Prelude (developerError)
 
@@ -38,6 +38,10 @@ instance HasProvenance FieldName where
 
 instance HasName FieldName Name where
   nameOf (FieldName _ name) = name
+
+fieldAccessIdentifier :: Identifier -> FieldName -> Identifier
+fieldAccessIdentifier recordIdent field =
+  Identifier (modulePath recordIdent) (nameOf field)
 
 --------------------------------------------------------------------------------
 -- Record fields

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -70,8 +70,10 @@ instance Delaborate V.Decl [B.Decl] where
       return [defAnn, defFun]
     V.DefFunction _ n sort t e -> case sort of
       V.TypeDecl binderCount -> delabTypeDecl n binderCount e
-      V.RecordDecl ann -> delabRecordDecl n ann t e
       V.FunctionDecl binderCount ann -> delabFunctionDecl n binderCount ann t e
+      V.ProjectionDecl binderCount -> delabFunctionDecl n binderCount Nothing t e
+    V.DefRecord _ n sort t e -> do
+      delabRecordDecl n sort t e
 
 instance Delaborate V.Expr B.Expr where
   delabM expr = case expr of
@@ -119,14 +121,14 @@ instance Delaborate (V.GenericRecordField V.Expr) B.RecordFieldDef where
     typ' <- delabM typ
     return $ B.FieldDef name' tokElemOf typ'
 
-instance Delaborate V.RecordDeclAnnotation B.Decl where
+instance Delaborate V.DefRecordSort B.Decl where
   delabM = \case
     V.AnnTensor -> return $ delabAnn tensorAnn []
-    V.AnnInstance -> return $ delabAnn instanceAnn []
     V.AnnTypeClass -> return $ delabAnn typeClassAnn []
 
 instance Delaborate V.FunctionDeclAnnotation B.Decl where
   delabM = \case
+    V.AnnInstance -> return $ delabAnn instanceAnn []
     V.AnnProperty -> return $ delabAnn propertyAnn []
 
 -- | Used for things not in the user-syntax.
@@ -426,17 +428,16 @@ delabTypeDecl ident binderCount expr = do
 delabRecordDecl ::
   (MonadDelab m) =>
   V.Identifier ->
-  Maybe V.RecordDeclAnnotation ->
-  V.Expr ->
-  V.Expr ->
+  Maybe V.DefRecordSort ->
+  V.Telescope ->
+  V.RecordFields ->
   m [B.Decl]
-delabRecordDecl ident maybeAnn typ expr = do
-  annDecls <- maybeToList <$> traverse delabM maybeAnn
+delabRecordDecl ident sort telescope fields = do
+  annDecl <- traverse delabM $ maybeToList sort
   let n' = delabIdentifier ident
-  let (telescope, fields) = foldRecordDef typ expr
   telescope' <- traverse delabNameBinder telescope
   fields' <- traverse delabM fields
-  return $ annDecls <> [B.DefRecord n' telescope' fields']
+  return $ annDecl <> [B.DefRecord n' telescope' fields']
 
 delabQuantifier :: (MonadDelab m) => V.Quantifier -> [V.Arg] -> m B.Expr
 delabQuantifier q args = case reverse args of
@@ -471,7 +472,7 @@ delabForeach args = case reverse args of
     return $ B.Foreach tokForeach binders' body'
   _ -> cheatDelabPretty V.ForeachTC args
 
-delabRecord :: (MonadDelab m) => [V.GenericRecordField V.Expr] -> m B.Expr
+delabRecord :: (MonadDelab m) => V.RecordFields -> m B.Expr
 delabRecord fields = do
   fields' <- traverse (bitraverse delabM delabM) fields
   return $ B.Record (fmap (uncurry B.FieldAssign) fields')

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -123,6 +123,7 @@ instance Delaborate V.RecordDeclAnnotation B.Decl where
   delabM = \case
     V.AnnTensor -> return $ delabAnn tensorAnn []
     V.AnnInstance -> return $ delabAnn instanceAnn []
+    V.AnnTypeClass -> return $ delabAnn typeClassAnn []
 
 instance Delaborate V.FunctionDeclAnnotation B.Decl where
   delabM = \case

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/Internal.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/Internal.hs
@@ -40,10 +40,13 @@ instance Delaborate V.Module B.Module where
 -- | Elaborate declarations.
 instance Delaborate V.Decl B.Decl where
   delabM = \case
-    V.DefFunction _ n _ t e -> B.DefFun (delabIdentifier n) <$> delabM t <*> delabM e
+    V.DefFunction _ n _ t e ->
+      B.DefFun (delabIdentifier n) <$> delabM t <*> delabM e
     V.DefAbstract _ n s t -> do
       constructor <- delabM s
       constructor (delabIdentifier n) <$> delabM t
+    V.DefRecord _ n _ t f -> do
+      B.DefRecord (delabIdentifier n) <$> traverse delabM t <*> traverse delabM f
 
 instance Delaborate V.DefAbstractSort (B.NameToken -> B.Expr -> B.Decl) where
   delabM sort = return $ case sort of
@@ -70,7 +73,7 @@ instance Delaborate V.Expr B.Expr where
 instance Delaborate V.FieldName B.NameToken where
   delabM (V.FieldName _ name) = return $ delabSymbol name
 
-instance Delaborate (V.GenericRecordField V.Expr) B.RecordField where
+instance Delaborate V.RecordField B.RecordField where
   delabM (field, expr) = B.Field <$> delabM field <*> delabM expr
 
 delabRelevance :: (V.HasRelevance a) => a -> [B.Modality]

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
@@ -162,6 +162,9 @@ parseAnnotation (tkName, opts) = do
     "@instance" -> do
       validateEmptyOpts tkName opts
       return $ RecordDeclAnn V.AnnInstance
+    "@typeclass" -> do
+      validateEmptyOpts tkName opts
+      return $ RecordDeclAnn V.AnnTypeClass
     name -> developerError $ "Unknown annotation found" <+> squotes (pretty name)
 
 elabDefAbstract ::

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
@@ -1,16 +1,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Vehicle.Syntax.BNFC.Elaborate.External
-  ( PartiallyParsedProg,
-    PartiallyParsedDecl,
-    UnparsedExpr (..),
-    partiallyElabModule,
-    elaborateDecl,
+  ( elabModule,
     elaborateExpr,
   )
 where
 
-import Control.Monad (foldM_, unless, when)
+import Control.Monad (foldM_, unless)
 import Control.Monad.Except (MonadError (..), throwError)
 import Control.Monad.Reader (runReaderT)
 import Data.Bitraversable (bitraverse)
@@ -44,30 +40,16 @@ import Vehicle.Syntax.Prelude (developerError, readNat, readRat)
 import Vehicle.Syntax.Tensor (pattern ZeroDimTensor)
 
 --------------------------------------------------------------------------------
--- Public interface
-
-type PartiallyParsedProg = V.GenericModule UnparsedExpr
-
-type PartiallyParsedDecl = V.GenericDecl UnparsedExpr
-
-newtype UnparsedExpr = UnparsedExpr B.Expr
-
---------------------------------------------------------------------------------
 -- Partially elaborating declarations
 
--- | We partially elaborate from the simple AST generated automatically by BNFC
--- to our more complicated internal version of the AST. We stop when we get
--- to the expression level. In theory this should allow us to read the
--- declaration signatures from the file without actually having to parse their
--- types and definitions.
-partiallyElabModule ::
+elabModule ::
   (MonadError ParseError m) =>
   ParseLocation ->
   B.Module ->
-  m PartiallyParsedProg
-partiallyElabModule file (B.DefModule imports decls) = flip runReaderT file $ do
+  m V.Module
+elabModule file (B.DefModule imports decls) = flip runReaderT file $ do
   let imports' = fmap elabImportStatement imports
-  decls' <- partiallyElabDecls decls
+  decls' <- elabDecls decls
   return $ V.Module imports' decls'
 
 elabImportStatement :: B.ImportStatement -> V.ImportStatement
@@ -75,12 +57,12 @@ elabImportStatement (B.Import path) = do
   let fragToString (B.ModulePathFrag frag) = unpack $ tkSymbol frag
   V.ImportStatement $ V.ModulePath $ fmap fragToString path
 
-partiallyElabDecls :: (MonadElab m) => [B.Decl] -> m [PartiallyParsedDecl]
-partiallyElabDecls = \case
+elabDecls :: (MonadElab m) => [B.Decl] -> m [V.Decl]
+elabDecls = \case
   [] -> return []
   decl : decls -> do
     (d', ds) <- elabDeclGroup [] (decl :| decls)
-    ds' <- partiallyElabDecls ds
+    ds' <- elabDecls ds
     return $ d' : ds'
 
 type Annotation = (B.TokAnnotation, B.DeclAnnOpts)
@@ -89,7 +71,7 @@ elabDeclGroup ::
   (MonadElab m) =>
   [Annotation] ->
   NonEmpty B.Decl ->
-  m (PartiallyParsedDecl, [B.Decl])
+  m (V.Decl, [B.Decl])
 elabDeclGroup anns = \case
   -- Type definition.
   B.DefType n bs t :| ds -> do
@@ -128,7 +110,7 @@ elabDeclGroup anns = \case
 
 data AnnotationResult
   = FunDeclAnn V.FunctionDeclAnnotation
-  | RecordDeclAnn V.RecordDeclAnnotation
+  | RecordDeclAnn V.DefRecordSort
   | AbstractDeclAnn V.DefAbstractSort
 
 instance Pretty AnnotationResult where
@@ -138,41 +120,40 @@ instance Pretty AnnotationResult where
     AbstractDeclAnn ann -> pretty ann
 
 parseAnnotation :: (MonadElab m) => Annotation -> m AnnotationResult
-parseAnnotation (tkName, opts) = do
-  case tkSymbol tkName of
-    "@builtin" -> do
-      validateEmptyOpts tkName opts
-      return $ AbstractDeclAnn V.BuiltinDef
-    "@network" -> do
-      validateEmptyOpts tkName opts
-      return $ AbstractDeclAnn V.NetworkDef
-    "@dataset" -> do
-      validateEmptyOpts tkName opts
-      return $ AbstractDeclAnn V.DatasetDef
-    "@parameter" -> do
-      let allowedOptions = Set.fromList [InferableOption]
-      optsList <- validateOpts tkName allowedOptions opts
-      AbstractDeclAnn <$> elabParameterOptions optsList
-    "@property" -> do
-      validateEmptyOpts tkName opts
-      return $ FunDeclAnn V.AnnProperty
-    "@tensor" -> do
-      validateEmptyOpts tkName opts
-      return $ RecordDeclAnn V.AnnTensor
-    "@instance" -> do
-      validateEmptyOpts tkName opts
-      return $ RecordDeclAnn V.AnnInstance
-    "@typeclass" -> do
-      validateEmptyOpts tkName opts
-      return $ RecordDeclAnn V.AnnTypeClass
-    name -> developerError $ "Unknown annotation found" <+> squotes (pretty name)
+parseAnnotation (tkName, opts) = case tkSymbol tkName of
+  "@builtin" -> do
+    validateEmptyOpts tkName opts
+    return $ AbstractDeclAnn V.BuiltinDef
+  "@network" -> do
+    validateEmptyOpts tkName opts
+    return $ AbstractDeclAnn V.NetworkDef
+  "@dataset" -> do
+    validateEmptyOpts tkName opts
+    return $ AbstractDeclAnn V.DatasetDef
+  "@parameter" -> do
+    let allowedOptions = Set.fromList [InferableOption]
+    optsList <- validateOpts tkName allowedOptions opts
+    AbstractDeclAnn <$> elabParameterOptions optsList
+  "@property" -> do
+    validateEmptyOpts tkName opts
+    return $ FunDeclAnn V.AnnProperty
+  "@instance" -> do
+    validateEmptyOpts tkName opts
+    return $ FunDeclAnn V.AnnInstance
+  "@tensor" -> do
+    validateEmptyOpts tkName opts
+    return $ RecordDeclAnn V.AnnTensor
+  "@typeclass" -> do
+    validateEmptyOpts tkName opts
+    return $ RecordDeclAnn V.AnnTypeClass
+  name -> developerError $ "Unknown annotation found" <+> squotes (pretty name)
 
 elabDefAbstract ::
   (MonadElab m) =>
   [Annotation] ->
   B.Name ->
   B.Expr ->
-  m (V.GenericDecl UnparsedExpr)
+  m V.Decl
 elabDefAbstract anns n t = do
   p <- mkProvenance n
   ident <- elabName n
@@ -188,7 +169,8 @@ elabDefAbstract anns n t = do
     [ann] ->
       throwError $ AbstractDefWithNonAbstractAnnotation p ident (pretty ann)
 
-  return $ V.DefAbstract p ident annotation (UnparsedExpr t)
+  typ <- elabDeclType t
+  return $ V.DefAbstract p ident annotation typ
 
 elabTypeDef ::
   (MonadElab m) =>
@@ -196,7 +178,7 @@ elabTypeDef ::
   B.Name ->
   [B.NameBinder] ->
   B.Expr ->
-  m (V.GenericDecl UnparsedExpr)
+  m V.Decl
 elabTypeDef anns name binders expr = do
   p <- mkProvenance name
   ident <- elabName name
@@ -205,8 +187,7 @@ elabTypeDef anns name binders expr = do
   case annotations of
     ann : _ ->
       throwError $ TypeDefWithAnnotation p ident (pretty ann)
-    [] -> do
-      return ()
+    [] -> return ()
 
   let typeTyp
         | null binders = tokType 0
@@ -224,7 +205,7 @@ elabFunctionDef ::
   B.Expr ->
   [B.NameBinder] ->
   B.Expr ->
-  m (V.GenericDecl UnparsedExpr)
+  m V.Decl
 elabFunctionDef anns name1 name2 typ binders expr = do
   p <- mkProvenance name1
   ident1 <- elabName name1
@@ -255,39 +236,28 @@ elabRecordDefinition ::
   B.Name ->
   [B.NameBinder] ->
   [B.RecordFieldDef] ->
-  m (V.GenericDecl UnparsedExpr)
+  m V.Decl
 elabRecordDefinition anns name telescope fields = do
   p <- mkProvenance name
   ident <- elabName name
 
   annotations <- traverse parseAnnotation anns
-  sort <-
-    V.RecordDecl <$> case annotations of
-      [RecordDeclAnn recordAnn] ->
-        return $ Just recordAnn
-      [] ->
-        return Nothing
-      ann1 : ann2 : _ ->
-        throwError $ MultiplyAnnotatedDef p ident (pretty ann1) (pretty ann2)
-      [AbstractDeclAnn absAnn] ->
-        throwError $ NonAbstractDefWithAbstractAnnotation p ident (pretty absAnn)
-      [FunDeclAnn absAnn] ->
-        throwError $ RecordDefWithFunctionAnnotation p ident (pretty absAnn)
+  sort <- case annotations of
+    [RecordDeclAnn recordAnn] ->
+      return $ Just recordAnn
+    [] ->
+      return Nothing
+    ann1 : ann2 : _ ->
+      throwError $ MultiplyAnnotatedDef p ident (pretty ann1) (pretty ann2)
+    [AbstractDeclAnn absAnn] ->
+      throwError $ NonAbstractDefWithAbstractAnnotation p ident (pretty absAnn)
+    [FunDeclAnn absAnn] ->
+      throwError $ RecordDefWithFunctionAnnotation p ident (pretty absAnn)
 
-  when (V.isAnnotatedAsTensor sort && not (null telescope)) $ do
-    throwError $ TensorAnnotationWithParameters p ident
+  fields' <- traverse elabRecordFieldDef fields
+  telescope' <- traverse (elabNameBinder elabExpr False) telescope
 
-  let defToAssign (B.FieldDef nam _tk val) = B.FieldAssign nam val
-  let fields' = B.Record $ fmap defToAssign fields
-
-  let (typ, expr)
-        | null telescope = (tokType 0, fields')
-        | otherwise =
-            ( B.ForallT tokForallT telescope (tokType 0),
-              B.Lam tokLambda telescope tokArrow fields'
-            )
-
-  elabGenericDefFun p ident sort typ mempty expr
+  return $ V.DefRecord p ident sort telescope' fields'
 
 elabGenericDefFun ::
   (MonadElab m) =>
@@ -297,12 +267,16 @@ elabGenericDefFun ::
   B.Expr ->
   [B.NameBinder] ->
   B.Expr ->
-  m (V.GenericDecl UnparsedExpr)
+  m V.Decl
 elabGenericDefFun p ident sort t binders e = do
   -- This is a bit evil, we don't normally store possibly empty set of
   -- binders, but we will use this to indicate the set of LHS variables.
-  let body = B.Lam tokLambda binders tokArrow e
-  return $ V.DefFunction p ident sort (UnparsedExpr t) (UnparsedExpr body)
+  t' <- elabDeclType t
+  let body = case binders of
+        [] -> e
+        _ -> B.Lam tokLambda binders tokArrow e
+  e' <- elabDeclType body
+  return $ V.DefFunction p ident sort t' e'
 
 validateOpts :: forall m token. (MonadElab m, IsToken token) => token -> Set Text -> B.DeclAnnOpts -> m [B.DeclAnnOption]
 validateOpts _token _allowedNames B.DeclAnnWithoutOpts = return mempty
@@ -340,8 +314,7 @@ elabParameterOptions opts =
         V.Builtin _ (V.BuiltinConstructor (V.BoolTensorLiteral (ZeroDimTensor infer)))
           | infer -> return V.Inferable
           | otherwise -> return V.NonInferable
-        _ -> do
-          throwError $ InvalidAnnotationOptionValue InferableOption expr'
+        _ -> throwError $ InvalidAnnotationOptionValue InferableOption expr'
 
 getInferOption :: B.DeclAnnOption -> Maybe (B.TokAnnInferOpt, B.Expr)
 getInferOption = \case
@@ -351,39 +324,18 @@ getInferOption = \case
 --------------------------------------------------------------------------------
 -- Full elaboration
 
-elaborateDecl ::
-  (MonadError ParseError m) =>
-  ParseLocation ->
-  PartiallyParsedDecl ->
-  m V.Decl
-elaborateDecl file decl = flip runReaderT file $ case decl of
-  V.DefAbstract p n r t -> V.DefAbstract p n r <$> elabDeclType t
-  V.DefFunction p n b t e -> V.DefFunction p n b <$> elabDeclType t <*> elabDeclBody e
-
 elabDeclType ::
   (MonadElab m) =>
-  UnparsedExpr ->
+  B.Expr ->
   m V.Expr
-elabDeclType (UnparsedExpr expr) = elabExpr expr
-
-elabDeclBody ::
-  (MonadElab m) =>
-  UnparsedExpr ->
-  m V.Expr
-elabDeclBody (UnparsedExpr expr) = case expr of
-  B.Lam tk binders _ body -> do
-    binders' <- traverse (elabNameBinder elabExpr True) binders
-    body' <- elabExpr body
-    p <- mkProvenance tk
-    return $ foldr (V.Lam p) body' binders'
-  _ -> developerError "Invalid declaration body - no lambdas found"
+elabDeclType = elabExpr
 
 elaborateExpr ::
   (MonadError ParseError m) =>
   ParseLocation ->
-  UnparsedExpr ->
+  B.Expr ->
   m V.Expr
-elaborateExpr file (UnparsedExpr expr) = runReaderT (elabExpr expr) file
+elaborateExpr file expr = runReaderT (elabExpr expr) file
 
 elabExpr :: (MonadElab m) => B.Expr -> m V.Expr
 elabExpr expr = case expr of
@@ -477,14 +429,19 @@ elabRecordFieldName tk = do
   p <- mkProvenance tk
   return $ V.FieldName p (tkSymbol tk)
 
-elabRecordFieldAssign :: (MonadElab m) => B.RecordFieldAssign -> m (V.GenericRecordField V.Expr)
-elabRecordFieldAssign (B.FieldAssign name expr) = (,) <$> elabRecordFieldName name <*> elabExpr expr
+elabRecordFieldAssign :: (MonadElab m) => B.RecordFieldAssign -> m V.RecordField
+elabRecordFieldAssign (B.FieldAssign name expr) = do
+  (,) <$> elabRecordFieldName name <*> elabExpr expr
+
+elabRecordFieldDef :: (MonadElab m) => B.RecordFieldDef -> m V.RecordField
+elabRecordFieldDef (B.FieldDef name _ expr) =
+  (,) <$> elabRecordFieldName name <*> elabExpr expr
 
 elabRecord :: (MonadElab m) => [B.RecordFieldAssign] -> m V.Expr
 elabRecord xs = do
   fields <- traverse elabRecordFieldAssign xs
   -- I'm struggling to make the left/right braces into tokens as the tokenizer doesn't
-  -- seem to recognise them correcty. Hence this very ugly hack.
+  -- seem to recognise them correctly. Hence this very ugly hack.
   -- pL <- mkProvenance tkL
   -- pR <- mkProvenance tkR
   -- let p = V.fillInProvenance (pL :| [pR])
@@ -496,10 +453,9 @@ elabRecord xs = do
 elabRecordAcc :: (MonadElab m) => B.Expr -> B.FieldAccess -> m V.Expr
 elabRecordAcc e field = do
   p <- mkProvenance field
-  let fieldName = V.FieldName p (Text.tail $ tkSymbol field)
+  let fieldName = V.FieldName p $ Text.tail $ tkSymbol field
   r <- elabExpr e
-
-  return $ V.RecordAcc (V.provenanceOf fieldName) r fieldName
+  return $ V.RecordAcc p r fieldName
 
 elabBasicBinder ::
   (MonadElab m) =>

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Utils.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Utils.hs
@@ -49,6 +49,8 @@ tensorAnn = mkToken B.TokAnnotation "@tensor"
 
 instanceAnn = mkToken B.TokAnnotation "@instance"
 
+typeClassAnn = mkToken B.TokAnnotation "@typeclass"
+
 tokArrow = mkToken B.TokArrow "->"
 
 tokForallT = mkToken B.TokForallT "forallT"

--- a/vehicle-syntax/src/Vehicle/Syntax/External.cf
+++ b/vehicle-syntax/src/Vehicle/Syntax/External.cf
@@ -10,7 +10,17 @@ position token Boolean  ({"True"} | {"False"});
 position token Natural  (digit+);
 position token Rational (digit+ '.' digit+);
 
-position token TokAnnotation ({"@"} ({"network"} | {"dataset"} | {"parameter"} | {"property"} | {"tensor"} | {"instance"} | {"builtin"}));
+position token TokAnnotation ({"@"}
+  ( {"network"}
+  | {"dataset"}
+  | {"parameter"}
+  | {"property"}
+  | {"tensor"}
+  | {"instance"}
+  | {"builtin"}
+  | {"typeclass"}
+  )
+);
 
 position token TokArrow     {"->"};
 position token TokForallT   {"forallT"};

--- a/vehicle-syntax/src/Vehicle/Syntax/Internal.cf
+++ b/vehicle-syntax/src/Vehicle/Syntax/Internal.cf
@@ -33,6 +33,8 @@ ExplicitBinder. Binder ::= "(" [Modality] NameToken ":" Expr ")";
 ImplicitBinder. Binder ::= "{" [Modality] NameToken ":" Expr "}";
 InstanceBinder. Binder ::= "{{" [Modality] NameToken ":" Expr "}}";
 
+separator Binder "";
+
 -- * Function arguments
 
 ExplicitArg. Arg ::= [Modality] Expr1;
@@ -78,6 +80,7 @@ DeclParam.     Decl ::= "(" "declare-parameter"      NameToken Expr1 ")";
 DeclImplParam. Decl ::= "(" "declare-impl-parameter" NameToken Expr1 ")";
 DeclPost.      Decl ::= "(" "declare-postulate"      NameToken Expr1 ")";
 DefFun.        Decl ::= "(" "define-fun"             NameToken Expr1 Expr1 ")";
+DefRecord.     Decl ::= "(" "define-record"          NameToken [Binder] [RecordField] ")";
 
 separator Decl "";
 

--- a/vehicle-syntax/src/Vehicle/Syntax/Parse.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/Parse.hs
@@ -1,33 +1,28 @@
 module Vehicle.Syntax.Parse
   ( ParseError (..),
-    UnparsedExpr,
-    PartiallyParsedProg,
-    PartiallyParsedDecl,
     ParseLocation,
     readAndParseModule,
-    parseDecl,
-    parseExpr,
-    readExpr,
   )
 where
 
 import Control.Monad.Except (MonadError (..))
 import Data.Text (Text)
 import Vehicle.Syntax.AST
-import Vehicle.Syntax.BNFC.Elaborate.External
+import Vehicle.Syntax.BNFC.Elaborate.External (elabModule)
 import Vehicle.Syntax.BNFC.Utils (ParseLocation)
-import Vehicle.Syntax.External.Abs qualified as External (Expr, Module)
+import Vehicle.Syntax.External.Abs qualified as External (Module)
 import Vehicle.Syntax.External.Layout as External (resolveLayout)
 import Vehicle.Syntax.External.Lex as External (Token)
-import Vehicle.Syntax.External.Par as External (myLexer, pExpr, pModule)
+import Vehicle.Syntax.External.Par as External (myLexer, pModule)
 import Vehicle.Syntax.Parse.Error (ParseError (..))
 
 --------------------------------------------------------------------------------
 -- Interface
 
-readAndParseModule :: (MonadError ParseError m) => ParseLocation -> Text -> m PartiallyParsedProg
-readAndParseModule modul txt = castBNFCError (partiallyElabModule modul) (parseExternalModule txt)
+readAndParseModule :: (MonadError ParseError m) => ParseLocation -> Text -> m Module
+readAndParseModule modul txt = castBNFCError (elabModule modul) (parseExternalModule txt)
 
+{-
 parseDecl :: (MonadError ParseError m) => ParseLocation -> PartiallyParsedDecl -> m Decl
 parseDecl = elaborateDecl
 
@@ -36,15 +31,16 @@ parseExpr = elaborateExpr
 
 readExpr :: (MonadError ParseError m) => Text -> m UnparsedExpr
 readExpr txt = castBNFCError (return . UnparsedExpr) (parseExternalExpr txt)
-
+-}
 --------------------------------------------------------------------------------
 -- Parsing
 
 type ExternalParser a = [External.Token] -> Either String a
 
+{-
 parseExternalExpr :: Text -> Either String External.Expr
 parseExternalExpr = runExternalParser False External.pExpr
-
+-}
 parseExternalModule :: Text -> Either String External.Module
 parseExternalModule = runExternalParser True External.pModule
 

--- a/vehicle-syntax/src/Vehicle/Syntax/Parse/Error.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/Parse/Error.hs
@@ -25,7 +25,6 @@ data ParseError
   | AbstractDefWithNonAbstractAnnotation Provenance Identifier (Doc Void)
   | NonAbstractDefWithAbstractAnnotation Provenance Identifier (Doc Void)
   | AnnotationWithNoDef Provenance Name
-  | TensorAnnotationWithParameters Provenance Identifier
   | -- Annotation options
     InvalidAnnotationOption Provenance Name Name [Name]
   | InvalidAnnotationOptionValue Name Expr

--- a/vehicle-syntax/src/Vehicle/Syntax/Sugar.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/Sugar.hs
@@ -9,7 +9,6 @@ module Vehicle.Syntax.Sugar
     foldForeachBinders,
     foldDeclBinders,
     foldLetBinders,
-    foldRecordDef,
     LetBinder,
   )
 where
@@ -18,7 +17,6 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Vehicle.Syntax.AST
 import Vehicle.Syntax.Builtin
-import Vehicle.Syntax.Prelude (developerError)
 
 -- This module deals with all the unfolding and folding of syntactic
 -- sugar in the external language. The unfolding is designed so that it should
@@ -28,21 +26,15 @@ import Vehicle.Syntax.Prelude (developerError)
 -- Pi/Fun/Forall declarations
 
 class HasBasicBinders expr where
-  isUniverse :: expr -> Bool
   getPiBinder :: expr -> Maybe (GenericBinder expr, expr)
   getLamBinder :: expr -> Maybe (GenericBinder expr, expr)
   getLetBinder :: expr -> Maybe (expr, GenericBinder expr, expr)
-  getRecord :: expr -> Maybe (GenericRecordFields expr)
 
 class HasBuiltinBinders expr where
   getQuantifierBinder :: Quantifier -> expr -> Maybe (GenericBinder expr, expr)
   getForeachBinder :: expr -> Maybe (GenericBinder expr, expr)
 
 instance HasBasicBinders Expr where
-  isUniverse = \case
-    Universe {} -> True
-    _ -> False
-
   getPiBinder = \case
     Pi _ binder body -> Just (binder, body)
     _ -> Nothing
@@ -53,10 +45,6 @@ instance HasBasicBinders Expr where
 
   getLetBinder = \case
     Let _ value binder body -> Just (value, binder, body)
-    _ -> Nothing
-
-  getRecord = \case
-    Record _ fields -> Just fields
     _ -> Nothing
 
 instance HasBuiltinBinders Expr where
@@ -151,20 +139,3 @@ foldLetBinders expr = case getLetBinder expr of
   Just (bound, binder, body)
     | wantsToFold binder -> first ((binder, bound) :) (foldLetBinders body)
   _ -> ([], expr)
-
---------------------------------------------------------------------------------
--- Decls
-
-foldRecordDef ::
-  (HasBasicBinders expr) =>
-  expr ->
-  expr ->
-  (GenericTelescope expr, GenericRecordFields expr)
-foldRecordDef typ body = case (getPiBinder typ, getLamBinder body) of
-  (Nothing, Nothing) -> case getRecord body of
-    Just fields | isUniverse typ -> ([], fields)
-    _ -> developerError "Malformed record definition"
-  (Just (piBinder, piBody), Just (_lamBinder, lamBody)) -> do
-    let (telescope, fields) = foldRecordDef piBody lamBody
-    (piBinder : telescope, fields)
-  _ -> developerError "Malformed record definition"

--- a/vehicle/src/Vehicle/Backend/Agda/CapitaliseTypeNames.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/CapitaliseTypeNames.hs
@@ -48,7 +48,7 @@ instance CapitaliseTypes [Decl DecidabilityBuiltin] where
       when isType $
         modify (insert (identifierOf d))
 
-      d' <- traverseDeclTypeAndExpr cap cap d
+      d' <- traverse cap d
       let d'' = if isType then mapIdentifier capitaliseIdentifier d' else d'
 
       ds' <- addDeclToContext d'' (cap ds)
@@ -66,12 +66,10 @@ instance CapitaliseTypes (Expr DecidabilityBuiltin) where
     Lam p binder body -> Lam p <$> cap binder <*> cap body
     BoundVar p v -> return $ BoundVar p v
     FreeVar p ident -> FreeVar p <$> capitaliseIdentifierIfType ident
-    Record p ident fields -> do
-      ident' <- traverse capitaliseIdentifierIfType ident
-      Record p ident' <$> traverseRecordFields cap fields
-    RecordAcc p record (ident, field) -> do
-      ident' <- capitaliseIdentifierIfType ident
-      RecordAcc p <$> cap record <*> pure (ident', field)
+    Record p recordType fields -> do
+      Record p <$> cap recordType <*> traverseRecordFields cap fields
+    RecordProj p recordType record field -> do
+      RecordProj p <$> cap recordType <*> cap record <*> pure field
 
 instance CapitaliseTypes (Arg DecidabilityBuiltin) where
   cap Arg {..} = do
@@ -95,13 +93,16 @@ capitaliseIdentifierIfType ident = do
       else ident
 
 isTypeDef :: forall m. (MonadCapitalise m) => Decl DecidabilityBuiltin -> m Bool
-isTypeDef decl = do
-  normType <- normaliseInEmptyEnv (typeOf decl)
-  case normType of
-    -- We don't capitalise things of type `Bool` because they will be lifted
-    -- to the type level, only things of type `X -> Bool`.
-    VPi {} -> go mempty normType
-    _ -> return False
+isTypeDef decl = case decl of
+  DefAbstract {} -> return False
+  DefRecord {} -> return False
+  DefFunction _ _ _ t _ -> do
+    normType <- normaliseInEmptyEnv t
+    case normType of
+      -- We don't capitalise things of type `Bool` because they will be lifted
+      -- to the type level, only things of type `X -> Bool`.
+      VPi {} -> go mempty normType
+      _ -> return False
   where
     go :: NamedBoundCtx -> Value DecidabilityBuiltin -> m Bool
     go _ (VBuiltin (DecidabilityBuiltinFunction PropType) []) = return True

--- a/vehicle/src/Vehicle/Backend/Agda/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Agda/Compile.hs
@@ -9,7 +9,7 @@ import Data.Foldable (fold)
 import Data.List (sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Maybe (mapMaybe)
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -310,27 +310,31 @@ binderBrackets topLevel = \case
 -- Compilation of program structure
 
 compileProg :: (MonadAgdaCompile m) => AgdaOptions -> Prog DecidabilityBuiltin -> m Code
-compileProg opts (Main ds) = vsep2 <$> traverse (compileDecl opts) ds
+compileProg opts (Main ds) = do
+  decls <- catMaybes <$> traverse (compileDecl opts) ds
+  return $ vsep2 decls
 
-compileDecl :: (MonadAgdaCompile m) => AgdaOptions -> Decl DecidabilityBuiltin -> m Code
+compileDecl :: (MonadAgdaCompile m) => AgdaOptions -> Decl DecidabilityBuiltin -> m (Maybe Code)
 compileDecl opts = \case
   DefAbstract _ n _ t ->
-    compilePostulate (compileIdentifier n) <$> compileExpr t
+    Just <$> compilePostulate n t
   DefFunction p n funSort t e -> case funSort of
-    TypeDecl binderCount -> compileFunctionDecl n binderCount t e
-    FunctionDecl binderCount Nothing -> compileFunctionDecl n binderCount t e
-    FunctionDecl _ (Just AnnProperty) -> compileProperty opts n e
-    RecordDecl _ -> compileRecordDecl p n t e
+    TypeDecl binderCount -> Just <$> compileFunctionDecl n binderCount t e
+    FunctionDecl binderCount Nothing -> Just <$> compileFunctionDecl n binderCount t e
+    FunctionDecl _ (Just AnnProperty) -> Just <$> compileProperty opts n e
+    FunctionDecl _ (Just AnnInstance) -> throwError $ UnimplementedFeature p "Compiling instances to Agda"
+    ProjectionDecl _ -> return Nothing
+  DefRecord p n _sort telescope fields ->
+    Just <$> compileRecordDecl p n telescope fields
 
 compileRecordDecl ::
   (MonadAgdaCompile m) =>
   Provenance ->
   Identifier ->
-  Type DecidabilityBuiltin ->
-  Expr DecidabilityBuiltin ->
+  Telescope DecidabilityBuiltin ->
+  RecordFields DecidabilityBuiltin ->
   m Code
-compileRecordDecl p ident typ expr = do
-  let (telescope, fields) = foldRecordDef typ expr
+compileRecordDecl p ident telescope fields = do
   t' <-
     if null telescope
       then return (compileType 0)
@@ -395,7 +399,7 @@ compileExpr expr = do
           <> concatWith (\x y -> x <> line <> ";" <+> y) fs'
           <> line
           <> "}"
-    RecordAcc _p r (_i, field) ->
+    RecordProj _p _t r field ->
       annotateApp [] Nothing (pretty field) [explicit r]
   logExit result
   return result
@@ -697,8 +701,15 @@ compileFunDef n t ns e =
     <+> e
 
 -- | Compile a `network` declaration
-compilePostulate :: Code -> Code -> Code
-compilePostulate name t = "postulate" <+> name <+> ":" <+> align t
+compilePostulate ::
+  (MonadAgdaCompile m) =>
+  Identifier ->
+  Type DecidabilityBuiltin ->
+  m Code
+compilePostulate ident typ = do
+  let name = compileIdentifier ident
+  t <- compileExpr typ
+  return $ "postulate" <+> name <+> ":" <+> align t
 
 compileProperty ::
   (MonadAgdaCompile m) =>

--- a/vehicle/src/Vehicle/Backend/Loss.hs
+++ b/vehicle/src/Vehicle/Backend/Loss.hs
@@ -68,6 +68,7 @@ convertDecl logicID logic decl = do
         DefFunction p ident ann typ expr
           | isPropertyDecl decl -> Just <$> convertPropertyDecl p ident ann typ expr
           | otherwise -> return Nothing
+        DefRecord {} -> return Nothing
 
 convertResourceDecl ::
   (MonadLogic m) =>

--- a/vehicle/src/Vehicle/Backend/Loss/JSON.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/JSON.hs
@@ -164,7 +164,8 @@ convertProg (S.Main decls) = Main <$> traverse convertDecl decls
 
 convertDecl :: (MonadJSON m) => S.Decl LossBuiltin -> m JDecl
 convertDecl = \case
-  S.DefAbstract {} -> compilerDeveloperError "Found abstract definition when converting to JSON"
+  S.DefAbstract {} -> developerError "Found abstract definition when converting to JSON"
+  S.DefRecord {} -> developerError "Found record when converting to JSON"
   S.DefFunction p ident _ typ body -> do
     typ' <- convertType emptyBoundEnv typ
     expr' <- convertExpr emptyBoundEnv body

--- a/vehicle/src/Vehicle/Backend/Rocq/Compile.hs
+++ b/vehicle/src/Vehicle/Backend/Rocq/Compile.hs
@@ -9,6 +9,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Foldable (fold)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
+import Data.Maybe (catMaybes)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -152,7 +153,7 @@ importStatements deps = vsep $ map pretty (Set.toList deps)
 preamble :: Set Dependency -> Code
 preamble deps =
   if Set.member (RequireImport MathcompRealsReals) deps
-    then compilePostulate "R" "realType"
+    then "Parameter" <+> "R" <+> ":" <+> align "realType" <> "."
     else ""
 
 --------------------------------------------------------------------------------
@@ -259,17 +260,22 @@ type MonadRocqCompile m =
 -- Program Compilation
 
 compileProg :: (MonadRocqCompile m) => Prog DecidabilityBuiltin -> m Code
-compileProg (Main ds) = vsep2 <$> traverse compileDecl ds
+compileProg (Main ds) = do
+  decls <- catMaybes <$> traverse compileDecl ds
+  return $ vsep2 decls
 
-compileDecl :: (MonadRocqCompile m) => Decl DecidabilityBuiltin -> m Code
+compileDecl :: (MonadRocqCompile m) => Decl DecidabilityBuiltin -> m (Maybe Code)
 compileDecl = \case
   DefAbstract _ n _ t ->
-    compilePostulate (compileIdentifier n) <$> compileExpr t
+    Just <$> compilePostulate n t
   DefFunction p n funSort t e -> case funSort of
-    TypeDecl binderCount -> compileFunctionDecl n binderCount t e
-    FunctionDecl binderCount Nothing -> compileFunctionDecl n binderCount t e
-    FunctionDecl _ (Just AnnProperty) -> compileProperty n e
-    RecordDecl _ -> compileRecordDecl p n t e
+    TypeDecl binderCount -> Just <$> compileFunctionDecl n binderCount t e
+    FunctionDecl binderCount Nothing -> Just <$> compileFunctionDecl n binderCount t e
+    FunctionDecl _ (Just AnnProperty) -> Just <$> compileProperty n e
+    FunctionDecl _ (Just AnnInstance) -> throwError $ UnimplementedFeature p "Compiling instances to Rocq"
+    ProjectionDecl {} -> return Nothing
+  DefRecord p n _ telescope fields ->
+    Just <$> compileRecordDecl p n telescope fields
 
 compileFunctionDecl ::
   (MonadRocqCompile m) =>
@@ -289,11 +295,10 @@ compileRecordDecl ::
   (MonadRocqCompile m) =>
   Provenance ->
   Identifier ->
-  Type DecidabilityBuiltin ->
-  Expr DecidabilityBuiltin ->
+  Telescope DecidabilityBuiltin ->
+  RecordFields DecidabilityBuiltin ->
   m Code
-compileRecordDecl p ident typ expr = do
-  let (telescope, fields) = foldRecordDef typ expr
+compileRecordDecl p ident telescope fields = do
   t' <-
     if null telescope
       then return (compileType 0)
@@ -325,8 +330,15 @@ extractDeclBinders binderCount typ expr
       (_, _) -> ([], expr)
 
 -- | Compile a 'network' declaration
-compilePostulate :: Code -> Code -> Code
-compilePostulate name t = "Parameter" <+> name <+> ":" <+> align t <> "."
+compilePostulate ::
+  (MonadRocqCompile m) =>
+  Identifier ->
+  Type DecidabilityBuiltin ->
+  m Code
+compilePostulate ident t = do
+  let name = compileIdentifier ident
+  typ <- compileExpr t
+  return $ "Parameter" <+> name <+> ":" <+> align typ <> "."
 
 compileExpr :: (MonadRocqCompile m) => Expr DecidabilityBuiltin -> m Code
 compileExpr expr = do
@@ -357,7 +369,7 @@ compileExpr expr = do
     Record _p _i fs -> do
       fs' <- traverse compileRecordField fs
       return $ encloseSep (lbrace <> "|" <> space) (space <> "|" <> rbrace) (semi <> space) fs'
-    RecordAcc _p r (_i, field) -> annotateNotation [] 200 ("$0.(" <> nameOf field <> ")") (Just $ nameOf field) [explicit r]
+    RecordProj _p _t r field -> annotateNotation [] 200 ("$0.(" <> nameOf field <> ")") (Just $ nameOf field) [explicit r]
   logExit result
   return result
 

--- a/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination/Error.hs
+++ b/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination/Error.hs
@@ -70,11 +70,20 @@ diagnoseSpecIncompatiblility prog propertyIdentifier typeCheckFn = do
       Right linearityProg -> Right <$> findDeclType propertyIdentifier linearityProg
 
 findDeclType :: (MonadCompile m) => Identifier -> Prog builtin -> m (Expr builtin)
-findDeclType ident (Main decls) = do
-  let candidates = filter (\decl -> identifierOf decl == ident) decls
-  case candidates of
-    [property] -> return $ typeOf property
-    _ -> compilerDeveloperError $ "Could not find property" <+> quotePretty ident <+> "in program after subtyping."
+findDeclType propIdent (Main decls) = do
+  let maybePropertyType = firstJust getPropertyType decls
+  case maybePropertyType of
+    Just propertyType -> return propertyType
+    Nothing ->
+      compilerDeveloperError $
+        "Could not find property"
+          <+> quotePretty propIdent
+          <+> "in program after subtyping."
+  where
+    getPropertyType :: Decl builtin -> Maybe (Type builtin)
+    getPropertyType = \case
+      DefFunction _ ident _ t _ | propIdent == ident -> Just t
+      _ -> Nothing
 
 unexpectedOriginType :: Identifier -> CompileError
 unexpectedOriginType ident =

--- a/vehicle/src/Vehicle/Compile/Dependency.hs
+++ b/vehicle/src/Vehicle/Compile/Dependency.hs
@@ -104,7 +104,7 @@ createDependencyGraph ds = fromEdges $ AdjacencyGraph $ Map.fromList $ fmap goDe
       Lam _ binder body -> do traverse_ go binder; go body
       Let _ bound binder body -> do go bound; traverse_ go binder; go body
       Record _ _ fields -> traverse_ (go . snd) fields
-      RecordAcc _ record _ -> go record
+      RecordProj _ recordType record _ -> do go recordType; go record
 
 --------------------------------------------------------------------------------
 -- Completely unused declarations

--- a/vehicle/src/Vehicle/Compile/Descope.hs
+++ b/vehicle/src/Vehicle/Compile/Descope.hs
@@ -1,5 +1,6 @@
 module Vehicle.Compile.Descope
-  ( descopeExpr,
+  ( descopeDecl,
+    descopeExpr,
     descopeExprInEmptyCtx,
     descopeExprNaively,
     descopeValueNaively,
@@ -22,13 +23,41 @@ import Vehicle.Syntax.AST.Expr qualified as S
 --------------------------------------------------------------------------------
 -- Interface
 
+descopeDecl :: (PrintableBuiltin builtin) => Decl builtin -> S.Decl
+descopeDecl decl = do
+  let builtinDecl = fmap convertExprBuiltins decl
+  case builtinDecl of
+    DefFunction p ident sort t e -> DefFunction p ident sort (descopeExprInEmptyCtx t) (descopeExprInEmptyCtx e)
+    DefAbstract p ident sort t -> DefAbstract p ident sort (descopeExprInEmptyCtx t)
+    DefRecord p ident sort t f -> do
+      let (t', f') = descopeRecordTelescope t f
+      DefRecord p ident sort t' f'
+
+descopeRecordTelescope ::
+  (PrintableBuiltin Builtin) =>
+  Telescope Builtin ->
+  RecordFields Builtin ->
+  (S.Telescope, S.RecordFields)
+descopeRecordTelescope telescope fields =
+  runFreshNameBoundContext (go telescope)
+  where
+    go :: (MonadNameContext m) => Telescope Builtin -> m (S.Telescope, S.RecordFields)
+    go = \case
+      [] -> do
+        fields' <- traverseRecordFields (genericDescopeExpr (ixToName Named)) fields
+        return ([], fields')
+      binder : binders -> do
+        binder' <- traverse (genericDescopeExpr (ixToName Named)) binder
+        (binders', fields') <- addNameToContext binder $ go binders
+        return (binder' : binders', fields')
+
 descopeExpr :: (PrintableBuiltin builtin) => NamedBoundCtx -> Expr builtin -> S.Expr
 descopeExpr ctx e =
   runNameBoundContext ctx $
     genericDescopeExpr (ixToName Named) (convertExprBuiltins e)
 
 descopeExprInEmptyCtx :: (PrintableBuiltin builtin) => Expr builtin -> S.Expr
-descopeExprInEmptyCtx e = descopeExpr mempty e
+descopeExprInEmptyCtx = descopeExpr mempty
 
 descopeExprNaively :: (PrintableBuiltin builtin) => Expr builtin -> S.Expr
 descopeExprNaively e = do
@@ -88,10 +117,10 @@ genericDescopeExpr f e = showDescopeExit $ case showDescopeEntry e of
     binder' <- traverse (genericDescopeExpr f) binder
     body' <- addNameToContext binder $ genericDescopeExpr f body
     return $ S.Pi p binder' body'
-  Record p _ fields -> do
+  Record p _recordType fields -> do
     fields' <- traverseRecordFields (genericDescopeExpr f) fields
     return $ S.Record p fields'
-  RecordAcc p record (_, field) -> do
+  RecordProj p _recordType record field -> do
     record' <- genericDescopeExpr f record
     return $ S.RecordAcc p record' field
 
@@ -140,10 +169,10 @@ genericDescopeValue f e = case e of
     binder' <- traverse (genericDescopeValue f) binder
     body' <- addNameToContext binder $ descopeClosure f binder closure
     return $ S.Lam p binder' body'
-  VRecord _ident fields -> do
+  VRecord _recordType fields -> do
     fields' <- traverseRecordFields (genericDescopeValue f) $ OMap.assocs fields
     return $ S.Record p fields'
-  VRecordAcc record (_ident, field) -> do
+  VRecordAcc _recordType record field -> do
     record' <- genericDescopeValue f record
     return $ S.RecordAcc p record' field
   where

--- a/vehicle/src/Vehicle/Compile/FunctionaliseResources.hs
+++ b/vehicle/src/Vehicle/Compile/FunctionaliseResources.hs
@@ -117,6 +117,8 @@ functionaliseDecl d =
       logDebug MaxDetail $ "Prepending resources" <+> pretty binderNames
       logDebug MaxDetail $ prettyFriendly fun
       return (addResourceUsage i binderNames, Just fun)
+    DefRecord {} ->
+      return (id, Just d)
 
 findResourceUses ::
   (MonadResource m builtin) =>

--- a/vehicle/src/Vehicle/Compile/Monomorphisation.hs
+++ b/vehicle/src/Vehicle/Compile/Monomorphisation.hs
@@ -132,24 +132,22 @@ handleUsedDecl applications decl = do
       <> line
       <> indent 2 (prettyMultiLineList $ NonEmpty.toList (fmap prettyVerbose applications))
 
-  monomorphisations <- calculateMonomorphisations (typeOf decl) applications
-
-  logDebug MaxDetail $
-    "Unique monomorphisable applications:"
-      <> line
-      <> indent 2 (prettyMultiLineList (fmap prettyVerbose monomorphisations))
-
-  let noMonomorphisation = do
-        logDebug MaxDetail "Not monomorphising as an abstract declaration"
-        return [decl]
-
   case decl of
     DefFunction p ident anns typ body -> do
+      let monomorphisations = calculateMonomorphisations typ applications
+
+      logDebug MaxDetail $
+        "Unique monomorphisable applications:"
+          <> line
+          <> indent 2 (prettyMultiLineList (fmap prettyVerbose monomorphisations))
+
       let numberOfApplications = length monomorphisations
       let allFreeVarsInArgs = Set.unions (freeVarsIn . argExpr <$> concat monomorphisations)
       let createNewName = numberOfApplications > 1 || ident `Set.member` allFreeVarsInArgs
       traverse (performMonomorphisation (p, ident, anns, typ, body) createNewName) monomorphisations
-    DefAbstract {} -> noMonomorphisation
+    _ -> do
+      logDebug MaxDetail "Not monomorphising as an abstract declaration"
+      return [decl]
 
 handleUnusedDecl ::
   (MonadCollect builtin m) =>
@@ -162,7 +160,9 @@ handleUnusedDecl decl isRootDecl = do
     then do
       -- Work out if the unused declaration needs to be monomorphised
       let fakeArgs = explicit (Hole mempty "fakeArg") : fakeArgs
-      let (argsToMono, _) = obtainArgsToMonomorphise (typeOf decl) fakeArgs
+      let argsToMono = case decl of
+            DefFunction _ _ _ t _ -> fst $ obtainArgsToMonomorphise t fakeArgs
+            _ -> mempty
       let needsToBeMonomorphised = not (null argsToMono)
 
       if needsToBeMonomorphised
@@ -178,17 +178,17 @@ handleUnusedDecl decl isRootDecl = do
       return []
 
 calculateMonomorphisations ::
-  (MonadCollect builtin m) =>
+  (Eq builtin) =>
   Type builtin ->
   NonEmpty [Arg builtin] ->
-  m [[Arg builtin]]
+  [[Arg builtin]]
 calculateMonomorphisations declType allApplications = do
   let calculateMonomorphisation = obtainArgsToMonomorphise declType
   let monomorphisations = fmap (fst . calculateMonomorphisation) allApplications
   -- This is inefficient and not strictly semantically correct.
   -- Semantic equality is difficult however.
   let uniqueMonomorphisations = nub $ NonEmpty.toList monomorphisations
-  return $ toList uniqueMonomorphisations
+  toList uniqueMonomorphisations
 
 performMonomorphisation ::
   (MonadCollect builtin m) =>

--- a/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/NBE.hs
@@ -167,14 +167,17 @@ eval ctx boundEnv expr = do
       fun' <- recEval fun
       args' <- traverse (traverse recEval) (NonEmpty.toList args)
       evalApp ctx fun' args'
-    Record _p ident fields -> do
+    Record _p recordType fields -> do
+      recordType' <- recEval recordType
       fields' <- traverseRecordFields recEval fields
-      return $ VRecord ident $ OMap.fromList fields'
-    RecordAcc _p record fieldRef@(_i, field) -> do
+      return $ VRecord recordType' $ OMap.fromList fields'
+    RecordProj _p recordType record field -> do
       record' <- recEval record
       case record' of
         VRecord _ fields -> return $ lookupRecordFieldS fields field
-        _ -> return $ VRecordAcc record' fieldRef
+        _ -> do
+          recordType' <- recEval recordType
+          return $ VRecordAcc recordType' record' field
 
   showExit ctx result
   return result
@@ -231,9 +234,7 @@ lookupIdentValue :: forall builtin m. (MonadFreeContext builtin m) => Identifier
 lookupIdentValue ident = do
   decl <- getDeclEntry (Proxy @builtin) ident
   return $ case decl of
-    -- This record check is kind of dodgy...
-    DefFunction _ _ sort _ value
-      | not (isDeclaredAsRecord sort) -> value
+    DefFunction _ _ _ _ value -> value
     _ -> VFreeVar ident []
 
 findInstanceArg :: (MonadLogger m, Show op) => op -> [GenericArg a] -> m (a, [GenericArg a])

--- a/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
+++ b/vehicle/src/Vehicle/Compile/Normalise/Quote.hs
@@ -66,12 +66,14 @@ instance (ConvertableBuiltin builtin1 builtin2) => Quote (Value builtin1) (Expr 
       let quotedBinder = quote p level binder
       let quotedBody = quoteClosure p level (binder, closure)
       Lam mempty quotedBinder quotedBody
-    VRecord ident fields -> do
+    VRecord recordType fields -> do
+      let quotedRecordType = quote p level recordType
       let quotedFields = mapRecordFields (quote p level) $ OMap.assocs fields
-      Record p ident quotedFields
-    VRecordAcc r field -> do
-      let quotedRecord = quote p level r
-      RecordAcc p quotedRecord field
+      Record p quotedRecordType quotedFields
+    VRecordAcc recordType record field -> do
+      let quotedRecordType = quote p level recordType
+      let quotedRecord = quote p level record
+      RecordProj p quotedRecordType quotedRecord field
 
 instance (Quote expr1 expr2) => Quote (GenericBinder expr1) (GenericBinder expr2) where
   quote p level = fmap (quote p level)

--- a/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
+++ b/vehicle/src/Vehicle/Compile/Prelude/Utils.hs
@@ -30,7 +30,7 @@ freeNamesIn = \case
   Let _ bound binder body -> freeNamesIn bound <> freeNamesIn (typeOf binder) <> freeNamesIn body
   Lam _ binder body -> freeNamesIn (typeOf binder) <> freeNamesIn body
   Record _ _ fields -> concatMap (freeNamesIn . snd) fields
-  RecordAcc _ r _ -> freeNamesIn r
+  RecordProj _ t r _ -> freeNamesIn t <> freeNamesIn r
 
 --------------------------------------------------------------------------------
 -- Destruction functions

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -130,9 +130,12 @@ data Strategy
 {-
 -- Testing code, do not delete!
 -- Fill in `TestType` and inspect the hole to see what it reduces to.
-type TestType = LinearExpression `In` NamedBoundCtx
+--  e.g. type TestType = LinearExpression `In` NamedBoundCtx
+
+type TestType = Prog Builtin `In` NamedBoundCtx
 
 data MyProxy (a :: Strategy) = MyProxy
+
 test :: MyProxy (StrategyFor FriendlyTags TestType)
 test = _
 -}
@@ -176,11 +179,13 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor tags (String `In` ctx) = 'Pretty
   StrategyFor tags (Identifier `In` ctx) = 'Pretty
   StrategyFor tags (ModulePath `In` ctx) = 'Pretty
+  StrategyFor tags (FieldName `In` ctx) = 'Pretty
   -------------------
   -- Unscoped expr --
   -------------------
   -- To convert any named representation to the target language, simply convert it.
   StrategyFor ('As lang) S.Expr = 'PrintAs lang
+  StrategyFor ('As lang) S.Decl = 'PrintAs lang
   StrategyFor ('Named tags) S.Expr = StrategyFor tags S.Expr
   StrategyFor ('Unnamed tags) S.Expr = StrategyFor tags S.Expr
   -----------------
@@ -190,6 +195,8 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   -- Otherwise converting it to an unnamed representation we descope naively by just converting the variables directly
   StrategyFor ('Named tags) (Expr builtin `In` NamedBoundCtx) = 'DescopeWithNames (StrategyFor tags S.Expr)
   StrategyFor ('Unnamed tags) (Expr builtin `In` ctx) = 'DescopeNaively (StrategyFor tags S.Expr)
+  StrategyFor ('Named tags) (Decl builtin `In` NoCtx) = 'DescopeWithNames (StrategyFor tags S.Decl)
+  StrategyFor ('Unnamed tags) (Decl builtin `In` ctx) = 'DescopeNaively (StrategyFor tags S.Decl)
   ------------
   -- Values --
   ------------
@@ -201,9 +208,9 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   -------------------
   -- Context setup --
   -------------------
-  StrategyFor tags (GenericProg expr) = StrategyFor tags (GenericModule expr)
-  StrategyFor tags (GenericModule expr) = 'SetupContext (StrategyFor tags (GenericModule expr `In` NamedBoundCtx))
-  StrategyFor tags (GenericDecl expr) = 'SetupContext (StrategyFor tags (GenericDecl expr `In` NamedBoundCtx))
+  StrategyFor tags (GenericProg expr) = 'SetupContext (StrategyFor tags (GenericModule expr))
+  StrategyFor tags (Module builtin) = StrategyFor tags (Decl builtin)
+  StrategyFor tags (Decl builtin) = 'SetupContext (StrategyFor tags (Decl builtin `In` NoCtx))
   StrategyFor tags (Contextualised object CompleteNamedBoundCtx) = 'AlterContext (StrategyFor tags (Contextualised object NamedBoundCtx))
   StrategyFor tags (Contextualised object ctx) = 'SetupContext (StrategyFor tags (object `In` ctx))
   StrategyFor tags (Contextualised object ctx `In` NoCtx) = 'SetupContext (StrategyFor tags (object `In` ctx))
@@ -222,8 +229,6 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor tags (MaybeTrivial a `In` ctx) = 'Functor (StrategyFor tags (a `In` ctx))
   StrategyFor tags (IntMap a `In` ctx) = 'Functor (StrategyFor tags (a `In` ctx))
   StrategyFor tags (MetaMap a `In` ctx) = 'Functor (StrategyFor tags (a `In` ctx))
-  StrategyFor tags (GenericModule expr `In` ctx) = (StrategyFor tags (expr `In` ctx))
-  StrategyFor tags (GenericDecl expr `In` ctx) = (StrategyFor tags (expr `In` ctx))
   StrategyFor tags (GenericArg expr `In` ctx) = (StrategyFor tags (expr `In` ctx))
   StrategyFor tags (GenericBinder expr `In` ctx) = (StrategyFor tags (expr `In` ctx))
   StrategyFor tags (Tensor a `In` ctx) = 'Functor (StrategyFor tags (a `In` ctx))
@@ -296,7 +301,6 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   --------------------
   StrategyFor ('Cleaned tags) a = 'Clean (StrategyFor tags a)
   StrategyFor ('ShortVectors tags) a = 'ShortenVectors (StrategyFor tags a)
-  -- StrategyFor tags (Contextualised object (ConstraintContext builtin)) = 'SetupContext (StrategyFor tags (object `In` NamedBoundCtx))
   ----------------
   -- Error case --
   ----------------
@@ -362,28 +366,52 @@ prettyWith = prettyUsing @(StrategyFor tags a) @a @b
 --------------------------------------------------------------------------------
 -- SetupContext
 
-instance (PrettyUsing rest (object `In` ctx)) => PrettyUsing ('SetupContext rest) (Contextualised object ctx) where
+instance
+  (PrettyUsing rest (object `In` ctx)) =>
+  PrettyUsing ('SetupContext rest) (Contextualised object ctx)
+  where
   prettyUsing (WithContext e ctx) = prettyUsing @rest (e, ctx)
 
-instance (PrettyUsing rest (object `In` ctx)) => PrettyUsing ('SetupContext rest) (Contextualised object ctx `In` NoCtx) where
+instance
+  (PrettyUsing rest (object `In` ctx)) =>
+  PrettyUsing ('SetupContext rest) (Contextualised object ctx `In` NoCtx)
+  where
   prettyUsing (WithContext e ctx, _) = prettyUsing @rest (e, ctx)
 
-instance (PrettyUsing rest (GenericModule expr)) => PrettyUsing rest (GenericProg expr) where
+instance
+  (PrettyUsing rest (GenericModule expr)) =>
+  PrettyUsing ('SetupContext rest) (GenericProg expr)
+  where
   prettyUsing (Main decls) = prettyUsing @rest (Module mempty decls)
 
-instance (PrettyUsing rest (GenericModule expr `In` NamedBoundCtx)) => PrettyUsing ('SetupContext rest) (GenericModule expr) where
-  prettyUsing prog = prettyUsing @rest (prog, emptyNamedCtx)
+instance
+  (PrettyUsing rest (Module expr `In` NoCtx)) =>
+  PrettyUsing ('SetupContext rest) (Module expr)
+  where
+  prettyUsing decl = prettyUsing @rest (decl, ())
 
-instance (PrettyUsing rest (GenericDecl expr `In` NamedBoundCtx)) => PrettyUsing ('SetupContext rest) (GenericDecl expr) where
-  prettyUsing decl = prettyUsing @rest (decl, emptyNamedCtx)
+instance
+  (PrettyUsing rest (Decl expr `In` NoCtx)) =>
+  PrettyUsing ('SetupContext rest) (Decl expr)
+  where
+  prettyUsing decl = prettyUsing @rest (decl, ())
 
-instance (PrettyUsing rest S.Expr) => PrettyUsing ('SetupContext rest) (S.Expr `In` NoCtx) where
+instance
+  (PrettyUsing rest S.Expr) =>
+  PrettyUsing ('SetupContext rest) (S.Expr `In` NoCtx)
+  where
   prettyUsing (e, ()) = prettyUsing @rest e
 
-instance (PrettyUsing rest S.Arg) => PrettyUsing ('SetupContext rest) (S.Arg `In` NoCtx) where
+instance
+  (PrettyUsing rest S.Arg) =>
+  PrettyUsing ('SetupContext rest) (S.Arg `In` NoCtx)
+  where
   prettyUsing (e, ()) = prettyUsing @rest e
 
-instance (PrettyUsing rest S.Binder) => PrettyUsing ('SetupContext rest) (S.Binder `In` NoCtx) where
+instance
+  (PrettyUsing rest S.Binder) =>
+  PrettyUsing ('SetupContext rest) (S.Binder `In` NoCtx)
+  where
   prettyUsing (e, ()) = prettyUsing @rest e
 
 instance
@@ -622,15 +650,15 @@ instance
 
 instance
   (PrettyUsing rest S.Decl, PrintableBuiltin builtin) =>
-  PrettyUsing ('DescopeWithNames rest) (Decl builtin `In` NamedBoundCtx)
+  PrettyUsing ('DescopeWithNames rest) (Decl builtin `In` NoCtx)
   where
-  prettyUsing (e, ctx) = prettyUsing @rest $ fmap (descopeExpr ctx) e
+  prettyUsing (e, ()) = prettyUsing @rest $ descopeDecl e
 
 instance
   (PrettyUsing rest S.Module, PrintableBuiltin builtin) =>
-  PrettyUsing ('DescopeWithNames rest) (Module builtin `In` NamedBoundCtx)
+  PrettyUsing ('DescopeWithNames rest) (Module builtin `In` NoCtx)
   where
-  prettyUsing (e, ctx) = prettyUsing @rest $ fmap (descopeExpr ctx) e
+  prettyUsing (e, ()) = prettyUsing @rest $ mapModuleDecls descopeDecl e
 
 -- Value
 

--- a/vehicle/src/Vehicle/Compile/Print/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Print/Error.hs
@@ -191,22 +191,6 @@ formatCompileError = \case
                 <+> ann
                 <+> "annotation."
         }
-    TensorAnnotationWithParameters p name ->
-      VehicleError
-        { provenance = Just p,
-          problem =
-            "The record"
-              <+> prettyIdentName name
-              <+> "cannot be annotated with a"
-              <+> pretty AnnTensor
-              <+> "annotation as annotating"
-              <+> "parameterised records is not yet supported.",
-          fix =
-            Just $
-              "remove the type parameters from the definition of"
-                <+> prettyIdentName name
-                <> "."
-        }
     AnnotationWithNoDef p ann ->
       VehicleError
         { provenance = Just p,

--- a/vehicle/src/Vehicle/Compile/Scope.hs
+++ b/vehicle/src/Vehicle/Compile/Scope.hs
@@ -11,10 +11,10 @@ import Data.Foldable (traverse_)
 import Data.List.NonEmpty qualified as NonEmpty
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
-import Vehicle.Compile.Print (prettyFriendly, prettyVerbose)
+import Vehicle.Compile.Print (prettyExternal)
 import Vehicle.Compile.Scope.Core
 import Vehicle.Compile.Scope.Generalise
-import Vehicle.Compile.Scope.RecordInstances (createTensorRecordConversionFunctions)
+import Vehicle.Compile.Scope.RecordInstances (createAuxilliaryRecordDeclarations)
 import Vehicle.Data.Builtin.Standard
 import Vehicle.Data.Code.ModuleInterface
 import Vehicle.Data.Universe (UniverseLevel (..))
@@ -42,49 +42,44 @@ scopeDecl decl =
         t' <- runMonadScopeExprT $ scopeExpr t
         return [DefAbstract p ident r t']
       DefFunction p ident anns t e -> do
-        t' <-
-          runMonadScopeExprT $
-            scopeExpr =<< generaliseType t
-
-        e' <-
-          runMonadScopeExprT $
-            if isDeclaredAsRecord anns
-              then scopeRecordDefinition ident e
-              else scopeExpr e
-
-        conversionFunctions <-
-          if isAnnotatedAsTensor anns
-            then createTensorRecordConversionFunctions p ident e'
-            else return []
-
-        let defFun = DefFunction p ident anns t' e'
-        return $ defFun : conversionFunctions
+        t' <- runMonadScopeExprT $ scopeExpr =<< generaliseType t
+        e' <- runMonadScopeExprT $ scopeExpr e
+        return [DefFunction p ident anns t' e']
+      DefRecord p ident sort telescope fields -> do
+        (telescope', fields') <- runMonadScopeExprT $ scopeRecordDefinition ident telescope fields
+        auxiliaryDeclarations <- createAuxilliaryRecordDeclarations p ident sort telescope' fields'
+        let defFun = DefRecord p ident sort telescope' fields'
+        return $ defFun : auxiliaryDeclarations
 
     traverse_ addNewDecl scopedDecls
-    traverse_ (logCompilerPassOutput . prettyVerbose) scopedDecls
-    traverse_ (logCompilerPassOutput . prettyFriendly) scopedDecls
+    traverse_ (logCompilerPassOutput . prettyExternal) scopedDecls
     return scopedDecls
 
 --------------------------------------------------------------------------------
 -- Expr scoping
 
 scopeRecordDefinition ::
+  forall m.
   (MonadScopeExpr m) =>
   Identifier ->
-  S.Expr ->
-  m (Expr Builtin)
-scopeRecordDefinition ident = \case
-  S.Lam p binder body -> do
-    scopeBinder binder $ \binder' ->
-      Lam p binder' <$> scopeRecordDefinition ident body
-  S.Record p fields -> do
-    fields' <- forM fields $ \(field, fieldType) -> do
-      fieldType' <- scopeExpr =<< generaliseType fieldType
-      addNewRecordDefField ident field
-      return (field, fieldType')
-    addNewRecordDef ident (fmap fst fields')
-    return $ Record p Nothing fields'
-  _ -> developerError "Found ill-formed record definition"
+  S.Telescope ->
+  S.RecordFields ->
+  m (Telescope Builtin, RecordFields Builtin)
+scopeRecordDefinition ident telescope fields = go [] telescope
+  where
+    go :: Telescope Builtin -> S.Telescope -> m (Telescope Builtin, RecordFields Builtin)
+    go revScopedTelescope = \case
+      binder : binders -> do
+        scopeBinder binder $ \binder' ->
+          go (binder' : revScopedTelescope) binders
+      [] -> do
+        let scopedTelescope = reverse revScopedTelescope
+        scopedFields <- forM fields $ \(field, fieldType) -> do
+          fieldType' <- scopeExpr =<< generaliseType fieldType
+          addNewRecordDefField ident scopedTelescope field
+          return (field, fieldType')
+        addNewRecordDef ident scopedTelescope scopedFields
+        return (scopedTelescope, scopedFields)
 
 scopeExpr ::
   (MonadScopeExpr m) =>
@@ -110,12 +105,14 @@ scopeExpr e = case e of
       Let p bound' binder' <$> scopeExpr body
   S.Record p fields -> do
     fields' <- traverseRecordFields scopeExpr fields
-    recordDefinitionIdent <- lookupRecordDefinitionByFields p (fmap fst fields')
-    return $ Record p (Just recordDefinitionIdent) fields'
+    identAndTelescope <- lookupRecordDefinitionByFields p (fmap fst fields')
+    let recordType = calculateConcreteRecordType p identAndTelescope
+    return $ Record p recordType fields'
   S.RecordAcc p record field -> do
     record' <- scopeExpr record
-    recordDefinitionIdent <- lookupRecordDefinitionByField field
-    return $ RecordAcc p record' (recordDefinitionIdent, field)
+    (ident, _) <- lookupRecordDefinitionByField field
+    let projFn = FreeVar p (Identifier (modulePath ident) (nameOf field))
+    return $ normAppList projFn [explicit record']
 
 scopeBuiltin ::
   (MonadScopeExpr m) =>
@@ -152,6 +149,14 @@ scopeVar p symbol = do
   case maybeVariable of
     Left ident -> return $ FreeVar p ident
     Right ix -> return $ BoundVar p ix
+
+calculateConcreteRecordType ::
+  Provenance ->
+  (Identifier, Telescope builtin) ->
+  Type builtin
+calculateConcreteRecordType p (ident, telescope) = do
+  let mkHoleArg binder = argFromBinder binder (Hole (provenanceOf binder) (fst $ getNamedBinderInfo binder))
+  normAppList (FreeVar p ident) $ fmap mkHoleArg telescope
 
 {-
 logScopeEntry :: MonadTraverse m => S.Expr -> m ()

--- a/vehicle/src/Vehicle/Compile/Scope/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Scope/Core.hs
@@ -55,17 +55,22 @@ runMonadScopeT modulePath importedCtx action = do
 
 -- | Called when parsing a record definition field-by-field so that
 -- earlier fields are in scope for later fields.
-addNewRecordDefField :: (MonadState ModuleScopingInterface m, MonadCompile m) => Identifier -> FieldName -> m ()
-addNewRecordDefField ident newField = do
+addNewRecordDefField ::
+  (MonadState ModuleScopingInterface m, MonadCompile m) =>
+  Identifier ->
+  Telescope Builtin ->
+  FieldName ->
+  m ()
+addNewRecordDefField ident telescope newField = do
   ModuleScopingInterface {..} <- get
   case Map.lookup newField recordIdentifiersByField of
     Nothing -> return ()
-    Just existingIdentifier ->
+    Just (existingIdentifier, _) ->
       throwError $ DeclarationDeclarationShadowing (provenanceOf newField) (Left newField) existingIdentifier
 
   put $
     ModuleScopingInterface
-      { recordIdentifiersByField = Map.insert newField ident recordIdentifiersByField,
+      { recordIdentifiersByField = Map.insert newField (ident, telescope) recordIdentifiersByField,
         ..
       }
 
@@ -75,14 +80,15 @@ addNewRecordDefField ident newField = do
 addNewRecordDef ::
   (MonadState ModuleScopingInterface m) =>
   Identifier ->
-  [FieldName] ->
+  Telescope Builtin ->
+  RecordFields Builtin ->
   m ()
-addNewRecordDef ident fields = do
+addNewRecordDef ident telescope fields = do
   ModuleScopingInterface {..} <- get
-  let fieldSet = Set.fromList fields
+  let fieldSet = Set.fromList $ fmap fst fields
   put $
     ModuleScopingInterface
-      { recordIdentifiersByFields = Map.insert fieldSet ident recordIdentifiersByFields,
+      { recordIdentifiersByFields = Map.insert fieldSet (ident, telescope) recordIdentifiersByFields,
         fieldsByRecordIdentifier = Map.insert ident fieldSet fieldsByRecordIdentifier,
         ..
       }
@@ -193,23 +199,27 @@ lookupBoundVariable name = do
   boundCtx <- asks boundCtx
   return (Ix <$> elemIndex (Just name) boundCtx)
 
-lookupRecordDefinitionByField :: (MonadScopeExpr m) => FieldName -> m Identifier
+lookupRecordDefinitionByField :: (MonadScopeExpr m) => FieldName -> m (Identifier, Telescope Builtin)
 lookupRecordDefinitionByField field = do
   maybeResult <- lookupInNonLocalCtx (Map.lookup field . recordIdentifiersByField)
   case maybeResult of
-    Just definitionIdent -> return definitionIdent
+    Just result -> return result
     Nothing -> do
       allFieldsInScope <- concatInNonLocalCtx (Map.keys . recordIdentifiersByField)
       let fieldName = nameOf field
       let suggestions = mispellingsSortedByLikelihood fieldName (fmap nameOf allFieldsInScope)
       throwError $ UnboundRecordAccessor (provenanceOf field) fieldName suggestions
 
-lookupRecordDefinitionByFields :: (MonadScopeExpr m) => Provenance -> [FieldName] -> m Identifier
+lookupRecordDefinitionByFields ::
+  (MonadScopeExpr m) =>
+  Provenance ->
+  [FieldName] ->
+  m (Identifier, Telescope Builtin)
 lookupRecordDefinitionByFields p fields = do
   let fieldSet = Set.fromList fields
   maybeResult <- lookupInNonLocalCtx (Map.lookup fieldSet . recordIdentifiersByFields)
   case maybeResult of
-    Just ident -> return ident
+    Just result -> return result
     Nothing -> do
       allFieldsByIdentifier <- concatInNonLocalCtx (Map.toList . fieldsByRecordIdentifier)
       let bestMatch = findBestRecordMatch fields allFieldsByIdentifier

--- a/vehicle/src/Vehicle/Compile/Scope/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Scope/Generalise.hs
@@ -40,9 +40,9 @@ findGeneralisableVariables = \case
   S.Let _ bound binder body -> do
     findGeneralisableVariables bound
     findGeneralisableVariablesBinder binder $ findGeneralisableVariables body
-  S.Record _ fields ->
+  S.Record _ fields -> do
     void $ traverseRecordFields findGeneralisableVariables fields
-  S.RecordAcc _ record _field ->
+  S.RecordAcc _ record _field -> do
     findGeneralisableVariables record
 
 findGeneralisableVariablesBinder :: (MonadScopeExpr m, MonadWriter [GeneralisableVariable] m) => S.Binder -> m () -> m ()

--- a/vehicle/src/Vehicle/Compile/Scope/RecordInstances.hs
+++ b/vehicle/src/Vehicle/Compile/Scope/RecordInstances.hs
@@ -1,14 +1,16 @@
 module Vehicle.Compile.Scope.RecordInstances
-  ( createTensorRecordConversionFunctions,
+  ( createAuxilliaryRecordDeclarations,
   )
 where
 
+import Control.Monad (unless)
 import Control.Monad.Except (MonadError (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Text qualified as Text
 import Vehicle.Compile.Error
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Scope.Core
+import Vehicle.Data.Builtin.Interface.Print (PrintableBuiltin)
 import Vehicle.Data.Builtin.Standard
 import Vehicle.Data.Code.DSL
 import Vehicle.Data.DSL
@@ -16,14 +18,91 @@ import Vehicle.Data.DSL
 --------------------------------------------------------------------------------
 -- Expr generalisation
 
+createAuxilliaryRecordDeclarations ::
+  (MonadScope m) =>
+  Provenance ->
+  Identifier ->
+  Maybe DefRecordSort ->
+  Telescope Builtin ->
+  RecordFields Builtin ->
+  m [Decl Builtin]
+createAuxilliaryRecordDeclarations p ident sort telescope fields = do
+  let visibility = if isAnnotatedAsTypeClass sort then Instance True else Explicit
+  recordProjectionFunctions <- traverse (createRecordProjectionFn p ident telescope visibility) fields
+  tensorConversionFunctions <-
+    if isAnnotatedAsTensor sort
+      then createTensorRecordConversionFunctions p ident telescope fields
+      else return []
+  return $ recordProjectionFunctions <> tensorConversionFunctions
+
+-- | Given a record declaration of the form
+--
+--    def record X t1 .. tn where
+--        { ...
+--        , f : t
+--        , ...
+--        }
+--
+-- creates a projection function:
+--
+--    f : forall {t1} ... {tn} -> [ X t1 ... tn ] -> t / [t1 ... tn]
+--    f {p1} ... {pn} [r] = r.f
+--
+-- where `[ ... ]` represents the provided visibility.
+createRecordProjectionFn ::
+  (MonadScope m, PrintableBuiltin builtin) =>
+  Provenance ->
+  Identifier ->
+  Telescope builtin ->
+  Visibility ->
+  RecordField builtin ->
+  m (Decl builtin)
+createRecordProjectionFn p ident telescope visibility (field, fieldType) = do
+  -- Change any explicit binders to implicit
+  let implicitTelescope = fmap (flip setBinderVisibility $ Implicit True) telescope
+
+  -- Create the parameters
+  let parameterIxs = reverse $ fmap Ix [0 .. (length telescope - 1)]
+  let mkParameterArg (binder, ix) = argFromBinder binder (BoundVar p ix)
+  let parameterArgs = fmap mkParameterArg (zip telescope parameterIxs)
+  let parameterisedRecordType = normAppList (FreeVar p ident) parameterArgs
+  let fnRecordBinder namingForm =
+        Binder
+          { binderDisplayForm = BinderDisplayForm namingForm True,
+            binderVisibility = visibility,
+            binderRelevance = Relevant,
+            binderValue = parameterisedRecordType
+          }
+
+  -- Create the type
+  let liftedFieldType = liftDBIndices 1 fieldType
+  let fnBaseType = Pi p (fnRecordBinder OnlyType) liftedFieldType
+  let fnType = foldr (Pi p) fnBaseType implicitTelescope
+
+  -- Create the body
+  let liftedRecordType = liftDBIndices 1 parameterisedRecordType
+  let recordProjExpr = RecordProj p liftedRecordType (BoundVar p (Ix 0)) field
+  let fnBaseBody = Lam p (fnRecordBinder (NameAndType "r" p)) recordProjExpr
+  let fnBody = foldr (Lam p) fnBaseBody implicitTelescope
+
+  -- Create the identifier
+  let fnIdent = fieldAccessIdentifier ident field
+  let fnSort = ProjectionDecl (length telescope + 1)
+
+  -- Create the declaration
+  return $ DefFunction p fnIdent fnSort fnType fnBody
+
 createTensorRecordConversionFunctions ::
   (MonadScope m) =>
   Provenance ->
   Identifier ->
-  Expr Builtin ->
+  Telescope Builtin ->
+  RecordFields Builtin ->
   m [Decl Builtin]
-createTensorRecordConversionFunctions p ident expr = do
-  let fields = getTensorRecordFields expr
+createTensorRecordConversionFunctions p ident telescope fields = do
+  unless (null telescope) $
+    throwError $
+      UnimplementedFeature p ("Annotating parameterised records with" <+> pretty AnnTensor)
 
   nonEmptyFields <- case fields of
     [] -> throwError $ ZeroFieldTensorLike (ident, p)
@@ -69,7 +148,7 @@ createRecordToTensor p recordIdent fieldElementType fieldDimensions fields = do
 
   -- Create the body
   let functionBody = fromDSL mempty $ explLam "x" recordType $ \record -> do
-        let tensorElements = fmap (\(fieldName, _) -> recordAcc record (recordIdent, fieldName)) fields
+        let tensorElements = fmap (\(fieldName, _) -> recordProj (freeVar recordIdent) record fieldName) fields
         stackTensor fieldElementType firstDimension fieldDimensions tensorElements
 
   DefFunction p functionIdent (FunctionDecl 1 Nothing) functionType functionBody

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -8,7 +8,6 @@ import Control.Monad.Except (MonadError (..))
 import Data.IntSet qualified as IntSet
 import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -75,8 +74,9 @@ typeCheckDecl uncheckedDecl isUnused =
     setCurrentDecl $ Just (convertedDecl, isUnused)
 
     decl <- case convertedDecl of
-      DefAbstract p n r t -> typeCheckAbstractDef p n r t isUnused
-      DefFunction p n b t e -> typeCheckFunctionDef p n b t e isUnused
+      DefAbstract p n s t -> typeCheckAbstractDef p n s t isUnused
+      DefFunction p n s t e -> typeCheckFunctionDef p n s t e isUnused
+      DefRecord p n s t f -> typeCheckRecordDef p n s t f isUnused
     checkAllUnknownsSolved (Proxy @builtin)
     finalDecl <- substMetaVariables decl
     logCompilerPassOutput $ prettyExternal finalDecl
@@ -142,16 +142,6 @@ typeCheckFunctionDef p ident anns typ body isUnused = do
   solveConstraints (Proxy @builtin)
   substDecl <- substMetaVariables checkedDecl
 
-  -- Check if the record is annotated as a tensor and check the restrictions.
-  -- Needs to be done after the main solving pass so that we are guaranteed to
-  -- get the most informative error message.
-  when (isAnnotatedAsTensor anns) $
-    logCompilerSection2 MidDetail "checking suitability of type as @tensor" $ do
-      let solvedBody = fromMaybe (developerError "body error") $ bodyOf checkedDecl
-      let checkedFields = getTensorRecordFields solvedBody
-      restrictRecordAnnotatedAsTensor (ident, p) checkedFields
-      solveConstraints (Proxy @builtin)
-
   if isAnnotatedAsProperty anns
     then return substDecl
     else do
@@ -165,6 +155,49 @@ typeCheckFunctionDef p ident anns typ body isUnused = do
 
       generaliseOverUnsolvedMetasAndConstraints checkedDecl1
 
+typeCheckRecordDef ::
+  forall builtin m.
+  (TCM builtin m) =>
+  Provenance ->
+  Identifier ->
+  Maybe DefRecordSort ->
+  Telescope builtin ->
+  RecordFields builtin ->
+  DeclIsUnused ->
+  m (Decl builtin)
+typeCheckRecordDef p ident anns uncheckedTelescope uncheckedFields isUnused = do
+  -- Type check the body.
+  let pass = bidirectionalPassDoc <+> "fields of" <+> quotePretty ident
+  (checkedTelescope, checkedFields) <-
+    logCompilerSection2 MidDetail pass $
+      checkRecordDefinition uncheckedTelescope uncheckedFields
+
+  when (isAnnotatedAsTensor anns) $
+    logCompilerSection2 MidDetail "checking suitability of type as @tensor" $ do
+      restrictRecordAnnotatedAsTensor (ident, p) checkedFields
+
+  -- Reconstruct the function.
+  let checkedDecl = DefRecord p ident anns checkedTelescope checkedFields
+
+  -- Solve constraints and substitute through.
+  setCurrentDecl $ Just (checkedDecl, isUnused)
+  solveConstraints (Proxy @builtin)
+  substMetaVariables checkedDecl
+
+{-
+
+  -- Check if the record is annotated as a tensor and check the restrictions.
+  -- Needs to be done after the main solving pass so that we are guaranteed to
+  -- get the most informative error message.
+  when (isAnnotatedAsTensor anns) $
+    logCompilerSection2 MidDetail "checking suitability of type as @tensor" $ do
+
+      solveConstraints (Proxy @builtin)
+          let checkedType = Universe p 0
+          let declaredFields = mapRecordFields (const $ Universe p 0) uncheckedFields
+          checkedFields <- traverse (checkRecordField declaredFields) uncheckedFields
+          return (Record p maybeParentIdent checkedFields, checkedType)
+-}
 checkDeclType :: (TCM builtin m, HasName name Name) => name -> Type builtin -> m (Type builtin)
 checkDeclType ident declType = do
   let pass = bidirectionalPassDoc <+> "type of" <+> quotePretty (nameOf ident)

--- a/vehicle/src/Vehicle/Compile/Type.hs
+++ b/vehicle/src/Vehicle/Compile/Type.hs
@@ -184,20 +184,6 @@ typeCheckRecordDef p ident anns uncheckedTelescope uncheckedFields isUnused = do
   solveConstraints (Proxy @builtin)
   substMetaVariables checkedDecl
 
-{-
-
-  -- Check if the record is annotated as a tensor and check the restrictions.
-  -- Needs to be done after the main solving pass so that we are guaranteed to
-  -- get the most informative error message.
-  when (isAnnotatedAsTensor anns) $
-    logCompilerSection2 MidDetail "checking suitability of type as @tensor" $ do
-
-      solveConstraints (Proxy @builtin)
-          let checkedType = Universe p 0
-          let declaredFields = mapRecordFields (const $ Universe p 0) uncheckedFields
-          checkedFields <- traverse (checkRecordField declaredFields) uncheckedFields
-          return (Record p maybeParentIdent checkedFields, checkedType)
--}
 checkDeclType :: (TCM builtin m, HasName name Name) => name -> Type builtin -> m (Type builtin)
 checkDeclType ident declType = do
   let pass = bidirectionalPassDoc <+> "type of" <+> quotePretty (nameOf ident)

--- a/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Bidirectional.hs
@@ -1,16 +1,16 @@
 module Vehicle.Compile.Type.Bidirectional
   ( checkExprType,
     checkTelescope,
+    checkRecordDefinition,
     inferExprType,
     solveArgInsertionProblem,
     createFreshUnificationConstraint,
-    MonadBidirectional,
-    runMonadBidirectional,
   )
 where
 
 import Control.Monad.Except (MonadError (..))
 import Control.Monad.Reader (MonadReader (..), ReaderT (..))
+import Data.Bifunctor (Bifunctor (..))
 import Data.Data (Proxy (..))
 import Data.List.NonEmpty qualified as NonEmpty (toList)
 import Data.Maybe (fromMaybe)
@@ -31,7 +31,7 @@ import Vehicle.Data.Builtin.Interface.Type (TypableBuiltin (..))
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Universe (UniverseLevel (..))
 import Vehicle.Data.Variable.Bound.Context.Generic
-import Vehicle.Data.Variable.Bound.Context.Name (MonadReadableNameContext (..))
+import Vehicle.Data.Variable.Bound.Context.Name (MonadReadableNameContext (..), prettyFriendlyInCtx)
 import Prelude hiding (pi)
 
 --------------------------------------------------------------------------------
@@ -247,50 +247,73 @@ inferExpr e = do
     Builtin p op -> do
       typ <- typeBuiltin p op
       return (Builtin p op, typ)
-    Record p maybeParentIdent uncheckedFields -> do
-      case maybeParentIdent of
-        Nothing -> do
-          let checkedType = Universe p 0
-          let declaredFields = mapRecordFields (const $ Universe p 0) uncheckedFields
-          checkedFields <- traverse (checkRecordField declaredFields) uncheckedFields
-          return (Record p maybeParentIdent checkedFields, checkedType)
-        Just parentIdent -> do
-          (typ, declaredFields) <- instantiateRecordExpr p parentIdent
-          checkedFields <- traverse (checkRecordField declaredFields) uncheckedFields
-          return (Record p (Just parentIdent) checkedFields, typ)
-    RecordAcc p uncheckedRecord (parentIdent, field) -> do
-      (recordTyp, declaredFields) <- instantiateRecordExpr p parentIdent
-      checkedRecord <- checkExpr recordTyp uncheckedRecord
-      let fieldType = lookupRecordField declaredFields field
-      return (RecordAcc p checkedRecord (parentIdent, field), fieldType)
+    Record p uncheckedRecordType uncheckedFields -> do
+      (checkedRecordType, expectedFieldTypes) <- checkRecordTypeAndCalculateRecordFieldTypes p uncheckedRecordType
+      checkedFields <- traverse (checkRecordField expectedFieldTypes) uncheckedFields
+      return (Record p checkedRecordType checkedFields, checkedRecordType)
+    RecordProj p uncheckedRecordType uncheckedRecord field -> do
+      (checkedRecordType, expectedFieldTypes) <- checkRecordTypeAndCalculateRecordFieldTypes p uncheckedRecordType
+      logDebugM MaxDetail $ prettyFriendlyInCtx checkedRecordType
+      prettyFields <- traverseRecordFields prettyFriendlyInCtx expectedFieldTypes
+      logDebug MaxDetail $ prettyMapEntries (fmap (first pretty) prettyFields)
+      checkedRecord <- checkExpr checkedRecordType uncheckedRecord
+      let fieldType = lookupRecordField expectedFieldTypes field
+      return (RecordProj p checkedRecordType checkedRecord field, fieldType)
 
   showInferExit res
   return res
 
-instantiateRecordExpr ::
+checkRecordTypeAndCalculateRecordFieldTypes ::
   forall builtin m.
   (MonadBidirectional builtin m) =>
   Provenance ->
-  Identifier ->
+  Type builtin ->
   m (Type builtin, RecordFields builtin)
-instantiateRecordExpr p ident = do
-  abstractTypAndExpr <- getRecordDefinition (Proxy @builtin) ident
-  boundCtx <- getBoundCtx (Proxy @(Type builtin))
-  let instanceConstraintOrigin t =
-        InstanceArgOrigin $
-          ArgOrigin
-            { checkedInstanceOp = FreeVar p ident,
-              checkedInstanceOpArgs = mempty,
-              -- This is very likely wrong
-              checkedInstanceOpType = FreeVar p ident,
-              checkedInstanceType = t
-            }
-  let createInstance r t = createFreshInstanceConstraint False boundCtx p (instanceConstraintOrigin t) r t
-  (_typ, expr, args) <- instantiateTelescope RecordTelescope createInstance boundCtx abstractTypAndExpr
-  let finalType = normAppList (FreeVar p ident) args
-  case expr of
-    Record _ Nothing fields -> return (finalType, fields)
-    _ -> developerError $ "Malformed record" <+> prettyVerbose expr
+checkRecordTypeAndCalculateRecordFieldTypes p uncheckedRecordType = do
+  checkedRecordType <- checkExpr (Universe p 0) uncheckedRecordType
+
+  (recordIdent, recordParameters) <- case checkedRecordType of
+    App (FreeVar _ ident) args -> return (ident, NonEmpty.toList args)
+    FreeVar _ ident -> return (ident, [])
+    _ ->
+      developerError $
+        "Ill-formed record type found during type-checking:"
+          <> lineIndent (prettyVerbose checkedRecordType)
+
+  (telescope, fields) <- getRecordDefinition (Proxy @builtin) recordIdent
+  ctx <- getNameContext
+  logDebug MaxDetail $ pretty ctx
+  logDebug MaxDetail $ prettyVerbose recordParameters
+  logDebug MaxDetail $ prettyVerbose fields
+  let substField fieldType = calculateRarameterisedRecordFieldType telescope fieldType recordParameters
+  let finalFields = mapRecordFields substField fields
+
+  return (checkedRecordType, finalFields)
+
+checkRecordDefinition ::
+  forall builtin m.
+  (MonadTypeChecker builtin m, HasTypeSystem builtin) =>
+  Telescope builtin ->
+  RecordFields builtin ->
+  m (Telescope builtin, RecordFields builtin)
+checkRecordDefinition t f =
+  runMonadBidirectional @m @builtin emptyBoundCtx Relevant $ checkRecordFieldsDef f t
+
+checkRecordFieldsDef ::
+  forall builtin m.
+  (MonadBidirectional builtin m) =>
+  RecordFields builtin ->
+  Telescope builtin ->
+  m (Telescope builtin, RecordFields builtin)
+checkRecordFieldsDef fields = \case
+  [] -> do
+    checkedFields <- traverseRecordFields (checkExpr (Universe mempty 0)) fields
+    return ([], checkedFields)
+  binder : binders -> do
+    checkedBinder <- checkBinder binder
+    (checkedBinders, checkedFields) <-
+      addBinderToContext checkedBinder $ checkRecordFieldsDef fields binders
+    return (checkedBinder : checkedBinders, checkedFields)
 
 -- | Takes a function and its arguments, inserts any needed implicits
 -- or instance arguments and then returns the function applied to the full

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
@@ -58,14 +58,14 @@ getDefaultableConstraints ::
 getDefaultableConstraints proxy possibleConstraints = do
   maybeDecl <- getCurrentDeclAndUnused @builtin
   result <- case maybeDecl of
-    Just (decl, declIsUnused) | not (isAbstractDecl decl || declIsUnused) -> do
+    Just (DefFunction _ _ _ t _, declIsUnused) | not declIsUnused -> do
       logDebug MaxDetail $ pretty declIsUnused
       -- We only want to generate default solutions for constraints
       -- that *don't* appear in the type of the declaration, as those will be
       -- quantified over later. However, if the declaration is unused then
       -- we don't care and we should use any defaults we can find.
       constraints <- getActiveConstraints
-      typeMetas <- getMetasLinkedToMetasIn constraints (typeOf decl)
+      typeMetas <- getMetasLinkedToMetasIn constraints t
 
       logDebugM MaxDetail $ do
         unsolvedMetasInTypeDoc <- prettyMetas proxy typeMetas

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/UnificationSolver.hs
@@ -193,7 +193,7 @@ unification info = \case
     solveClosure info (binder1, closure1) (binder2, closure2)
   VRecord ident1 fields1 :~: VRecord ident2 fields2
     | ident1 == ident2 -> solveRecords info fields1 fields2
-  VRecordAcc record1 field1 :~: VRecordAcc record2 field2
+  VRecordAcc _recordType1 record1 field1 :~: VRecordAcc _recordType2 record2 field2
     | field1 == field2 -> subUnify info record1 record2
   ---------------------
   -- Flex-flex cases --
@@ -384,7 +384,7 @@ pruneMetaDependencies ctx (solvingMetaID, solvingMetaSpine) attemptedSolution = 
       VBoundVar v spine -> VBoundVar v <$> traverse (traverse go) spine
       VFreeVar v spine -> VFreeVar v <$> traverse (traverse go) spine
       VRecord ident fields -> VRecord ident <$> traverse go fields
-      VRecordAcc record field -> VRecordAcc <$> go record <*> pure field
+      VRecordAcc recordType record field -> VRecordAcc <$> go recordType <*> go record <*> pure field
       -- Definitely going to have come back and fix this one later.
       -- Can't inspect the metas in the environment, as not every variable
       -- in the environment will be used?

--- a/vehicle/src/Vehicle/Compile/Type/Generalise.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Generalise.hs
@@ -251,7 +251,13 @@ prependBinderAndSolve decl (meta, binder) =
     -- Then finally update the declaration
     let alterType t = return $ Pi p typeBinder t
     let alterBody e = return $ Lam p bodyBinder e
-    finalDecl <- traverseDeclTypeAndExpr alterType alterBody substDecl
+    finalDecl <- case substDecl of
+      DefFunction _ i s t e -> DefFunction p i s <$> alterType t <*> alterBody e
+      DefAbstract _ i s t -> DefAbstract p i s <$> alterType t
+      _ ->
+        developerError $
+          "Unsupported definition type in generalistion:"
+            <> lineIndent (prettyVerbose substDecl)
 
     -- Substitute the new meta solution through.
     setCurrentDecl $ Just (finalDecl, False)

--- a/vehicle/src/Vehicle/Compile/Type/Irrelevance.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Irrelevance.hs
@@ -58,7 +58,7 @@ instance RemoveIrrelevantCode m (Expr builtin) where
           else Lam p <$> remove binder <*> remove body
       Let p bound binder body -> Let p <$> remove bound <*> remove binder <*> remove body
       Record p ident fields -> Record p ident <$> traverseRecordFields remove fields
-      RecordAcc p record field -> RecordAcc p <$> remove record <*> pure field
+      RecordProj p recordType record field -> RecordProj p <$> remove recordType <*> remove record <*> pure field
       Universe {} -> return expr
       FreeVar {} -> return expr
       BoundVar {} -> return expr

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -66,7 +66,7 @@ instance MetaSubstitutable m builtin (Expr builtin) where
       FreeVar {} -> return expr
       BoundVar {} -> return expr
       Record p ident fields -> Record p ident <$> traverseRecordFields (substMetasAt ctx s) fields
-      RecordAcc p record field -> RecordAcc p <$> substMetasAt ctx s record <*> pure field
+      RecordProj p recordType record field -> RecordProj p <$> substMetasAt ctx s recordType <*> substMetasAt ctx s record <*> pure field
       -- NOTE: no need to lift the substitutions here as we're passing under the binders
       -- because by construction every meta-variable solution is a closed term.
       Pi p binder res -> Pi p <$> substMetasAt ctx s binder <*> substMetasAt (nameOf binder : ctx) s res
@@ -108,7 +108,7 @@ instance MetaSubstitutable m builtin (Value builtin) where
     VFreeVar v spine -> VFreeVar v <$> traverse (substMetasAt ctx s) spine
     VBoundVar v spine -> VBoundVar v <$> traverse (substMetasAt ctx s) spine
     VRecord ident fields -> VRecord ident <$> traverse (substMetasAt ctx s) fields
-    VRecordAcc record field -> VRecordAcc <$> substMetasAt ctx s record <*> pure field
+    VRecordAcc recordType record field -> VRecordAcc <$> substMetasAt ctx s recordType <*> substMetasAt ctx s record <*> pure field
     VBuiltin b spine -> do
       spine' <- traverse (substMetasAt ctx s) spine
       normaliseBuiltin ctx b spine'

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -94,7 +94,7 @@ instance HasMetas (Expr builtin) where
     Lam _ binder body -> do findMetas binder; findMetas body
     App fun args -> do findMetas fun; findMetas args
     Record _ _ fields -> findMetas $ fmap snd fields
-    RecordAcc _ record _ -> findMetas record
+    RecordProj _ recordType record _ -> do findMetas recordType; findMetas record
 
 instance HasMetas (Value builtin) where
   findMetas expr = case expr of
@@ -108,7 +108,7 @@ instance HasMetas (Value builtin) where
     VPi binder closure -> do findMetas binder; findMetas closure
     VLam binder closure -> do findMetas binder; findMetas closure
     VRecord _ fields -> findMetas (snd <$> OMap.assocs fields)
-    VRecordAcc record _ -> findMetas record
+    VRecordAcc recordType record _ -> do findMetas recordType; findMetas record
 
 instance HasMetas (Closure builtin) where
   findMetas (Closure env expr) = do traverseEnv_ findMetas env; findMetas expr

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -36,7 +36,6 @@ import Vehicle.Data.Variable.Bound.Context.Generic
 import Vehicle.Data.Variable.Bound.Context.Name
 import Vehicle.Data.Variable.Free.Context (addDeclToContext)
 import Vehicle.Data.Variable.Free.Context.Class (MonadFreeContext)
-import Vehicle.Syntax.Sugar (foldRecordDef)
 
 --------------------------------------------------------------------------------
 -- Solved meta-state
@@ -379,28 +378,12 @@ getRecordDefinition ::
   (MonadTypeChecker builtin m) =>
   Proxy builtin ->
   Identifier ->
-  m (Type builtin, Expr builtin)
+  m (Telescope builtin, RecordFields builtin)
 getRecordDefinition proxy ident = do
   decl <- getDecl proxy ident
   case decl of
-    DefFunction _ _ sort typ body
-      | isDeclaredAsRecord sort ->
-          return (typ, body)
-    _ ->
-      developerError $
-        pretty ident <+> "is unexpectedly not a record"
-
-getDeclaredRecordFields ::
-  (MonadTypeChecker builtin m) =>
-  Proxy builtin ->
-  Identifier ->
-  m (RecordFields builtin)
-getDeclaredRecordFields proxy ident = do
-  decl <- getDecl proxy ident
-  case decl of
-    DefFunction _ _ sort typ body
-      | isDeclaredAsRecord sort ->
-          return $ snd $ foldRecordDef typ body
+    DefRecord _ _ _ telescope fields ->
+      return (telescope, fields)
     _ ->
       developerError $
         pretty ident <+> "is unexpectedly not a record"
@@ -410,7 +393,12 @@ getDeclType ::
   Proxy builtin ->
   Identifier ->
   m (Type builtin)
-getDeclType proxy ident = typeOf <$> getDecl proxy ident
+getDeclType proxy ident = do
+  decl <- getDecl proxy ident
+  return $ case decl of
+    DefAbstract _ _ _ t -> t
+    DefFunction _ _ _ t _ -> t
+    DefRecord p _ _ telescope _ -> foldr (Pi p) (Universe p 0) telescope
 
 addTypedDeclToContext ::
   (MonadTypeChecker builtin m) =>

--- a/vehicle/src/Vehicle/Compile/Type/Subsystem.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Subsystem.hs
@@ -39,7 +39,7 @@ import Vehicle.Data.Builtin.Standard
 import Vehicle.Data.Code.ModuleInterface (ImportedModuleContext, ModuleInterface (..), emptyModuleScopingInterface, emptyModuleTypingInterface)
 import Vehicle.Libraries.StandardLibrary (standardLibraryBuiltinModulePath)
 import Vehicle.Syntax.AST.Expr qualified as S
-import Vehicle.Syntax.Parse (ParseLocation, parseDecl, readAndParseModule)
+import Vehicle.Syntax.Parse (ParseLocation, readAndParseModule)
 
 polarityTypeCheck ::
   (MonadIO m, MonadCompile m) =>
@@ -178,7 +178,7 @@ resolveInstanceArgumentsAndCasts prog =
           Let _ e1 binder e2 -> Let p (go e1) (fmap go binder) (go e2)
           Lam _ binder e -> Lam p (fmap go binder) (go e)
           Record _ ident fields -> Record p ident (mapRecordFields go fields)
-          RecordAcc _ record (ident, FieldName _ name) -> RecordAcc p (go record) (ident, FieldName p name)
+          RecordProj _ recordType record field -> RecordProj p (go recordType) (go record) field
 
 removeImplicitArgs ::
   forall m builtin.
@@ -208,12 +208,10 @@ removeImplicitArgs prog =
       Lam p binder body -> Lam p <$> traverse go binder <*> go body
       Let p bound binder body -> Let p <$> go bound <*> traverse go binder <*> go body
       Record p ident fields -> Record p ident <$> traverseRecordFields go fields
-      RecordAcc p record field -> RecordAcc p <$> go record <*> pure field
+      RecordProj p recordType record field -> RecordProj p <$> go recordType <*> go record <*> pure field
 
 parseModuleText :: (MonadCompile m) => ParseLocation -> Text -> m S.Module
 parseModuleText location txt = do
   case runExcept (readAndParseModule location txt) of
     Left err -> throwError $ ParseError location err
-    Right prog -> case traverseModuleDecls (parseDecl location) prog of
-      Left err -> throwError $ ParseError location err
-      Right prog' -> return prog'
+    Right modul -> return modul

--- a/vehicle/src/Vehicle/Data/Code/Expr.hs
+++ b/vehicle/src/Vehicle/Data/Code/Expr.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Vehicle.Data.Code.Expr
-  ( Expr (Universe, Pi, Builtin, BoundVar, FreeVar, Hole, Meta, Let, Lam, Record, RecordAcc, App),
+  ( Expr (Universe, Pi, Builtin, BoundVar, FreeVar, Hole, Meta, Let, Lam, Record, RecordProj, App),
     Type,
     Binder,
     Arg,
@@ -28,6 +28,7 @@ module Vehicle.Data.Code.Expr
     Substitution,
     substituteDB,
     getBuiltinApp,
+    calculateRarameterisedRecordFieldType,
   )
 where
 
@@ -113,13 +114,14 @@ data Expr builtin
   | -- | Records
     Record
       Provenance
-      (Maybe Identifier) -- Nothing indicates a definition, Just indicates the parent record definition
+      (Type builtin) -- Type of the record, e.g. `Pair Int Int`
       (RecordFields builtin)
   | -- | Records accessors
-    RecordAcc
+    RecordProj
       Provenance
-      (Expr builtin)
-      (Identifier, FieldName)
+      (Type builtin) -- Type of the record, e.g. `Pair Int Int`
+      (Expr builtin) -- The actual record, e.g. `{a = 1, b = 1}`
+      FieldName -- The field to access, e.g. `a`
   deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
 
 --------------------------------------------------------------------------------
@@ -136,7 +138,7 @@ pattern App f xs <- UnsafeApp f xs
   where
     App f xs = normApp f xs
 
-{-# COMPLETE Universe, App, Pi, Builtin, BoundVar, FreeVar, Hole, Meta, Let, Lam, Record, RecordAcc #-}
+{-# COMPLETE Universe, App, Pi, Builtin, BoundVar, FreeVar, Hole, Meta, Let, Lam, Record, RecordProj #-}
 
 -- | Smart constructor for applications with possibly no arguments.
 normAppList :: Expr builtin -> [Arg builtin] -> Expr builtin
@@ -182,7 +184,7 @@ instance HasProvenance (Expr builtin) where
     Let p _ _ _ -> p
     Lam p _ _ -> p
     Record p _ _ -> p
-    RecordAcc p _ _ -> p
+    RecordProj p _ _ _ -> p
 
 --------------------------------------------------------------------------------
 -- Utilities
@@ -231,8 +233,8 @@ traverseBuiltinsM f expr = case expr of
   Pi p binder res -> Pi p <$> traverseBuiltinsBinder f binder <*> traverseBuiltinsM f res
   Let p bound binder body -> Let p <$> traverseBuiltinsM f bound <*> traverseBuiltinsBinder f binder <*> traverseBuiltinsM f body
   Lam p binder body -> Lam p <$> traverseBuiltinsBinder f binder <*> traverseBuiltinsM f body
-  Record p i fs -> Record p i <$> traverseRecordFields (traverseBuiltinsM f) fs
-  RecordAcc p r field -> RecordAcc p <$> traverseBuiltinsM f r <*> pure field
+  Record p t fs -> Record p <$> traverseBuiltinsM f t <*> traverseRecordFields (traverseBuiltinsM f) fs
+  RecordProj p t r field -> RecordProj p <$> traverseBuiltinsM f t <*> traverseBuiltinsM f r <*> pure field
   Universe p u -> return $ Universe p u
   FreeVar p v -> return $ FreeVar p v
   BoundVar p v -> return $ BoundVar p v
@@ -303,7 +305,7 @@ traverseFreeVarsM underBinder processFreeVar = go
         body' <- underBinder binder' (go body)
         return $ Let p bound' binder' body'
       Record p i fs -> Record p i <$> traverseRecordFields go fs
-      RecordAcc p r field -> RecordAcc p <$> go r <*> pure field
+      RecordProj p t r field -> RecordProj p <$> go t <*> go r <*> pure field
 
 freeVarsIn :: Expr builtin -> Set Identifier
 freeVarsIn =
@@ -320,10 +322,6 @@ freeVarsIn =
 -- Instances
 
 instance HasBasicBinders (Expr builtin) where
-  isUniverse = \case
-    Universe _ _ -> True
-    _ -> False
-
   getPiBinder = \case
     Pi _ binder body -> Just (binder, body)
     _ -> Nothing
@@ -334,10 +332,6 @@ instance HasBasicBinders (Expr builtin) where
 
   getLetBinder = \case
     Let _ value binder body -> Just (value, binder, body)
-    _ -> Nothing
-
-  getRecord = \case
-    Record _ _ fields -> Just fields
     _ -> Nothing
 
 instance (BuiltinHasBoolLiterals builtin, BuiltinHasForeach builtin) => HasBuiltinBinders (Expr builtin) where
@@ -407,7 +401,7 @@ instance Substitutable (Expr builtin) (Expr builtin) where
     Let p e1 binder e2 -> Let p <$> subst e1 <*> traverse subst binder <*> underDBBinder (subst e2)
     Lam p binder e -> Lam p <$> traverse subst binder <*> underDBBinder (subst e)
     Record p i fs -> Record p i <$> traverseRecordFields subst fs
-    RecordAcc p r field -> RecordAcc p <$> subst r <*> pure field
+    RecordProj p t r field -> RecordProj p <$> subst t <*> subst r <*> pure field
 
 shiftDBIndex :: Ix -> Lv -> Ix
 shiftDBIndex i l = Ix (unIx i + unLv l)
@@ -471,3 +465,6 @@ substArgs :: Expr builtin -> [Arg builtin] -> Expr builtin
 substArgs (Lam _ _ body) (arg : args) = do
   substArgs (argExpr arg `substDBInto` body) args
 substArgs e args = normAppList e args
+
+calculateRarameterisedRecordFieldType :: Telescope builtin -> Type builtin -> [Arg builtin] -> Type builtin
+calculateRarameterisedRecordFieldType telescope fieldType = substArgs (foldr (Lam mempty) fieldType telescope)

--- a/vehicle/src/Vehicle/Data/Code/ModuleInterface.hs
+++ b/vehicle/src/Vehicle/Data/Code/ModuleInterface.hs
@@ -15,8 +15,8 @@ import Vehicle.Data.Code.Value
 --- | The public interface to a module, i.e. the set of declarations that
 --- it exports.
 data ModuleScopingInterface = ModuleScopingInterface
-  { recordIdentifiersByField :: Map FieldName Identifier,
-    recordIdentifiersByFields :: Map (Set FieldName) Identifier,
+  { recordIdentifiersByField :: Map FieldName (Identifier, Telescope Builtin),
+    recordIdentifiersByFields :: Map (Set FieldName) (Identifier, Telescope Builtin),
     fieldsByRecordIdentifier :: Map Identifier (Set FieldName),
     declsIdentifiersByName :: Map Name Identifier
   }

--- a/vehicle/src/Vehicle/Data/Code/Value.hs
+++ b/vehicle/src/Vehicle/Data/Code/Value.hs
@@ -75,8 +75,8 @@ data Value builtin
   | VBuiltin !builtin !(Spine builtin)
   | VLam !(VBinder builtin) !(Closure builtin)
   | VPi !(VBinder builtin) !(Closure builtin)
-  | VRecord (Maybe Identifier) !(OMap FieldName (Value builtin))
-  | VRecordAcc !(Value builtin) !(Identifier, FieldName)
+  | VRecord (VType builtin) !(OMap FieldName (Value builtin))
+  | VRecordAcc !(VType builtin) !(Value builtin) !FieldName
   deriving (Show, Generic, Eq, Ord)
 
 type VType builtin = Value builtin
@@ -124,7 +124,9 @@ boundVariablesIn value = execWriter (go value)
         goClosure closure
       VRecord _ident fields ->
         traverse_ go fields
-      VRecordAcc record (_ident, _field) -> go record
+      VRecordAcc recordType record _ -> do
+        go recordType
+        go record
 
     goClosure :: (MonadWriter (Set Lv) m) => Closure builtin -> m ()
     goClosure (Closure (BoundEnv env) _) =

--- a/vehicle/src/Vehicle/Data/DSL.hs
+++ b/vehicle/src/Vehicle/Data/DSL.hs
@@ -57,7 +57,7 @@ class DSL expr where
   app :: expr -> NonEmpty (Visibility, Relevance, expr) -> expr
   pi :: Maybe Name -> Visibility -> Relevance -> expr -> (expr -> expr) -> expr
   lam :: Name -> Visibility -> Relevance -> expr -> (expr -> expr) -> expr
-  recordAcc :: expr -> (Identifier, FieldName) -> expr
+  recordProj :: expr -> expr -> FieldName -> expr
 
 newtype DSLExpr builtin = DSL
   { unDSL :: Provenance -> Lv -> Expr builtin
@@ -108,9 +108,10 @@ instance DSL (DSLExpr builtin) where
         args' = fmap (\(v, r, e) -> Arg v r (unDSL e p i)) args
      in App fun' args'
 
-  recordAcc record field = DSL $ \p i -> do
+  recordProj recordType record field = DSL $ \p i -> do
+    let recordType' = unDSL recordType p i
     let record' = unDSL record p i
-    RecordAcc p record' field
+    RecordProj p recordType' record' field
 
 --------------------------------------------------------------------------------
 -- AST

--- a/vehicle/src/Vehicle/List.hs
+++ b/vehicle/src/Vehicle/List.hs
@@ -104,6 +104,7 @@ searchDecl decl = do
       | otherwise -> do
           entity <- searchPropertyDecl (identifierOf decl, provenanceOf decl) (sharedData typ) typ body
           tell [entity]
+    DefRecord {} -> return ()
 
 searchPropertyDecl :: (MonadList m, MonadSupply PropertyID m) => DeclProvenance -> SharedData -> VType Builtin -> Value Builtin -> m ListableEntity
 searchPropertyDecl prov sharedData declType declBody = do
@@ -144,7 +145,7 @@ searchValue value = case value of
     body <- normaliseClosure binder closure
     searchValue body
   VRecord _ fields -> traverse_ searchValue fields
-  VRecordAcc record _ -> searchValue record
+  VRecordAcc _ record _ -> searchValue record
   -- Never traverse into types so the following cases shouldn't happen!
   VUniverse {} -> unexpectedExprError pass "VUniverse"
   VPi {} -> unexpectedExprError pass "VUniverse"

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -14,6 +14,7 @@ import Control.Monad.State (MonadState (..), StateT (..), gets, modify)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
 import Vehicle.Backend.Prelude
 import Vehicle.Compile.Dependency (AdjacencyGraph, emptyAdjacencyGraph, insertEdge, insertNode, topologicalSort)
@@ -109,16 +110,17 @@ printPropertyTypes ::
 printPropertyTypes = \case
   Left err -> throwError err
   Right (Main decls) -> do
-    let properties = filter isPropertyDecl decls
-    let propertyDocs = fmap propertySummary properties
+    let propertyDocs = mapMaybe toPropertySummary decls
     let outputDoc = concatWith (\a b -> a <> line <> b) propertyDocs
     programOutput outputDoc
     where
-      propertySummary :: (PrintableBuiltin builtin) => Decl builtin -> Doc a
-      propertySummary decl = do
-        let propertyName = pretty $ identifierName $ identifierOf decl
-        let propertyType = prettyFriendlyEmptyCtx (typeOf decl)
-        propertyName <+> ":" <+> propertyType
+      toPropertySummary :: (PrintableBuiltin builtin) => Decl builtin -> Maybe (Doc a)
+      toPropertySummary = \case
+        DefFunction _ ident sort typ _ | isAnnotatedAsProperty sort -> do
+          let propertyName = pretty $ identifierName ident
+          let propertyType = prettyFriendlyEmptyCtx typ
+          Just $ propertyName <+> ":" <+> propertyType
+        _ -> Nothing
 
 runCompileMonad ::
   forall m a.

--- a/vehicle/tests/golden/compile/simple-logic/Rocq.v.golden
+++ b/vehicle/tests/golden/compile/simple-logic/Rocq.v.golden
@@ -45,4 +45,4 @@ Definition myLogic : DifferentiableLogic := {| true := - const_t (100000 : R)
 
 Parameter f : 'nT[R]_(nil) -> 'nT[R]_(nil).
 
-Axiom p : forall x, f x >= myLogic.(true).
+Axiom p : forall x, f x >= true myLogic.

--- a/vehicle/tests/golden/compile/simple-record/spec.vcl
+++ b/vehicle/tests/golden/compile/simple-record/spec.vcl
@@ -12,8 +12,10 @@ Pair = \x y -> { a : x, b : y }
 a : \forall {x} {y} -> Pair x y -> x
 a {x} {y} r = Proj (Pair x y) r a
 
-b : \forall x y -> y
+a : \forall {x} {y} -> Pair x y -> y
+a {x} {y} r = Proj (Pair x y) r b
 -}
+
 RealPair : Type
 RealPair = Pair Real Real
 

--- a/vehicle/tests/golden/compile/simple-record/spec.vcl
+++ b/vehicle/tests/golden/compile/simple-record/spec.vcl
@@ -8,6 +8,11 @@ Delaborated to
 
 Pair : \forall x y -> Set
 Pair = \x y -> { a : x, b : y }
+
+a : \forall {x} {y} -> Pair x y -> x
+a {x} {y} r = Proj (Pair x y) r a
+
+b : \forall x y -> y
 -}
 RealPair : Type
 RealPair = Pair Real Real


### PR DESCRIPTION
- Records and record projections now store their type which simplifies the implementation greatly.
- Scope checking now generates appropriate projection functions automatically (as if all records were automatically opened in Agda).