### PR TITLE
Add TensorLike typeclass

### DIFF
--- a/vehicle/lib/Definitions.vcl
+++ b/vehicle/lib/Definitions.vcl
@@ -49,8 +49,8 @@ gtRatTensorReduced xs ys = reduceAnd True (xs >. ys)
 --------------------------------------------------------------------------------
 
 record TensorLike r t dims {{isTensorType : IsTensorType t dims}} where
-  { toTensorLike     : r -> tensor
-  , fromTensorLike   : tensor -> r
+  { toTensorLike     : r -> Tensor t dims
+  , fromTensorLike   : Tensor t dims -> r
   }
 
 --------------------------------------------------------------------------------

--- a/vehicle/lib/Definitions.vcl
+++ b/vehicle/lib/Definitions.vcl
@@ -49,8 +49,8 @@ gtRatTensorReduced xs ys = reduceAnd True (xs >. ys)
 --------------------------------------------------------------------------------
 
 record TensorLike r t dims {{isTensorType : IsTensorType t dims}} where
-  { toTensorLike     : r -> Tensor t dims
-  , fromTensorLike   : Tensor t dims -> r
+  { toTensor         : r -> Tensor t dims
+  , fromTensor       : Tensor t dims -> r
   }
 
 --------------------------------------------------------------------------------

--- a/vehicle/lib/Definitions.vcl
+++ b/vehicle/lib/Definitions.vcl
@@ -45,6 +45,15 @@ gtRatTensorReduced : Tensor Real (dim :: dims) -> Tensor Real (dim :: dims) -> B
 gtRatTensorReduced xs ys = reduceAnd True (xs >. ys)
 
 --------------------------------------------------------------------------------
+-- TensorLike
+--------------------------------------------------------------------------------
+
+record TensorLike r t dims {{isTensorType : IsTensorType t dims}} where
+  { toTensorLike     : r -> tensor
+  , fromTensorLike   : tensor -> r
+  }
+
+--------------------------------------------------------------------------------
 -- Index
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Add the `TensorLike` typeclass to `Definitions.vcl`
TensorLike has the toTensorLike and fromTensorLike methods.