### PR TITLE
Add priority for defaults and instance candidates based on generality

### DIFF
--- a/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/AST/Decl.hs
@@ -172,13 +172,17 @@ instance NFData DefFunctionSort
 
 instance Serialize DefFunctionSort
 
+-- | The priority of the candidate when trying to find a default.
+-- Instances with lower priority will be used as a default in
+-- preference to higher priorities.
+type InstancePriority = Int
+
 -- | Possible annotations for ordinatary functions.
 data FunctionDeclAnnotation
   = -- | The function was annotated with @property
     AnnProperty
-  | -- | The function was annotated with @instance.
-    -- The `Bool` indicates whether it should be the default instance.
-    AnnInstance Bool
+  | -- | The function was annotated with @instance..
+    AnnInstance (Maybe InstancePriority)
   deriving (Eq, Show, Generic)
 
 instance NFData FunctionDeclAnnotation

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Delaborate/External.hs
@@ -128,7 +128,9 @@ instance Delaborate V.DefRecordSort B.Decl where
 
 instance Delaborate V.FunctionDeclAnnotation B.Decl where
   delabM = \case
-    V.AnnInstance t -> return $ delabAnn instanceAnn [mkBoolAnnOption DefaultOption t]
+    V.AnnInstance t -> return $ delabAnn instanceAnn $ case t of
+      Nothing -> []
+      Just v -> [mkMaybeIntAnnOption DefaultOption v]
     V.AnnProperty -> return $ delabAnn propertyAnn []
 
 -- | Used for things not in the user-syntax.
@@ -489,4 +491,9 @@ delabVecLiteral args = do
   B.VecLiteral tokSeqOpen <$> traverse (delabM . argExpr) explArgs <*> pure tokSeqClose
 
 mkBoolAnnOption :: Text -> Bool -> B.DeclAnnOption
-mkBoolAnnOption name value = B.InferAnnOption (mkToken B.TokAnnInferOpt name) (B.Literal (B.BoolLiteral (delabBoolLit value)))
+mkBoolAnnOption name value =
+  B.InferAnnOption (mkToken B.TokAnnInferOpt name) (B.Literal (B.BoolLiteral (delabBoolLit value)))
+
+mkMaybeIntAnnOption :: Text -> Int -> B.DeclAnnOption
+mkMaybeIntAnnOption name value =
+  B.DefaultAnnOption (mkToken B.TokAnnDefaultOpt name) (delabNatLit value)

--- a/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
+++ b/vehicle-syntax/src/Vehicle/Syntax/BNFC/Elaborate/External.hs
@@ -294,7 +294,7 @@ validateOpts token allowedNames (B.DeclAnnWithOpts opts) = do
         B.NameAnnOption tk value -> mkEntry tk (B.Var value)
         B.InferAnnOption tk value -> mkEntry tk value
         B.TypeAnnOption tk expr -> mkEntry tk expr
-        B.DefaultAnnOption tk value -> mkEntry tk (B.Literal $ B.BoolLiteral value)
+        B.DefaultAnnOption tk value -> mkEntry tk (B.Literal $ B.NatLiteral value)
 
       let nameTxt = name
       value' <- elabExpr value
@@ -324,17 +324,18 @@ getInferOption = \case
   B.InferAnnOption optTk name -> Just (optTk, name)
   _ -> Nothing
 
-elabInstanceOptions :: (MonadElab m) => [B.DeclAnnOption] -> m V.FunctionDeclAnnotation
+elabInstanceOptions ::
+  (MonadElab m) =>
+  [B.DeclAnnOption] ->
+  m V.FunctionDeclAnnotation
 elabInstanceOptions opts =
   V.AnnInstance <$> case mapMaybe getInstanceDefaultOption opts of
-    [] -> return False
-    (_, bool) : _ -> do
-      let isDefault = elabBoolLiteral bool
-      return isDefault
+    [] -> return Nothing
+    (_, priority) : _ -> return $ Just priority
 
-getInstanceDefaultOption :: B.DeclAnnOption -> Maybe (B.TokAnnDefaultOpt, B.Boolean)
+getInstanceDefaultOption :: B.DeclAnnOption -> Maybe (B.TokAnnDefaultOpt, Int)
 getInstanceDefaultOption = \case
-  B.DefaultAnnOption optTk name -> Just (optTk, name)
+  B.DefaultAnnOption optTk name -> Just (optTk, elabNatLiteral name)
   _ -> Nothing
 
 --------------------------------------------------------------------------------
@@ -561,7 +562,7 @@ elabLiteral = \case
     return $ V.Builtin p $ V.BuiltinConstructor $ V.BoolTensorLiteral $ ZeroDimTensor b
   B.NatLiteral t -> do
     p <- mkProvenance t
-    let n = readNat (tkSymbol t)
+    let n = elabNatLiteral t
     let fromNat = V.Builtin p (V.TypeClassOp V.FromNatTC)
     return $ app fromNat [V.Builtin p $ V.BuiltinConstructor $ V.NatLiteral n]
   B.RatLiteral t -> do
@@ -569,6 +570,9 @@ elabLiteral = \case
     let r = readRat (tkSymbol t)
     let fromRat = V.Builtin p (V.TypeClassOp V.FromRatTC)
     return $ app fromRat [V.Builtin p $ V.BuiltinConstructor $ V.RatTensorLiteral $ ZeroDimTensor r]
+
+elabNatLiteral :: B.Natural -> Int
+elabNatLiteral t = readNat (tkSymbol t)
 
 elabBoolLiteral :: B.Boolean -> Bool
 elabBoolLiteral t = read (unpack $ tkSymbol t)

--- a/vehicle-syntax/src/Vehicle/Syntax/External.cf
+++ b/vehicle-syntax/src/Vehicle/Syntax/External.cf
@@ -278,7 +278,7 @@ separator Expr ",";
 -- they necessarily have priority over it.
 NameAnnOption.  DeclAnnOption ::= TokAnnNameOpt "=" Name;
 InferAnnOption. DeclAnnOption ::= TokAnnInferOpt "=" Expr;
-DefaultAnnOption. DeclAnnOption ::= TokAnnDefaultOpt "=" Boolean;
+DefaultAnnOption. DeclAnnOption ::= TokAnnDefaultOpt "=" Natural;
 TypeAnnOption.  DeclAnnOption ::= Name "=" Expr;
 
 separator DeclAnnOption ",";

--- a/vehicle/lib/Definitions.vcl
+++ b/vehicle/lib/Definitions.vcl
@@ -72,11 +72,11 @@ record HasAdd t1 t2 t3 where
   { addTC : t1 -> t2 -> t3
   }
 
-@instance(default=True)
+@instance(default=0)
 natHasAdd : HasAdd Nat Nat Nat
 natHasAdd = { addTC = addNat }
 
-@instance
+@instance(default=1)
 realTensorHasAdd : HasAdd (Tensor Real dims) (Tensor Real dims) (Tensor Real dims)
 realTensorHasAdd = { addTC = addRealTensor }
 

--- a/vehicle/src/Vehicle/Compile/Print.hs
+++ b/vehicle/src/Vehicle/Compile/Print.hs
@@ -243,6 +243,7 @@ type family StrategyFor (tags :: Tags) a :: Strategy where
   StrategyFor tags (UnificationConstraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
   StrategyFor tags (ApplicationConstraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
   StrategyFor tags (Constraint builtin `In` ConstraintContext builtin) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
+  StrategyFor tags (InstanceCandidate builtin `In` BoundCtx (Type builtin)) = StrategyFor tags (Expr builtin `In` NamedBoundCtx)
   StrategyFor tags (MetaInfo builtin `In` NoCtx) = StrategyFor tags (Value builtin `In` NamedBoundCtx)
   --------------------------
   -- Variable constraints --
@@ -828,7 +829,7 @@ instance
   ) =>
   PrettyUsing rest (InstanceConstraint builtin `In` ConstraintContext builtin)
   where
-  prettyUsing (Resolve _ solution _ goal, ctx) = do
+  prettyUsing (Resolve _ solution _ _ goal, ctx) = do
     let nameCtx = namedBoundCtxOf ctx
     let solution' = pretty solution
     let expr' = prettyUsing @rest (goalExpr goal, nameCtx)
@@ -858,6 +859,14 @@ instance
     UnificationConstraint uc -> prettyUsing @rest (uc, ctx)
     InstanceConstraint tc -> prettyUsing @rest (tc, ctx)
     ApplicationConstraint tc -> prettyUsing @rest (tc, ctx)
+
+instance
+  ( PrettyUsing rest (Expr builtin `In` NamedBoundCtx)
+  ) =>
+  PrettyUsing rest (InstanceCandidate builtin `In` BoundCtx (Type builtin))
+  where
+  prettyUsing (candidate, ctx) = do
+    prettyUsing @rest (candidateExpr candidate, toNamedBoundCtx ctx)
 
 instance
   ( PrettyUsing rest (Type builtin `In` NamedBoundCtx)

--- a/vehicle/src/Vehicle/Compile/Print/Error/Typing.hs
+++ b/vehicle/src/Vehicle/Compile/Print/Error/Typing.hs
@@ -82,7 +82,7 @@ typingErrorDetails = \case
               <+> "but was unable to prove it."
           CheckingInstanceType instanceOrigin ->
             instanceOriginConstraintMessage instanceOrigin
-        InstanceConstraint (Resolve instanceOrigin _ _ _) -> instanceOriginConstraintMessage instanceOrigin
+        InstanceConstraint (Resolve instanceOrigin _ _ _ _) -> instanceOriginConstraintMessage instanceOrigin
         -- AuxiliaryConstraint (Auxiliary auxiliaryOrigin _ _) -> auxiliaryOriginConstraintMessage auxiliaryOrigin
         ApplicationConstraint {} ->
           "unsolved application constraint: " <+> prettyFriendly (WithContext constraint ctx)
@@ -396,7 +396,10 @@ calculateInstanceCandidateTypeArgs (WithContext candidate typingCtx) =
     calculateCandidateType :: BoundCtx (Expr builtin) -> Expr builtin -> ([Arg builtin], BoundCtx (Expr builtin))
     calculateCandidateType dbCtx = \case
       Builtin _ _tc -> ([], dbCtx)
+      FreeVar _ _ident -> ([], dbCtx)
       App (Builtin _ _tc) args ->
+        (NonEmpty.toList args, dbCtx)
+      App (FreeVar _ _ident) args ->
         (NonEmpty.toList args, dbCtx)
       Pi _ binder result ->
         calculateCandidateType (binder : dbCtx) result

--- a/vehicle/src/Vehicle/Compile/Scope/RecordInstances.hs
+++ b/vehicle/src/Vehicle/Compile/Scope/RecordInstances.hs
@@ -212,4 +212,4 @@ createTensorLikeInstance p recordIdent fieldElementType fieldDimensions fields =
   let functionName = Text.pack "_" <> nameOf recordIdent <> "IsTensorLike"
   let functionIdent = Identifier (modulePath recordIdent) functionName
 
-  DefFunction p functionIdent (FunctionDecl 1 (Just (AnnInstance False))) recordType functionBody
+  DefFunction p functionIdent (FunctionDecl 1 (Just (AnnInstance Nothing))) recordType functionBody

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/Core.hs
@@ -11,7 +11,7 @@ module Vehicle.Compile.Type.Constraint.Core
 where
 
 import Data.Bifunctor (Bifunctor (..))
-import Data.Map (fromListWith, mapMaybeWithKey)
+import Data.Map (fromListWith)
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.NBE (eval)
 import Vehicle.Compile.Prelude
@@ -61,27 +61,23 @@ extractHeadFromInstanceCandidate candidate@InstanceCandidate {..} = do
           <> "Problematic subexpr:"
             <+> problemDoc
 
-mkCandidate :: (DSLExpr builtin, DSLExpr builtin, Bool) -> InstanceCandidate builtin
-mkCandidate (expr, solution, defaultInstance) = do
+mkCandidate ::
+  (DSLExpr builtin, DSLExpr builtin, Maybe InstancePriority) ->
+  InstanceCandidate builtin
+mkCandidate (expr, solution, priority) = do
   let p = mempty
   let expr' = fromDSL p expr
   let solution' = fromDSL p solution
-  InstanceCandidate expr' solution' defaultInstance
+  InstanceCandidate expr' solution' priority
 
-makeInstanceDatabase :: (PrintableBuiltin builtin, Ord builtin) => [InstanceCandidate builtin] -> InstanceDatabase builtin
+makeInstanceDatabase ::
+  (Ord builtin, PrintableBuiltin builtin) =>
+  [InstanceCandidate builtin] ->
+  InstanceDatabase builtin
 makeInstanceDatabase allInstances = do
   let tcAndCandidates = fmap (second (: []) . extractHeadFromInstanceCandidate) allInstances
-  let instances = fromListWith (<>) tcAndCandidates
-  let defaults = mapMaybeWithKey findDefault instances
-  InstanceDatabase instances defaults
-  where
-    findDefault :: (Pretty builtin) => Either Identifier builtin -> [InstanceCandidate builtin] -> Maybe (InstanceCandidate builtin)
-    findDefault b instances = do
-      let defaultInstances = filter defaultInstance instances
-      case defaultInstances of
-        [] -> Nothing
-        [inst] -> Just inst
-        _ -> developerError $ "Multiple default instances found for" <+> quotePretty b
+  let instances = fromListWith (<>) (reverse tcAndCandidates)
+  InstanceDatabase instances
 
 instantiateInstanceConstraintSolution ::
   forall builtin m.
@@ -89,7 +85,7 @@ instantiateInstanceConstraintSolution ::
   WithContext (InstanceConstraint builtin) ->
   Expr builtin ->
   m ()
-instantiateInstanceConstraintSolution (WithContext (Resolve origin meta _ _) ctx) solution = do
+instantiateInstanceConstraintSolution (WithContext (Resolve origin meta _ _ _) ctx) solution = do
   metaInfo <- getMetaInfo meta
   let boundCtx = boundContextOf ctx
   case metaSolution metaInfo of

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceDefaultSolver.hs
@@ -5,7 +5,9 @@ module Vehicle.Compile.Type.Constraint.InstanceDefaultSolver
 where
 
 import Control.Monad (filterM)
-import Data.Maybe (catMaybes)
+import Data.Foldable (minimumBy)
+import Data.Maybe (catMaybes, mapMaybe)
+import Data.Ord (comparing)
 import Data.Proxy (Proxy (..))
 import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print (PrettyVerbose, prettyVerbose)
@@ -16,7 +18,6 @@ import Vehicle.Compile.Type.Meta.Variable
 import Vehicle.Compile.Type.Monad.Class
 import Vehicle.Data.Builtin.Interface.Print
 import Vehicle.Data.Builtin.Interface.Type (TypableBuiltin)
-import Vehicle.Data.Variable.Bound.Context.Generic (HasBoundCtx (..))
 
 type MonadInstanceDefault builtin m =
   ( MonadTypeChecker builtin m,
@@ -27,12 +28,12 @@ newtype DefaultCandidate builtin
   = DefaultCandidate
       ( WithContext (InstanceConstraint builtin),
         InstanceGoal builtin,
-        InstanceCandidate builtin
+        PossibleInstanceCandidate builtin
       )
 
 instance (PrintableBuiltin builtin) => Pretty (DefaultCandidate builtin) where
   pretty (DefaultCandidate (constraint, _, candidate)) =
-    prettyVerbose constraint <+> "~" <+> prettyVerbose (candidateExpr candidate)
+    prettyVerbose constraint <+> "~" <+> prettyVerbose (candidateExpr $ objectIn candidate)
 
 addNewInstanceConstraintUsingDefaults ::
   forall builtin m.
@@ -104,10 +105,15 @@ findDefault ::
   m (Maybe (DefaultCandidate builtin))
 findDefault constraint = do
   let goal = instanceGoal $ objectIn constraint
-  maybeDefaultCandidate <- getDefaultInstanceCandidate goal
-  return $ case maybeDefaultCandidate of
-    Just candidate -> Just $ DefaultCandidate (constraint, goal, candidate)
-    Nothing -> Nothing
+  case instanceCandidateState $ objectIn constraint of
+    Nothing -> developerError "No attempt has been made to solve constraint that we are trying to solve with defaults"
+    Just (allCandidates, _) -> do
+      let candidateAndPriorities = mapMaybe (\c -> (,c) <$> candidatePriority (objectIn c)) allCandidates
+      return $ case candidateAndPriorities of
+        [] -> Nothing
+        cs -> do
+          let highestPriorityCandidate = snd $ minimumBy (comparing fst) cs
+          Just $ DefaultCandidate (constraint, goal, highestPriorityCandidate)
 
 acceptDefaultCandidate ::
   forall builtin m.
@@ -117,4 +123,5 @@ acceptDefaultCandidate ::
 acceptDefaultCandidate c@(DefaultCandidate (constraint, goal, candidate)) = do
   logDebug MaxDetail $ "using default" <+> pretty c
   _ <- removeInstanceConstraint (Proxy @builtin) (constraintID $ contextOf constraint)
-  acceptCandidate constraint goal (WithContext candidate (boundContextOf $ contextOf constraint))
+  _ <- acceptCandidate constraint goal candidate
+  return ()

--- a/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Constraint/InstanceSolver.hs
@@ -17,7 +17,6 @@ import Vehicle.Compile.Type.Constraint.UnificationSolver (runUnificationSolver)
 import Vehicle.Compile.Type.Core
 import Vehicle.Compile.Type.Monad
 import Vehicle.Compile.Type.Monad.Class
-import Vehicle.Data.Builtin.Interface.Print
 import Vehicle.Data.Builtin.Interface.Type (TypableBuiltin)
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Variable.Bound.Context.Generic
@@ -64,76 +63,128 @@ solveInstanceConstraint depth constraint = do
   logDebug MaxDetail $ "Forced:" <+> prettyExternal normConstraint
 
   let goal = instanceGoal $ objectIn normConstraint
-  candidates <- getInstanceCandidates goal
-  solveInstanceGoal normConstraint candidates depth goal
+  candidateState <- getCurrentCandidateState normConstraint
+  solveInstanceGoal normConstraint candidateState depth goal
 
 solveInstanceGoal ::
   forall builtin m.
   (MonadInstance builtin m) =>
   WithContext (InstanceConstraint builtin) ->
-  [InstanceCandidate builtin] ->
+  InstanceCandidateState builtin ->
   InstanceSearchDepth ->
   InstanceGoal builtin ->
   m ()
-solveInstanceGoal constraint rawBuiltinCandidates depth goal = do
-  let boundCtx = boundContext $ contextOf constraint
-  candidatesInBoundCtx <- findCandidatesInBoundCtx goal boundCtx
-  -- The previously declared candidates have access to the entire bound context
-  let builtinCandidates = fmap (`WithContext` boundCtx) rawBuiltinCandidates
-  let allCandidates = builtinCandidates <> candidatesInBoundCtx
-
+solveInstanceGoal constraint (candidates, failedCandidates) depth goal = do
   logDebug MaxDetail $
     line
-      <> "Builtin candidates:"
+      <> "Candidates:"
       <> line
-      <> indent 2 (prettyMultiLineList (fmap prettyCandidate builtinCandidates))
-      <> line
-      <> "Context candidates:"
-      <> line
-      <> indent 2 (prettyMultiLineList (fmap prettyCandidate candidatesInBoundCtx))
-      <> line
-      <> "Depth:" <+> pretty depth
+      <> indent 2 (prettyMultiLineList (fmap prettyExternal candidates))
       <> line
 
   -- Try all candidates
   (unsuccessfulCandidates, successfulCandidates) <-
-    partitionEithers <$> traverse (checkCandidate constraint goal depth) allCandidates
+    partitionEithers <$> traverse (checkCandidate constraint goal depth) candidates
 
   case successfulCandidates of
     -- If there is a single valid candidate then we adopt the resulting state
-    [(candidate, typeCheckerState)] -> do
-      logDebug MaxDetail $ "Accepting only remaining candidate:" <+> squotes (prettyCandidate candidate)
-      adoptHypotheticalState typeCheckerState
+    [SuccessfulInstanceCandidate {..}] -> do
+      logDebug MaxDetail $ "Accepting only remaining candidate:" <+> squotes (prettyExternal successfulCandidate)
+      adoptHypotheticalState successfulState
 
     -- If there are no valid candidates then we fail.
     [] -> do
       freeCtx <- getFreeCtx (Proxy @builtin)
       finalConstraint <- substMetaVariables constraint
-      throwError $ TypingError $ FailedInstanceConstraint $ FailedInstanceConstraintError freeCtx finalConstraint unsuccessfulCandidates
+      throwError $
+        TypingError $
+          FailedInstanceConstraint $
+            FailedInstanceConstraintError
+              { _freeCtx = freeCtx,
+                failedConstraint = finalConstraint,
+                exploredCandidates = failedCandidates <> unsuccessfulCandidates
+              }
 
     -- Otherwise there are still multiple valid candidates so we're forced to block.
     _ -> do
-      logDebug MaxDetail "Multiple possible candidates found so deferring."
-      -- TODO can we be more precise with the set of blocking metas?
-      -- Probably not as the set of blocking metas will depend on the depth at which we're searching
+      logDebug MaxDetail $
+        "Multiple possible candidates:"
+          <> lineIndent (vsep $ fmap (prettyExternal . successfulCandidate) successfulCandidates)
 
-      blockedConstraint <- blockConstraintOn constraint <$> getUnsolvedMetas (Proxy @builtin)
-      addInstanceConstraints [blockedConstraint]
+      -- Find most general candiate
+      case findLeastGeneralCandidate successfulCandidates of
+        Just SuccessfulInstanceCandidate {..} -> do
+          logDebug MaxDetail $ "Accepting least general candidate:" <+> squotes (prettyExternal successfulCandidate)
+          adoptHypotheticalState successfulState
+        Nothing -> do
+          -- Create the updated constraint
+          let newPossibleCandidates = fmap successfulCandidate successfulCandidates
+          let newFailedCandidates = failedCandidates <> unsuccessfulCandidates
+          let newConstraint = flip mapObject constraint $ \c ->
+                c
+                  { instanceCandidateState = Just (newPossibleCandidates, newFailedCandidates)
+                  }
+          -- TODO can we be more precise with the set of blocking metas?
+          -- Probably not as the set of blocking metas will depend on the depth at which we're searching
+          blockedConstraint <- blockConstraintOn newConstraint <$> getUnsolvedMetas (Proxy @builtin)
 
--- | Locates any more candidates that are in the bound context of the constraint
-findCandidatesInBoundCtx ::
+          addInstanceConstraints [blockedConstraint]
+
+getCurrentCandidateState ::
   forall builtin m.
   (MonadInstance builtin m) =>
+  WithContext (InstanceConstraint builtin) ->
+  m (InstanceCandidateState builtin)
+getCurrentCandidateState constraint =
+  case instanceCandidateState $ objectIn constraint of
+    Nothing -> getInitialCandidateState constraint
+    Just state -> return state
+
+getInitialCandidateState ::
+  forall builtin m.
+  (MonadInstance builtin m) =>
+  WithContext (InstanceConstraint builtin) ->
+  m (InstanceCandidateState builtin)
+getInitialCandidateState constraint = do
+  let goal = instanceGoal $ objectIn constraint
+  let boundCtx = boundContext $ contextOf constraint
+
+  -- Candidates in free context
+  rawBuiltinCandidates <- getInstanceCandidatesFromFreeCtx goal
+  let builtinCandidates = fmap (`WithContext` boundCtx) rawBuiltinCandidates
+
+  -- Candidates in bound context
+  let candidatesInBoundCtx = getCandidatesInBoundCtx goal boundCtx
+
+  logDebug MaxDetail $
+    line
+      <> "Builtin candidates:"
+      <> line
+      <> indent 2 (prettyMultiLineList (fmap prettyExternal builtinCandidates))
+      <> line
+      <> "Context candidates:"
+      <> line
+      <> indent 2 (prettyMultiLineList (fmap prettyExternal candidatesInBoundCtx))
+      <> line
+
+  let possibleCandidates = builtinCandidates <> candidatesInBoundCtx
+  let failedCandidates = mempty
+  return (possibleCandidates, failedCandidates)
+
+-- | Locates any more candidates that are in the bound context of the constraint
+getCandidatesInBoundCtx ::
+  forall builtin.
+  (Eq builtin) =>
   InstanceGoal builtin ->
   BoundCtx (Type builtin) ->
-  m [WithContext (InstanceCandidate builtin)]
-findCandidatesInBoundCtx goal ctx = go ctx
+  [WithContext (InstanceCandidate builtin)]
+getCandidatesInBoundCtx goal ctx = go ctx
   where
-    go :: (MonadCompile m) => BoundCtx (Type builtin) -> m [WithContext (InstanceCandidate builtin)]
+    go :: BoundCtx (Type builtin) -> [WithContext (InstanceCandidate builtin)]
     go = \case
-      [] -> return []
+      [] -> []
       (binder : localCtx) -> do
-        candidates <- go localCtx
+        let candidates = go localCtx
         let binderType = typeOf binder
         case findInstanceGoalHead binderType of
           Right binderHead | binderHead == goalHead goal -> do
@@ -141,10 +192,16 @@ findCandidatesInBoundCtx goal ctx = go ctx
                   InstanceCandidate
                     { candidateExpr = binderType,
                       candidateSolution = BoundVar mempty (dbLevelToIndex (Lv $ length ctx) (Lv $ length localCtx)),
-                      defaultInstance = False
+                      candidatePriority = Nothing
                     }
-            return $ WithContext candidate localCtx : candidates
-          _ -> return candidates
+            WithContext candidate localCtx : candidates
+          _ -> candidates
+
+data SuccessfulInstanceCandidate builtin = SuccessfulInstanceCandidate
+  { successfulCandidate :: WithContext (InstanceCandidate builtin),
+    successfulState :: TypeCheckerState builtin,
+    successfulSolution :: Value builtin
+  }
 
 -- | Checks whether a candidate is a possibility for the instance goal.
 -- Returns `Nothing` if it is definitely not a valid candidate and
@@ -156,13 +213,14 @@ checkCandidate ::
   InstanceGoal builtin ->
   InstanceSearchDepth ->
   WithContext (InstanceCandidate builtin) ->
-  m (Either (WithContext (InstanceCandidate builtin), UnAnnDoc) (WithContext (InstanceCandidate builtin), TypeCheckerState builtin))
+  m (Either (FailedInstanceCandidate builtin) (SuccessfulInstanceCandidate builtin))
 checkCandidate constraint goal depth candidate = do
-  let candidateDoc = squotes (prettyCandidate candidate)
+  let candidateDoc = squotes (prettyExternal candidate)
   logCompilerSection2 MaxDetail ("trying candidate instance" <+> candidateDoc) $ do
     result <- runTypeCheckerTHypothetically $ do
-      logCompilerSection MaxDetail "hypothetically accepting candidate" $
-        acceptCandidate constraint goal candidate
+      instantiatedSolution <-
+        logCompilerSection MaxDetail "hypothetically accepting candidate" $
+          acceptCandidate constraint goal candidate
 
       -- Run the solvers to check for conflicts
       let proxy = Proxy @builtin
@@ -170,22 +228,24 @@ checkCandidate constraint goal depth candidate = do
       if depth == 0
         then return mempty
         else runInstanceSolver proxy (depth - 1)
+      return instantiatedSolution
+
     case result of
       Left err -> do
         let vehicleError = formatCompileError err
         logDebug MaxDetail $ line <> "Rejecting" <+> candidateDoc <+> "as a possibility"
         logDebug MaxDetail $ indent 2 (pretty vehicleError) <> line
         return $ Left (candidate, problem vehicleError)
-      Right (_, state) -> do
+      Right (instantiatedSolution, state) -> do
         logDebug MaxDetail $ "Keeping" <+> candidateDoc <+> "as a possibility" <> line
-        return $ Right (candidate, state)
+        return $ Right $ SuccessfulInstanceCandidate candidate state instantiatedSolution
 
 acceptCandidate ::
   (MonadInstance builtin m) =>
   WithContext (InstanceConstraint builtin) ->
   InstanceGoal builtin ->
   WithContext (InstanceCandidate builtin) ->
-  m ()
+  m (Value builtin)
 acceptCandidate (WithContext Resolve {..} constraintCtx) goal candidate = do
   -- Allow the candidate to access all the arguments in the goal telescope.
   let goalCtxExtension = goalTelescope goal
@@ -204,6 +264,8 @@ acceptCandidate (WithContext Resolve {..} constraintCtx) goal candidate = do
 
   -- Add the constriants
   addUnificationConstraints [goalConstraint]
+
+  return substCandidateExpr
 
 -- | Generate meta variables for each binder in the telescope of the candidate
 -- and then substitute them into the candidate expression.
@@ -230,7 +292,83 @@ instantiateCandidateTelescope goalCtxExtension (constraintCtx, constraintOrigin)
     normCandidateBody <- eval (toNamedBoundCtx initialCtx) (boundContextToEnv initialCtx) candidateBody
     return (normCandidateBody, candidateSol)
 
--- TODO move this to Print
-prettyCandidate :: (PrintableBuiltin builtin) => WithContext (InstanceCandidate builtin) -> Doc a
-prettyCandidate (WithContext candidate ctx) =
-  prettyExternal (WithContext (candidateExpr candidate) (toNamedBoundCtx ctx))
+-- | Sees if one of the candidates is provably less general than all the
+-- others, e.g.
+--
+--   HasAdd (Tensor Rat t)
+--
+-- is less than general than
+--
+--   {{TensorLike r}} -> HasAdd r
+findLeastGeneralCandidate ::
+  (Eq builtin) =>
+  [SuccessfulInstanceCandidate builtin] ->
+  Maybe (SuccessfulInstanceCandidate builtin)
+findLeastGeneralCandidate = \case
+  -- TODO this could be generalised to find a minimum in the whole graph
+  -- but this is sufficient now.
+  [c1, c2] -> case c1 `lessGeneralThan` c2 of
+    Nothing -> Nothing
+    -- This is a hack to stop type-classes with zero arguments
+    -- from being declared equal (e.g. `IsTensorType` in decidability types)...
+    Just EQ -> Nothing
+    Just LT -> Just c1
+    Just GT -> Just c2
+  _ -> Nothing
+
+lessGeneralThan ::
+  forall builtin.
+  (Eq builtin) =>
+  SuccessfulInstanceCandidate builtin ->
+  SuccessfulInstanceCandidate builtin ->
+  Maybe Ordering
+lessGeneralThan candidate1 candidate2 =
+  go (successfulSolution candidate1) (successfulSolution candidate2)
+  where
+    go :: Value builtin -> Value builtin -> Maybe Ordering
+    go v1 v2 = case (v1, v2) of
+      (VMeta {}, VMeta {}) -> Just EQ
+      (VMeta {}, _) -> Just GT
+      (_, VMeta {}) -> Just LT
+      (VBuiltin b1 args1, VBuiltin b2 args2)
+        | b1 /= b2 -> Nothing
+        | otherwise -> goArgs args1 args2
+      (VFreeVar i1 args1, VFreeVar i2 args2)
+        | i1 /= i2 -> Nothing
+        | otherwise -> goArgs args1 args2
+      -- TODO extend with remaining cases?
+      _ -> Nothing
+
+    goArgs :: Spine builtin -> Spine builtin -> Maybe Ordering
+    goArgs args1 args2
+      | length args1 /= length args2 = Nothing
+      | otherwise = do
+          let maybeResults = zipWith (\x y -> go (argExpr x) (argExpr y)) args1 args2
+          let OrderingCounts {..} = countOrderings maybeResults
+          if numberOfNothings > 0 || (numberOfLTs > 0 && numberOfGTs > 0)
+            then Nothing
+            else
+              if numberOfEQs == length maybeResults
+                then Just EQ
+                else
+                  if numberOfLTs > 0
+                    then Just LT
+                    else Just GT
+
+data OrderingCounts = OrderingCounts
+  { numberOfNothings :: Int,
+    numberOfEQs :: Int,
+    numberOfLTs :: Int,
+    numberOfGTs :: Int
+  }
+
+countOrderings :: [Maybe Ordering] -> OrderingCounts
+countOrderings = \case
+  [] -> OrderingCounts 0 0 0 0
+  o : os -> do
+    let counts = countOrderings os
+    case o of
+      Nothing -> counts {numberOfNothings = numberOfNothings counts + 1}
+      Just EQ -> counts {numberOfEQs = numberOfEQs counts + 1}
+      Just LT -> counts {numberOfLTs = numberOfLTs counts + 1}
+      Just GT -> counts {numberOfGTs = numberOfGTs counts + 1}

--- a/vehicle/src/Vehicle/Compile/Type/Core.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Core.hs
@@ -165,22 +165,10 @@ goalExpr InstanceGoal {..} =
     Left ident -> VFreeVar ident goalSpine
     Right builtin -> VBuiltin builtin goalSpine
 
-data InstanceConstraint builtin = Resolve
-  { instanceOrigin :: InstanceConstraintOrigin builtin,
-    instanceSolution :: MetaID,
-    instanceRelevance :: Relevance,
-    instanceGoal :: InstanceGoal builtin
-  }
-  deriving (Show)
-
-type instance
-  WithContext (InstanceConstraint builtin) =
-    Contextualised (InstanceConstraint builtin) (ConstraintContext builtin)
-
 data InstanceCandidate builtin = InstanceCandidate
   { candidateExpr :: Expr builtin,
     candidateSolution :: Expr builtin,
-    defaultInstance :: Bool
+    candidatePriority :: Maybe InstancePriority
   }
   deriving (Generic, Show)
 
@@ -200,6 +188,28 @@ type instance
   WithContext (InstanceCandidate builtin) =
     Contextualised (InstanceCandidate builtin) (BoundCtx (Type builtin))
 
+type FailedInstanceCandidate builtin = (WithContext (InstanceCandidate builtin), UnAnnDoc)
+
+type PossibleInstanceCandidate builtin = WithContext (InstanceCandidate builtin)
+
+type InstanceCandidateState builtin =
+  ( [PossibleInstanceCandidate builtin],
+    [FailedInstanceCandidate builtin]
+  )
+
+data InstanceConstraint builtin = Resolve
+  { instanceOrigin :: InstanceConstraintOrigin builtin,
+    instanceSolution :: MetaID,
+    instanceRelevance :: Relevance,
+    instanceCandidateState :: Maybe (InstanceCandidateState builtin),
+    instanceGoal :: InstanceGoal builtin
+  }
+  deriving (Show)
+
+type instance
+  WithContext (InstanceConstraint builtin) =
+    Contextualised (InstanceConstraint builtin) (ConstraintContext builtin)
+
 type InstanceConstraintInfo builtin =
   ( ConstraintContext builtin,
     InstanceConstraintOrigin builtin
@@ -210,22 +220,18 @@ type InstanceSearchDepth = Int
 -- | Stores the list of instance candidates currently in scope.
 -- We use a HashMap rather than an ordinary Map as not all builtins may be
 -- totally ordered (e.g. PolarityBuiltin and LinearityBuiltin)
-data InstanceDatabase builtin = InstanceDatabase
-  { instances :: Map (InstanceHead builtin) [InstanceCandidate builtin],
-    defaultInstances :: Map (InstanceHead builtin) (InstanceCandidate builtin)
+newtype InstanceDatabase builtin = InstanceDatabase
+  { instances :: Map (InstanceHead builtin) [InstanceCandidate builtin]
   }
   deriving (Generic)
 
 instance (Ord builtin, Serialize builtin) => Serialize (InstanceDatabase builtin)
 
 emptyInstanceDatabase :: (Ord builtin) => InstanceDatabase builtin
-emptyInstanceDatabase = InstanceDatabase mempty mempty
+emptyInstanceDatabase = InstanceDatabase mempty
 
 lookupInstances :: (Ord builtin) => InstanceGoal builtin -> InstanceDatabase builtin -> [InstanceCandidate builtin]
 lookupInstances goal database = Map.findWithDefault [] (goalHead goal) (instances database)
-
-lookupDefaultInstance :: (Ord builtin) => InstanceGoal builtin -> InstanceDatabase builtin -> Maybe (InstanceCandidate builtin)
-lookupDefaultInstance goal database = Map.lookup (goalHead goal) (defaultInstances database)
 
 insertInstanceIntoDatabase ::
   (Ord builtin) =>
@@ -235,11 +241,7 @@ insertInstanceIntoDatabase ::
   InstanceDatabase builtin
 insertInstanceIntoDatabase instanceHead instanceCandidate InstanceDatabase {..} =
   InstanceDatabase
-    { instances = Map.insertWith (<>) instanceHead [instanceCandidate] instances,
-      defaultInstances =
-        if defaultInstance instanceCandidate
-          then Map.insert instanceHead instanceCandidate defaultInstances
-          else defaultInstances
+    { instances = Map.insertWith (<>) instanceHead [instanceCandidate] instances
     }
 
 --------------------------------------------------------------------------------

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Substitution.hs
@@ -129,8 +129,8 @@ instance MetaSubstitutable m builtin (GluedExpr builtin) where
   substMetasAt ctx s (Glued a b) = Glued <$> substMetasAt ctx s a <*> substMetasAt ctx s b
 
 instance MetaSubstitutable m builtin (InstanceConstraint builtin) where
-  substMetasAt ctx s (Resolve origin m r g) = do
-    Resolve <$> substMetasAt ctx s origin <*> findUltimateUnsolvedMeta s m <*> pure r <*> substMetasAt ctx s g
+  substMetasAt ctx s (Resolve origin m r c g) = do
+    Resolve <$> substMetasAt ctx s origin <*> findUltimateUnsolvedMeta s m <*> pure r <*> pure c <*> substMetasAt ctx s g
 
 instance MetaSubstitutable m builtin (InstanceGoal builtin) where
   substMetasAt ctx s (InstanceGoal t h spine) =

--- a/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Meta/Variable.hs
@@ -129,7 +129,7 @@ instance (HasMetas a) => HasMetas (NonEmpty a) where
   findMetas = mapM_ findMetas
 
 instance HasMetas (InstanceConstraint builtin) where
-  findMetas (Resolve _ m _ goal) = do
+  findMetas (Resolve _ m _ _ goal) = do
     tell (MetaSet.singleton m)
     findMetas goal
 

--- a/vehicle/src/Vehicle/Compile/Type/Monad.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad.hs
@@ -162,7 +162,7 @@ createFreshInstanceConstraint auxiliaryConstraint boundCtx p origin relevance tc
   context <- createFreshConstraintCtx p boundCtx
   nTCExpr <- eval (toNamedBoundCtx boundCtx) env tcExpr
   let goal = parseInstanceGoal nTCExpr
-  let constraint = WithContext (Resolve origin metaID relevance goal) context
+  let constraint = WithContext (Resolve origin metaID relevance Nothing goal) context
 
   if auxiliaryConstraint
     then addAuxiliaryInstanceConstraints [constraint]
@@ -182,7 +182,7 @@ createDerivedInstanceConstraint (ctx, origin) r t = do
   let dbLevel = contextDBLevel ctx
   let newTypeClassExpr = quote p dbLevel t
   (metaID, metaExpr) <- freshSolutionMeta p newTypeClassExpr (boundContextOf ctx)
-  let newConstraint = Resolve origin metaID r $ parseInstanceGoal t
+  let newConstraint = Resolve origin metaID r Nothing $ parseInstanceGoal t
 
   newCtx <- copyContext ctx Nothing
   return (metaExpr, WithContext newConstraint newCtx)
@@ -206,12 +206,12 @@ addInstanceToInstanceDatabase ::
   forall builtin m.
   (MonadTypeChecker builtin m) =>
   Decl builtin ->
-  Bool ->
+  Maybe InstancePriority ->
   m ()
-addInstanceToInstanceDatabase decl isDefault =
+addInstanceToInstanceDatabase decl priority =
   case decl of
     DefFunction _ _ _ t e -> do
-      let candidate = InstanceCandidate t e isDefault
+      let candidate = InstanceCandidate t e priority
       instanceHead <- findValidInstanceHead (identifierOf decl, provenanceOf decl) candidate
       modifyTypeCheckerState $ \state ->
         state

--- a/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
+++ b/vehicle/src/Vehicle/Compile/Type/Monad/Class.hs
@@ -194,23 +194,14 @@ getMetaVariableCtx = getsTypeCheckerDeclState metaVariableCtx
 getNumberOfMetasCreated :: forall builtin m. (MonadTypeChecker builtin m) => Proxy builtin -> m Int
 getNumberOfMetasCreated _ = getsTypeCheckerDeclState @builtin (length . metaVariableCtx)
 
-getInstanceCandidates ::
+getInstanceCandidatesFromFreeCtx ::
   (MonadTypeChecker builtin m) =>
   InstanceGoal builtin ->
   m [InstanceCandidate builtin]
-getInstanceCandidates goal = do
+getInstanceCandidatesFromFreeCtx goal = do
   imports <- getsTypeCheckerState importedModules
   current <- getsTypeCheckerState currentModuleInterface
   return $ concatInCombinedContext typingInterface (lookupInstances goal . instanceDatabase) current imports
-
-getDefaultInstanceCandidate ::
-  (MonadTypeChecker builtin m) =>
-  InstanceGoal builtin ->
-  m (Maybe (InstanceCandidate builtin))
-getDefaultInstanceCandidate goal = do
-  imports <- getsTypeCheckerState importedModules
-  current <- getsTypeCheckerState currentModuleInterface
-  return $ lookupInCombinedContext typingInterface (lookupDefaultInstance goal . instanceDatabase) current imports
 
 -- | Gets the type from the database
 getBuiltinTypeFromDatabase ::

--- a/vehicle/src/Vehicle/Data/Builtin/Decidability/Instances.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Decidability/Instances.hs
@@ -15,6 +15,7 @@ import Vehicle.Data.Builtin.Core (BuiltinFunction (..), DerivedFunction (..))
 import Vehicle.Data.Builtin.Decidability
 import Vehicle.Data.Code.DSL
 import Vehicle.Data.DSL
+import Vehicle.Syntax.AST.Decl (InstancePriority)
 
 decidabilityBuiltinInstances :: InstanceDatabase DecidabilityBuiltin
 decidabilityBuiltinInstances = makeInstanceDatabase allInstances
@@ -34,7 +35,7 @@ allInstances =
     --------------
     [ ( decTypeClass ValidPropertyType [tProp],
         tUnit,
-        False
+        Nothing
       )
     ]
       -------------
@@ -46,7 +47,7 @@ allInstances =
              lamDims $ \_ds1 ->
                lamDims $ \_ds2 ->
                  tUnit,
-             False
+             Nothing
            )
          ]
       -------------
@@ -54,11 +55,11 @@ allInstances =
       -------------
       <> [ ( isTensorType,
              tTensorRaw,
-             True
+             Just 0
            ),
            ( isTensorType,
              propTensor,
-             False
+             Nothing
            )
          ]
       <> tensorTypeClassCandidate FieldNot (builtinFunction Not) PropNot
@@ -83,18 +84,22 @@ allInstances =
       -------------
       <> [ ( isVectorType,
              tVectorRaw,
-             True
+             Just 0
            ),
            ( isVectorType,
              propVector,
-             False
+             Nothing
            )
          ]
       <> vectorTypeClassCandidate FieldFromVectorLiteral vectorToVector BoolVectorToProp
       <> vectorTypeClassCandidate FieldAtVector (builtinFunction AtVector) PropNaryProductAt
       <> vectorTypeClassCandidate FieldForeachVector (builtinFunction ForeachVector) PropNaryProductForeach
 
-type TempCandidate = (DSLExpr DecidabilityBuiltin, DSLExpr DecidabilityBuiltin, Bool)
+type TempCandidate =
+  ( DSLExpr DecidabilityBuiltin,
+    DSLExpr DecidabilityBuiltin,
+    Maybe InstancePriority
+  )
 
 decTypeClass :: DecidabilityBuiltinTypeClass -> NonEmpty (DSLExpr DecidabilityBuiltin) -> DSLExpr DecidabilityBuiltin
 decTypeClass tc args = builtin (DecidabilityBuiltinTypeClass tc) @@ args
@@ -118,11 +123,11 @@ vectorTypeClassCandidate ::
 vectorTypeClassCandidate field standardOp typeOp =
   [ ( decTypeClass (HasVectorTypeClassField field) [tVectorRaw],
       standardOp,
-      False
+      Nothing
     ),
     ( decTypeClass (HasVectorTypeClassField field) [propVector],
       decFunction typeOp,
-      False
+      Nothing
     )
   ]
 
@@ -134,11 +139,11 @@ tensorTypeClassCandidate ::
 tensorTypeClassCandidate field standardOp typeOp =
   [ ( decTypeClass (HasTensorTypeClassField field) [tTensorRaw],
       standardOp,
-      False
+      Nothing
     ),
     ( decTypeClass (HasTensorTypeClassField field) [propTensor],
       decFunction typeOp,
-      False
+      Nothing
     )
   ]
 

--- a/vehicle/src/Vehicle/Data/Builtin/Linearity/Solver.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Linearity/Solver.hs
@@ -24,7 +24,7 @@ solveLinearityConstraint ::
   WithContext (InstanceConstraint LinearityBuiltin) ->
   m ()
 solveLinearityConstraint constraintWithCtx = do
-  substConstraintWithCtx@(WithContext normConstraint@(Resolve origin _ _ goal) ctx) <- substMetaVariables @LinearityBuiltin constraintWithCtx
+  substConstraintWithCtx@(WithContext normConstraint@(Resolve origin _ _ _ goal) ctx) <- substMetaVariables @LinearityBuiltin constraintWithCtx
   logDebug MaxDetail $ "Forced:" <+> prettyFriendly substConstraintWithCtx
 
   (tc, spine) <- getTypeClass goal

--- a/vehicle/src/Vehicle/Data/Builtin/Polarity/Solver.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Polarity/Solver.hs
@@ -24,7 +24,7 @@ solvePolarityConstraint ::
   WithContext (InstanceConstraint PolarityBuiltin) ->
   m ()
 solvePolarityConstraint constraintWithCtx = do
-  normConstraintWithCtx@(WithContext normConstraint@(Resolve origin _ _ goal) ctx) <- substMetaVariables constraintWithCtx
+  normConstraintWithCtx@(WithContext normConstraint@(Resolve origin _ _ _ goal) ctx) <- substMetaVariables constraintWithCtx
   logDebugM MaxDetail $ do
     let forcedExpr = goalExpr $ instanceGoal $ objectIn normConstraintWithCtx
     let boundCtx = namedBoundCtxOf $ contextOf normConstraintWithCtx

--- a/vehicle/src/Vehicle/Data/Builtin/Standard/Instances.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Standard/Instances.hs
@@ -35,7 +35,7 @@ allInstances =
               validPropertyType (tBoolTensor ds),
             lamDims $ \_ds ->
               tUnit,
-            False
+            Nothing
           ),
           ( forAllTypes $ \tElem ->
               forAllDims $ \d ->
@@ -45,35 +45,35 @@ allInstances =
               lamDim $ \_d ->
                 instLam "r1" (validPropertyType tElem) $ \_inst ->
                   tUnit,
-            False
+            Nothing
           ),
           ------------------------------------
           -- ValidNonInferableParameterType --
           ------------------------------------
           ( validNonInferableParameterType (tBoolTensor dimNil),
             unitLit,
-            False
+            Nothing
           ),
           ( forAllIrrelevantNat "n" $ \n ->
               validNonInferableParameterType (tIndex n),
             irrelImplNatLam "n" $ \_n ->
               unitLit,
-            False
+            Nothing
           ),
           ( validNonInferableParameterType tNat,
             unitLit,
-            False
+            Nothing
           ),
           ( validNonInferableParameterType (tRatTensor dimNil),
             unitLit,
-            False
+            Nothing
           ),
           ---------------------------------
           -- ValidInferableParameterType --
           ---------------------------------
           ( validInferableParameterType tNat,
             unitLit,
-            False
+            Nothing
           ),
           ----------------------
           -- ValidDatasetType --
@@ -84,7 +84,7 @@ allInstances =
             implLam "t" type0 $ \t ->
               instLam "r1" (validDatasetListElementType t) $ \_ ->
                 tUnit,
-            False
+            Nothing
           ),
           ( forAllTypes $ \t ->
               forAllDim Irrelevant $ \d ->
@@ -94,7 +94,7 @@ allInstances =
               lam "d" (Implicit False) Irrelevant tDim $ \_d ->
                 instLam "r1" (validDatasetListElementType t) $ \_ ->
                   tUnit,
-            False
+            Nothing
           ),
           ( forAllTypes $ \t ->
               forAllDims $ \ds ->
@@ -104,7 +104,7 @@ allInstances =
               lamDims $ \_ds ->
                 instLam "r1" (validDatasetTensorElementType t) $ \_ ->
                   tUnit,
-            False
+            Nothing
           ),
           -- List element types
           ( forAllTypes $ \t ->
@@ -113,7 +113,7 @@ allInstances =
             implLam "t" type0 $ \t ->
               instLam "r1" (validDatasetListElementType t) $ \_ ->
                 tUnit,
-            False
+            Nothing
           ),
           ( forAllTypes $ \t ->
               forAllDim Irrelevant $ \d ->
@@ -123,7 +123,7 @@ allInstances =
               lam "d" (Implicit False) Irrelevant tDim $ \_d ->
                 instLam "r1" (validDatasetListElementType t) $ \_ ->
                   tUnit,
-            False
+            Nothing
           ),
           ( forAllTypes $ \t ->
               forAllDims $ \ds ->
@@ -133,32 +133,32 @@ allInstances =
               lamDims $ \_ds ->
                 instLam "r1" (validDatasetTensorElementType t) $ \_ ->
                   tUnit,
-            False
+            Nothing
           ),
           ( forAllIrrelevantNat "n" $ \n ->
               validDatasetListElementType (tIndex n),
             irrelImplNatLam "n" $ \_n ->
               tUnit,
-            False
+            Nothing
           ),
           ( validDatasetListElementType tNat,
             tUnit,
-            False
+            Nothing
           ),
           -- Element typs
           ( forAllIrrelevantNat "n" $ \n ->
               validDatasetTensorElementType (tIndex n),
             irrelImplNatLam "n" $ \_n ->
               tUnit,
-            False
+            Nothing
           ),
           ( validDatasetTensorElementType tNat,
             tUnit,
-            False
+            Nothing
           ),
           ( validDatasetTensorElementType tRat,
             tUnit,
-            False
+            Nothing
           ),
           ----------------------
           -- ValidNetworkType --
@@ -169,7 +169,7 @@ allInstances =
             lamDims $ \_ds1 ->
               lamDims $ \_ds2 ->
                 tUnit,
-            False
+            Nothing
           ),
           -------------------------
           -- ValidTensorLikeType --
@@ -180,14 +180,14 @@ allInstances =
             lamType $ \_t ->
               lamDim $ \_ds ->
                 tUnit,
-            False
+            Nothing
           ),
           -- ----------------
           -- HasRatLits --
           ----------------
           ( hasRatLits (tRatTensor dimNil),
             builtinCast (FromRat FromRatToRat),
-            False
+            Nothing
           ),
           ----------------
           -- HasNatLits --
@@ -196,15 +196,15 @@ allInstances =
               hasNatLits (tIndex n),
             irrelImplNatLam "n" $ \n ->
               builtinCast (FromNat FromNatToIndex) .@@@ [n],
-            False
+            Nothing
           ),
           ( hasNatLits tNat,
             builtinCast (FromNat FromNatToNat),
-            True
+            Just 0
           ),
           ( hasNatLits (tRatTensor dimNil),
             builtinCast (FromNat FromNatToRat),
-            False
+            Nothing
           ),
           ----------------
           -- HasVecLits --
@@ -217,7 +217,7 @@ allInstances =
               lamDim $ \d ->
                 lamDims $ \ds ->
                   builtinFunction StackTensor @@@ [t, d] .@@@ [ds],
-            False
+            Nothing
           ),
           ( forAllTypes $ \t ->
               forAllDim Irrelevant $ \d ->
@@ -225,7 +225,7 @@ allInstances =
             implLam "t" type0 $ \t ->
               lamDim $ \d ->
                 builtinConstructor VectorLiteral @@@ [t, d],
-            False
+            Nothing
           ),
           ( forAllTypes $ \t ->
               forAllDim Irrelevant $ \d ->
@@ -233,7 +233,7 @@ allInstances =
             implLam "t" type0 $ \t ->
               lamDim $ \d ->
                 builtinCast FromVectorToList @@@ [t, d],
-            False
+            Nothing
           ),
           ------------------
           -- IsTensorType --
@@ -242,13 +242,13 @@ allInstances =
               isTensorType tBool ds,
             lamDims $ \ds ->
               tTensor tBool ds,
-            False
+            Nothing
           ),
           ( forAllDims $ \ds ->
               isTensorType tRat ds,
             lamDims $ \ds ->
               tTensor tRat ds,
-            False
+            Nothing
           ),
           ( forAllIrrelevant "ds" tDims $ \ds ->
               forAllTypes $ \t ->
@@ -256,32 +256,32 @@ allInstances =
             lamDims $ \ds ->
               implLam "t" type0 $ \t ->
                 tTensor t ds,
-            False
+            Nothing
           ),
           ------------
           -- HasNeg --
           ------------
           ( forAllDims $ \dims -> hasNeg (tRatTensor dims) (tRatTensor dims),
             lamDims $ \dims -> builtinFunction (Neg NegRatTensor) .@@@ [dims],
-            False
+            Nothing
           ),
           ------------
           -- HasMul --
           ------------
           ( hasMul tNat tNat tNat,
             builtinFunction (Mul MulNat),
-            True
+            Just 0
           ),
           ( forAllDims $ \dims -> hasMul (tRatTensor dims) (tRatTensor dims) (tRatTensor dims),
             lamDims $ \dims -> builtinFunction (Mul MulRatTensor) .@@@ [dims],
-            False
+            Nothing
           ),
           ------------
           -- HasDiv --
           ------------
           ( forAllDims $ \dims -> hasDiv (tRatTensor dims) (tRatTensor dims) (tRatTensor dims),
             lamDims $ \dims -> builtinFunction (Div DivRatTensor) .@@@ [dims],
-            False
+            Nothing
           ),
           ------------
           -- HasAt --
@@ -292,7 +292,7 @@ allInstances =
             lamType $ \tElem ->
               lamDim $ \d ->
                 builtinFunction AtVector @@@ [tElem] .@@@ [d],
-            False
+            Nothing
           ),
           ( forAllTypes $ \tElem ->
               forAllDim Irrelevant $ \d ->
@@ -302,7 +302,7 @@ allInstances =
               lamDim $ \d ->
                 lamDims $ \ds ->
                   builtinFunction AtTensor @@@ [tElem] .@@@ [d, ds],
-            False
+            Nothing
           ),
           ------------
           -- HasForeach --
@@ -313,7 +313,7 @@ allInstances =
             lamType $ \tElem ->
               lam "d" (Implicit False) Relevant tDim $ \d ->
                 builtinFunction ForeachVector @@@ [tElem, d],
-            False
+            Nothing
           ),
           ( forAllTypes $ \tElem ->
               forAllDim Relevant $ \d ->
@@ -323,21 +323,21 @@ allInstances =
               lam "d" (Implicit False) Relevant tDim $ \d ->
                 lamDims $ \ds ->
                   builtinFunction ForeachTensor @@@ [tElem, d] .@@@ [ds],
-            False
+            Nothing
           ),
           ------------
           -- HasMap --
           ------------
           ( hasMap tListRaw,
             builtinFunction MapList,
-            True
+            Nothing
           ),
           ------------
           -- HasFold --
           ------------
           ( hasFold tListRaw,
             builtinFunction FoldList,
-            False
+            Nothing
           )
         ]
       <> comparisonCandidates Le
@@ -349,7 +349,7 @@ allInstances =
       <> quantifierCandidates Forall
       <> quantifierCandidates Exists
   where
-    comparisonCandidates :: ComparisonOp -> [(DSLExpr Builtin, DSLExpr Builtin, Bool)]
+    comparisonCandidates :: ComparisonOp -> [(DSLExpr Builtin, DSLExpr Builtin, Maybe InstancePriority)]
     comparisonCandidates op =
       [ ( forAll "n1" tNat $ \n1 ->
             forAll "n2" tNat $ \n2 ->
@@ -357,18 +357,18 @@ allInstances =
           implLam "n1" tNat $ \n1 ->
             implLam "n2" tNat $ \n2 ->
               builtinFunction (CompareIndex op) @@@ [n1, n2],
-          False
+          Nothing
         ),
         ( hasCompare op tNat tNat (tBoolTensor dimNil),
           builtinFunction (CompareNat op),
-          True
+          Just 0
         ),
         -- We separate out the zero-dimensional tensor case so that we have a unique
         -- representation of comparisons over zero tensors. Otherwise, we end up
         -- having both pointwise and reduced comparisons.
         ( hasCompare op (tRatTensor dimNil) (tRatTensor dimNil) (tBoolTensor dimNil),
           builtinFunction (CompareRatTensorPointwise op) .@@@ [dimNil],
-          False
+          Just 1
         ),
         ( forAllDim Irrelevant $ \d ->
             forAllDims $ \dims ->
@@ -376,24 +376,24 @@ allInstances =
           lamDim $ \d ->
             lamDims $ \dims ->
               builtinDerivedFunction (CompareRatTensorReduced op) .@@@ [d, dims],
-          False
+          Nothing
         )
       ]
 
     quantifierCandidates ::
       Quantifier ->
-      [(DSLExpr Builtin, DSLExpr Builtin, Bool)]
+      [(DSLExpr Builtin, DSLExpr Builtin, Maybe InstancePriority)]
     quantifierCandidates q =
       [ ( forAllNat $ \n ->
             hasQuantifier q (tIndex n),
           lamDim $ \n ->
             builtinDerivedFunction (QuantifyIndex q) @@@ [n],
-          False
+          Nothing
         ),
         ( forAllDims $ \ds ->
             hasQuantifier q (tRatTensor ds),
           lamDims $ \ds ->
             builtinFunction (QuantifyRatTensor q) @@@ [ds],
-          False
+          Nothing
         )
       ]

--- a/vehicle/src/Vehicle/TypeCheck.hs
+++ b/vehicle/src/Vehicle/TypeCheck.hs
@@ -6,7 +6,7 @@ module Vehicle.TypeCheck
   )
 where
 
-import Control.Monad (forM, forM_, when)
+import Control.Monad (forM, when)
 import Control.Monad.Except (ExceptT, MonadError (..))
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks)
@@ -27,7 +27,7 @@ import Vehicle.Compile.Print.Error
 import Vehicle.Compile.Scope (scopeModuleDecls)
 import Vehicle.Compile.Serialise (readObjectFile, writeObjectFile)
 import Vehicle.Compile.Type
-import Vehicle.Compile.Type.Core (InstanceDatabase (..), emptyInstanceDatabase)
+import Vehicle.Compile.Type.Core (emptyInstanceDatabase)
 import Vehicle.Compile.Type.Subsystem
 import Vehicle.Data.Builtin.Decidability.Type ()
 import Vehicle.Data.Builtin.Interface.Print
@@ -36,7 +36,7 @@ import Vehicle.Data.Builtin.Polarity.Type ()
 import Vehicle.Data.Builtin.Standard
 import Vehicle.Data.Builtin.Standard.Instances (standardBuiltinInstances)
 import Vehicle.Data.Builtin.Standard.Type ()
-import Vehicle.Data.Code.ModuleInterface (ImportedModuleContext, ModuleInterface (..), instanceDatabase, mergeImportedFreeEnvs, typedModule)
+import Vehicle.Data.Code.ModuleInterface (ImportedModuleContext, ModuleInterface (..), mergeImportedFreeEnvs, typedModule)
 import Vehicle.Data.Code.Value (FreeEnv)
 import Vehicle.Data.Variable.Free.Context (runFreeContextT)
 import Vehicle.Libraries (ensureLatestVersionOfLibraryInstalled, resolveLibrary)
@@ -358,10 +358,6 @@ parseAndTypeCheckModule moduleFile implicitImports moduleText = do
   let finalImports = implicitImports <> imports
   (_status, importedCtx) <- loadImports finalImports
 
-  forM_ importedCtx $ \(path, int, _) -> do
-    let InstanceDatabase dat _ = instanceDatabase $ typingInterface int
-    logDebug MinDetail $ pretty path <+> pretty (length dat)
-
   let instances =
         if modulePath == standardLibraryDefinitionsModulePath
           then standardBuiltinInstances
@@ -376,9 +372,6 @@ parseAndTypeCheckModule moduleFile implicitImports moduleText = do
             typingInterface = typingInterface,
             typedModule = typedModule
           }
-
-  let InstanceDatabase dat2 _ = instanceDatabase typingInterface
-  logDebug MinDetail $ "after" <+> pretty (length dat2)
 
   writeObjectFile moduleFile moduleText moduleInterface
 

--- a/vehicle/tests/golden/compile/issue914/Type.err.golden
+++ b/vehicle/tests/golden/compile/issue914/Type.err.golden
@@ -1,6 +1,6 @@
 Error in file 'spec.vcl' at Line 6, Columns 13-20: unable to work out a valid type for the overloaded expression 'foreach'.
 The possible options explored were:
-  1. (Index ds -> Tensor ds B) -> Tensor t (d :: ds)
-    - rejected: unable to find a consistent type for the overloaded expression 'foreach'. In particular 'Tensor Real ?21 -> Real' is not equal to 'Tensor ?26 ?28'.
-  2. (Index A -> A) -> Vector t d
+  1. (Index A -> A) -> Vector t d
     - rejected: unable to find a consistent type for the overloaded expression 'foreach'. In particular 'Tensor Real [1]' is not equal to 'Vector ?26 ?27'.
+  2. (Index ds -> Tensor ds B) -> Tensor t (d :: ds)
+    - rejected: unable to find a consistent type for the overloaded expression 'foreach'. In particular 'Tensor Real ?21 -> Real' is not equal to 'Tensor ?26 ?28'.

--- a/vehicle/tests/golden/error/other-verifier/quantifiedNat/Marabou.err.golden
+++ b/vehicle/tests/golden/error/other-verifier/quantifiedNat/Marabou.err.golden
@@ -1,6 +1,6 @@
 Error in file 'quantifiedNat.vcl' at Line 3, Columns 5-11: unable to work out a valid type for the overloaded expression 'forall'.
 The possible options explored were:
-  1. (Tensor Real ds -> Bool) -> Bool
-    - rejected: unable to find a consistent type for the overloaded expression 'forall'. In particular 'Nat' is not equal to 'Tensor Real ?12'.
-  2. (Index n -> Bool) -> Bool
+  1. (Index n -> Bool) -> Bool
     - rejected: unable to find a consistent type for the overloaded expression 'forall'. In particular 'Nat' is not equal to 'Index ?12'.
+  2. (Tensor Real ds -> Bool) -> Bool
+    - rejected: unable to find a consistent type for the overloaded expression 'forall'. In particular 'Nat' is not equal to 'Tensor Real ?12'.

--- a/vehicle/tests/golden/error/other-verifier/quantifiedVectorNat/Marabou.err.golden
+++ b/vehicle/tests/golden/error/other-verifier/quantifiedVectorNat/Marabou.err.golden
@@ -1,6 +1,6 @@
 Error in file 'quantifiedVectorNat.vcl' at Line 3, Columns 5-11: unable to work out a valid type for the overloaded expression 'forall'.
 The possible options explored were:
-  1. (Tensor Real ds -> Bool) -> Bool
-    - rejected: unable to find a consistent type for the overloaded expression 'forall'. In particular 'Vector Nat 2' is not equal to 'Tensor Real ?22'.
-  2. (Index n -> Bool) -> Bool
+  1. (Index n -> Bool) -> Bool
     - rejected: unable to find a consistent type for the overloaded expression 'forall'. In particular 'Vector Nat 2' is not equal to 'Index ?22'.
+  2. (Tensor Real ds -> Bool) -> Bool
+    - rejected: unable to find a consistent type for the overloaded expression 'forall'. In particular 'Vector Nat 2' is not equal to 'Tensor Real ?22'.

--- a/vehicle/tests/golden/error/typing/incorrectTensorLength/TypeCheck.err.golden
+++ b/vehicle/tests/golden/error/typing/incorrectTensorLength/TypeCheck.err.golden
@@ -8,6 +8,6 @@
       11
     ]
   },
-  "problem": "unable to work out a valid type for the overloaded expression '[1]'.\nThe possible options explored were:\n  1. List t\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'List ?22'.\n  2. Vector t d\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'Vector ?22 ?23'.\n  3. Tensor t (d :: ds)\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular '1' is not equal to '2'.",
+  "problem": "unable to work out a valid type for the overloaded expression '[1]'.\nThe possible options explored were:\n  1. Tensor t (d :: ds)\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular '1' is not equal to '2'.\n  2. Vector t d\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'Vector ?22 ?23'.\n  3. List t\n    - rejected: unable to find a consistent type for the overloaded expression '[1]'. In particular 'Tensor Real [2]' is not equal to 'List ?22'.",
   "fix": null
 }


### PR DESCRIPTION
Some changes to instance resolution that allow us to have overlapping instances with more fine grained control over which one we actually want.

In particular less general instances (e.g. `HasAdd Nat`) are automatically picked over more general instances (e.g. `TensorLike t -> HasAdd t`).