### PR TITLE
Try to fix mypy error

### DIFF
--- a/vehicle-python/setup.py
+++ b/vehicle-python/setup.py
@@ -21,7 +21,7 @@ ext_module = setuptools.Extension(
 )
 
 
-class cabal_build_ext(setuptools.command.build_ext.build_ext, setuptools.Command):
+class cabal_build_ext(setuptools.command.build_ext.build_ext):
     def finalize_options(self) -> None:
         super().finalize_options()
 
@@ -65,7 +65,7 @@ class cabal_build_ext(setuptools.command.build_ext.build_ext, setuptools.Command
         # Taken from setuptools:
         # https://github.com/pypa/setuptools/blob/245d72a8aa4d47e1811425213aba2a06a0bb64fa/setuptools/command/build_ext.py#L247-L249
         if ext._needs_stub:  # type: ignore[attr-defined]
-            build_lib = self.get_finalized_command("build_py").build_lib
+            build_lib = self.get_finalized_command("build_py").build_lib  # type: ignore[attr-defined]
             self.write_stub(build_lib, ext)
 
     def cabal_configure_ext(self, ext: setuptools.Extension) -> None:
@@ -183,7 +183,7 @@ class cabal_build_ext(setuptools.command.build_ext.build_ext, setuptools.Command
 def main() -> None:
     setuptools.setup(
         ext_modules=[ext_module],
-        cmdclass={"build_ext": cabal_build_ext},
+        cmdclass={"build_ext": cabal_build_ext}, # type: ignore[arg-type]
     )
 
 

--- a/vehicle-python/setup.py
+++ b/vehicle-python/setup.py
@@ -21,7 +21,7 @@ ext_module = setuptools.Extension(
 )
 
 
-class cabal_build_ext(setuptools.command.build_ext.build_ext):
+class cabal_build_ext(setuptools.command.build_ext.build_ext, setuptools.Command):
     def finalize_options(self) -> None:
         super().finalize_options()
 
@@ -65,7 +65,7 @@ class cabal_build_ext(setuptools.command.build_ext.build_ext):
         # Taken from setuptools:
         # https://github.com/pypa/setuptools/blob/245d72a8aa4d47e1811425213aba2a06a0bb64fa/setuptools/command/build_ext.py#L247-L249
         if ext._needs_stub:  # type: ignore[attr-defined]
-            build_lib = self.get_finalized_command("build_py").build_lib  # type: ignore[attr-defined]
+            build_lib = self.get_finalized_command("build_py").build_lib
             self.write_stub(build_lib, ext)
 
     def cabal_configure_ext(self, ext: setuptools.Extension) -> None:

--- a/vehicle-python/setup.py
+++ b/vehicle-python/setup.py
@@ -183,7 +183,7 @@ class cabal_build_ext(setuptools.command.build_ext.build_ext):
 def main() -> None:
     setuptools.setup(
         ext_modules=[ext_module],
-        cmdclass={"build_ext": cabal_build_ext}, # type: ignore[arg-type]
+        cmdclass={"build_ext": cabal_build_ext},  # type: ignore[arg-type]
     )
 
 


### PR DESCRIPTION
Attempts to fix the recent build failure:
```
vehicle-python/setup.py:186: error: Argument "cmdclass" to "setup" has incompatible type "dict[str, type[cabal_build_ext]]"; expected "_MutableDictLike[str, type[Command]]"  [arg-type]
vehicle-python/setup.py:186: note: Following member(s) of "dict[str, type[cabal_build_ext]]" have conflicts:
vehicle-python/setup.py:186: note:     Expected:
vehicle-python/setup.py:186: note:         def get(self, str, Any | None = ..., /) -> type[Command] | None
vehicle-python/setup.py:186: note:     Got:
vehicle-python/setup.py:186: note:         @overload
vehicle-python/setup.py:186: note:         def get(self, str, /) -> type[cabal_build_ext] | None
vehicle-python/setup.py:186: note:         @overload
vehicle-python/setup.py:186: note:         def get(self, str, type[cabal_build_ext], /) -> type[cabal_build_ext]
vehicle-python/setup.py:186: note:         @overload
vehicle-python/setup.py:186: note:         def [_T] get(self, str, _T, /) -> type[cabal_build_ext] | _T
```