### PR TITLE
Add parameter flag to loss compialation

### DIFF
--- a/vehicle-python/src/vehicle_lang/loss/_ast/__init__.py
+++ b/vehicle-python/src/vehicle_lang/loss/_ast/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable, Mapping
 
 from ... import session as session
 from ...typing import DeclarationName, DifferentiableLogic, Target
@@ -11,6 +11,7 @@ def load(
     path: str | Path,
     *,
     declarations: Iterable[DeclarationName] = (),
+    parameters: Mapping[str, Any] | None = None,
     target: Target = DifferentiableLogic.Vehicle,
 ) -> _nodes.Program:
     exc, out, err, log = session.check_output(
@@ -22,6 +23,10 @@ def load(
             target._vehicle_option_name,
             f"--specification={path}",
             *[f"--declaration={declaration_name}" for declaration_name in declarations],
+            *[
+                f"--parameter={name}:{value}"
+                for name, value in (parameters or {}).items()
+            ],
         ]
     )
     if exc != 0:

--- a/vehicle-python/src/vehicle_lang/loss/_common.py
+++ b/vehicle-python/src/vehicle_lang/loss/_common.py
@@ -24,6 +24,7 @@ def load_loss_specification(
     logic: DifferentiableLogic,
     samplers: Mapping[str, Any] | None,
     declarations: Iterable[DeclarationName],
+    parameters: Mapping[str, Any] | None = None,
     declaration_context: MutableMapping[str, Any] | None,
     translation_factory: TranslationFactory,
     default_sampler_factory: SamplerFactory,
@@ -41,6 +42,7 @@ def load_loss_specification(
         path,
         target=logic,
         declarations=declarations,
+        parameters=parameters,
     )
 
     translation = translation_factory()

--- a/vehicle-python/src/vehicle_lang/loss/pytorch.py
+++ b/vehicle-python/src/vehicle_lang/loss/pytorch.py
@@ -23,6 +23,7 @@ def load_specification(
     logic: DifferentiableLogic = DifferentiableLogic.DL2,
     samplers: Mapping[str, Any] | None = None,
     declarations: Iterable[DeclarationName] = (),
+    parameters: Mapping[str, Any] | None = None,
     declaration_context: MutableMapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Load a loss function compiled for PyTorch."""
@@ -32,6 +33,7 @@ def load_specification(
         logic=logic,
         samplers=samplers,
         declarations=declarations,
+        parameters=parameters,
         declaration_context=declaration_context,
         translation_factory=PyTorchTranslation,
         default_sampler_factory=DefaultPyTorchSampler,

--- a/vehicle-python/src/vehicle_lang/loss/tensorflow.py
+++ b/vehicle-python/src/vehicle_lang/loss/tensorflow.py
@@ -23,6 +23,7 @@ def load_specification(
     logic: DifferentiableLogic = DifferentiableLogic.DL2,
     samplers: Mapping[str, Any] | None = None,
     declarations: Iterable[DeclarationName] = (),
+    parameters: Mapping[str, Any] | None = None,
     declaration_context: MutableMapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Load a loss function compiled for TensorFlow."""
@@ -32,6 +33,7 @@ def load_specification(
         logic=logic,
         samplers=samplers,
         declarations=declarations,
+        parameters=parameters,
         declaration_context=declaration_context,
         translation_factory=TensorFlowTranslation,
         default_sampler_factory=DefaultTensorFlowSampler,

--- a/vehicle/src/Vehicle/Backend/Loss/Domain.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Domain.hs
@@ -3,7 +3,7 @@ module Vehicle.Backend.Loss.Domain
   )
 where
 
-import Control.Monad (foldM, forM)
+import Control.Monad (foldM, forM, guard)
 import Control.Monad.Except (MonadError (..), runExceptT)
 import Control.Monad.State (MonadState (..), evalStateT)
 import Data.Bifunctor (Bifunctor (..))
@@ -593,6 +593,20 @@ compileLinearExpr dims expr = case toRatTensorValue expr of
   -- The expression is being blocked
   VRatConstTensor {} -> unlinearisable
   VRatStackTensor {} -> unlinearisable
+  -- Handle concrete index lookups on bound tensor variables (e.g. x ! 0).
+  -- This allows per-index bounds like `0 <= x ! 0 <= 1 and 0 <= x ! 1 <= 2`
+  -- to be recognised as constraints, not just the `forall i . min ! i <= x ! i`
+  -- pattern (which NBE's foreach-fusion lifts to tensor-level comparisons).
+  VRatAt (AtTensorArgs _tElem _d _ds tensor (IIndexLiteral i)) ->
+    case toRatTensorValue tensor of
+      VRatTensorBoundVar lv -> do
+        maybeChildLv <- resolveAtBoundVar lv i
+        case maybeChildLv of
+          Nothing -> unlinearisable
+          Just childLv -> do
+            maybeExpr <- compileRatTensorVar dims childLv
+            maybe unlinearisable return maybeExpr
+      _ -> unlinearisable
   VRatAt {} -> unlinearisable
   VRatTensorFreeVar {} -> unlinearisable
   VRatForeach {} -> unlinearisable
@@ -623,6 +637,23 @@ compileRatTensorVar dims lv = do
   forM maybeSliceVar $ \(_tensorVar, sliceVar) -> do
     zeroTensor <- evalConstTensor $ ConstTensorArgs IRatType (IRatLiteral 0) dims
     return $ singletonVarExpr (TensorValue dims zeroTensor) sliceVar
+
+-- | Given a tensor bound variable at level @parentLv@ and a concrete index @i@,
+-- resolve the de Bruijn level of the corresponding child slice variable.
+-- For example, if @x : Tensor Real [5]@ is at level @lv@, then
+-- @resolveAtBoundVar lv 2@ returns @Just (lv + 3)@ (the slice for @x ! 2@).
+resolveAtBoundVar ::
+  (MonadReadableTensorBoundContext m) =>
+  Lv ->
+  Int ->
+  m (Maybe Lv)
+resolveAtBoundVar parentLv idx = do
+  (_, maybeSliceVar) <- lookupVariableInNestedCtx parentLv
+  return $ do
+    (nestedVar, _) <- maybeSliceVar
+    children <- childVariablesOf nestedVar
+    guard (idx >= 0 && idx < length children)
+    return $ toLv $ nestedStartingVariable (children !! idx)
 
 --------------------------------------------------------------------------------
 -- Utils

--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -231,6 +231,7 @@ compileLossParser =
     <$> lossLogicParser
     <*> specificationParser
     <*> declarationParser
+    <*> parameterParser
     <*> outputParser
 
 lossLogicParser :: Parser DifferentiableLogicID

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -42,6 +42,7 @@ data LossOptions = LossOptions
   { differentiableLogicID :: DifferentiableLogicID,
     specification :: FilePath,
     declarationsToCompile :: DeclarationNames,
+    parameterValues :: ParameterValues,
     outputFile :: Maybe FilePath
   }
   deriving (Show, Eq)
@@ -154,7 +155,9 @@ compileToLossFunction ::
   m ()
 compileToLossFunction LossOptions {..} typedProg outputAsJSON =
   logCompilerPass Loss $ do
-    lossTensorProg <- convertToLossTensors differentiableLogicID typedProg
+    let resources = Resources specification mempty mempty parameterValues
+    (expandedProg, _, _, _, _) <- expandResources resources typedProg
+    lossTensorProg <- convertToLossTensors differentiableLogicID expandedProg
     hoistedProg <- hoistInferableParameters lossTensorProg
     functionalisedProg <- functionaliseResources hoistedProg
     jsonProg <- convertToJSONProg functionalisedProg

--- a/vehicle/tests/golden/compile/help/vehicle-compile-loss.out.golden
+++ b/vehicle/tests/golden/compile/help/vehicle-compile-loss.out.golden
@@ -1,5 +1,6 @@
 Usage: vehicle compile loss (-l|--logic LOGIC) (-s|--specification FILE) 
-                            [-e|--declaration NAME] [-o|--output FILE]
+                            [-e|--declaration NAME] [-p|--parameter NAME:VALUE] 
+                            [-o|--output FILE]
 
   Compile a specification to a loss function.
 
@@ -12,6 +13,12 @@ Available options:
                            compilation. Can be provided multiple times. If not
                            provided then all declarations in the specification
                            will be compiled.
+  -p,--parameter NAME:VALUE
+                           Provide a value for a parameter referenced in the
+                           specification. Its value should consist of a
+                           colon-separated pair of the name of the parameter in
+                           the specification and its value. Can be provided
+                           multiple times.
   -o,--output FILE         Output location for compiled file(s). Defaults to
                            `stdout` if not provided.
   -h,--help                Show this help text

--- a/vehicle/tests/golden/compile/perIndexBounds/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/perIndexBounds/DL2Loss.vcl.golden
@@ -1,0 +1,3 @@
+@property;
+p : (Tensor Real -> Tensor Real) -> Tensor Real;
+p = \ f -> [ 1.0, 1.0, 1.0 ] / search[x] (\ e -> \ xs -> reduceMul e xs) [3] [ 0.0, 2.0, 4.0 ] [ 1.0, 3.0, 5.0 ] (\ x -> max 0.0 (f x ! 0))

--- a/vehicle/tests/golden/compile/perIndexBounds/spec.vcl
+++ b/vehicle/tests/golden/compile/perIndexBounds/spec.vcl
@@ -1,0 +1,20 @@
+-- Test that per-index explicit bounds are correctly extracted
+-- by the loss compiler (as opposed to only supporting
+-- `forall i . min ! i <= x ! i <= max ! i`).
+
+type InputVector = Tensor Real [3]
+
+a = 0
+b = 1
+c = 2
+
+@network
+f : InputVector -> InputVector
+
+@property
+p : Bool
+p = forall x .
+    (0 <= x ! a <= 1 and
+     2 <= x ! b <= 3 and
+     4 <= x ! c <= 5) =>
+    f x ! a >= 0

--- a/vehicle/tests/golden/compile/perIndexBounds/test.json
+++ b/vehicle/tests/golden/compile/perIndexBounds/test.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "TypeCheck",
+    "run": "vehicle typecheck -s spec.vcl",
+    "needs": ["spec.vcl"]
+  },
+  {
+    "name": "DL2Loss",
+    "run": "vehicle compile loss -s spec.vcl -l DL2Loss -o DL2Loss.vcl",
+    "needs": ["spec.vcl"],
+    "produces": ["DL2Loss.vcl"]
+  }
+]


### PR DESCRIPTION
Currently, there is no support for parameters in specifications when compiling to loss. This PR just adds them in the same way as for verification.