### PR TITLE
Remove support for GHC 8.10 and 9.0, add support for 9.10 and 9.12

### DIFF
--- a/.github/workflows/build-vehicle.yml
+++ b/.github/workflows/build-vehicle.yml
@@ -27,33 +27,33 @@ jobs:
               extra-args: ""
               extra-args-test-golden: ""
         include:
-          # Build with GHC 9.12.2
-          # - os:
-          #     name: Linux
-          #     type: ubuntu-latest
-          #   haskell:
-          #     ghc:
-          #       version: "9.12.2"
-          #     cabal:
-          #       version: "3.14.2.0"
-          #       project-file: "cabal.project"
-          #       extra-args: ""
-          #       # TODO: Migrate testVerifier to a Haskell executable for portability.
-          #       extra-args-test-golden: "--test-option='--allowlist-externals=TestVerifier'"
-          # Build with GHC 9.10.2
-          # - os:
-          #     name: Linux
-          #     type: ubuntu-latest
-          #   haskell:
-          #     ghc:
-          #       version: "9.10.2"
-          #     cabal:
-          #       version: "3.14.2.0"
-          #       project-file: "cabal.project"
-          #       extra-args: ""
-          #       # TODO: Migrate testVerifier to a Haskell executable for portability.
-          #       extra-args-test-golden: "--test-option='--allowlist-externals=TestVerifier'"
-          # Build with GHC 9.8.4
+          # Build with GHC 9.12
+          - os:
+              name: Linux
+              type: ubuntu-latest
+            haskell:
+              ghc:
+                version: "9.12.2"
+              cabal:
+                version: "3.14.2.0"
+                project-file: "cabal.project"
+                extra-args: ""
+                # TODO: Migrate testVerifier to a Haskell executable for portability.
+                extra-args-test-golden: "--test-option='--allowlist-externals=TestVerifier'"
+          # Build with GHC 9.10
+          - os:
+              name: Linux
+              type: ubuntu-latest
+            haskell:
+              ghc:
+                version: "9.10.3"
+              cabal:
+                version: "3.14.2.0"
+                project-file: "cabal.project"
+                extra-args: ""
+                # TODO: Migrate testVerifier to a Haskell executable for portability.
+                extra-args-test-golden: "--test-option='--allowlist-externals=TestVerifier'"
+          # Build with GHC 9.8
           - os:
               name: Linux
               type: ubuntu-latest
@@ -66,7 +66,7 @@ jobs:
                 extra-args: ""
                 # TODO: Migrate testVerifier to a Haskell executable for portability.
                 extra-args-test-golden: "--test-option='--allowlist-externals=TestVerifier'"
-          # Build with GHC 9.4.8
+          # Build with GHC 9.4
           - os:
               name: Linux
               type: ubuntu-latest
@@ -78,37 +78,13 @@ jobs:
                 project-file: "cabal.project"
                 extra-args: ""
                 extra-args-test-golden: ""
-          # Build with GHC 9.2.8
+          # Build with GHC 9.2
           - os:
               name: Linux
               type: ubuntu-latest
             haskell:
               ghc:
                 version: "9.2.8"
-              cabal:
-                version: "3.14.2.0"
-                project-file: "cabal.project"
-                extra-args: ""
-                extra-args-test-golden: ""
-          # Build with GHC 9.0.2
-          - os:
-              name: Linux
-              type: ubuntu-latest
-            haskell:
-              ghc:
-                version: "9.0.2"
-              cabal:
-                version: "3.14.2.0"
-                project-file: "cabal.project"
-                extra-args: ""
-                extra-args-test-golden: ""
-          # Build with GHC 8.10.7
-          - os:
-              name: Linux
-              type: ubuntu-latest
-            haskell:
-              ghc:
-                version: "8.10.7"
               cabal:
                 version: "3.14.2.0"
                 project-file: "cabal.project"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## v0.25
 
+### General
+
+* Removed support for GHC 8.10 and 9.0 and added support for GHC 9.10 and 9.12.
+
 ### Loss backend
 
 * Fixed a bug where the compiler would loop infinitely on certain specifications.

--- a/cabal.project
+++ b/cabal.project
@@ -6,14 +6,6 @@
 --   Any configuration that is shared by all configurations of Vehicle should
 --   be put into `cabal.project.config`.
 --
---   Each supported GHC version has its own version of this file, which is
---   named `cabal.project.ghc-X.Y`. If no changes are needed, that file simply
---   imports this file.
---
---   For each project file `cabal.project.ghc-X.Y` there is a corresponding
---   freeze file `cabal.project.ghc-X.Y.freeze` which records the package
---   versions and flags with which the project is known to compile.
---
 -- See: https://cabal.readthedocs.io/en/latest/cabal-project.html
 
 import: cabal.project.config

--- a/tasty-golden-executable/tasty-golden-executable.cabal
+++ b/tasty-golden-executable/tasty-golden-executable.cabal
@@ -9,7 +9,12 @@ copyright:       © Wen Kokke
 category:        Testing
 build-type:      Simple
 tested-with:
-  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.5 || ==9.8.4
+  GHC ==9.2.8
+   || ==9.4.8
+   || ==9.6.5
+   || ==9.8.4
+   || ==9.10.3
+   || ==9.12.2
 
 extra-doc-files: CHANGELOG.md
 

--- a/vehicle-syntax/vehicle-syntax.cabal
+++ b/vehicle-syntax/vehicle-syntax.cabal
@@ -13,7 +13,12 @@ license:            BSD-3-Clause
 license-file:       LICENSE
 build-type:         Custom
 tested-with:
-  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.5 || ==9.8.4
+  GHC ==9.2.8
+   || ==9.4.8
+   || ==9.6.5
+   || ==9.8.4
+   || ==9.10.3
+   || ==9.12.2
 
 extra-source-files:
   src/Vehicle/Syntax/External.cf

--- a/vehicle/vehicle.cabal
+++ b/vehicle/vehicle.cabal
@@ -13,7 +13,12 @@ license:            BSD-3-Clause
 license-file:       LICENSE
 build-type:         Simple
 tested-with:
-  GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.5 || ==9.8.4
+  GHC ==9.2.8
+   || ==9.4.8
+   || ==9.6.5
+   || ==9.8.4
+   || ==9.10.3
+   || ==9.12.2
 
 -- Standard library
 -- Test files


### PR DESCRIPTION
Have various libraries I would like to use that don't support 8.* (e.g. see #1023)