### PR TITLE
Fix #1086 by fixing reduction of blocking variables in loss backend.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 
 * Fixed a bug where the compiler where if a propery involved multiple quantifiers, the compiler woudl sometimes report that one of them was unbounded.
 
+* Fixed a bug where bounds on sub-indices of a tensor weren't being detected properly.
+
 ## v0.24
 
 ### Loss backend

--- a/vehicle/src/Vehicle/Backend/Loss/Domain.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Domain.hs
@@ -5,9 +5,7 @@ where
 
 import Control.Monad (foldM, forM)
 import Control.Monad.Except (MonadError (..), runExceptT)
-import Control.Monad.State (MonadState (..), evalStateT)
 import Data.Bifunctor (Bifunctor (..))
-import Data.Coerce (coerce)
 import Data.Foldable (foldrM)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
@@ -442,13 +440,13 @@ compileComparison (op, args)
         Left err -> case err of
           ImpureButProgress value -> compileBool value
           ContainsNetwork ident -> do
-            logDebug MaxDetail $ "rejected-assertion" <+> parens ("contains" <+> quotePretty ident)
+            logDebug MaxDetail $ "invalid-bound" <+> parens ("contains" <+> quotePretty ident)
             compileNonBoundComparison (op, args)
           ContainsMultipleUserVariablesFromSameSlice _parent var1 var2 -> do
             logDebugM MaxDetail $ do
               var1Doc <- squotes <$> prettyFriendlyInCtx var1
               var2Doc <- squotes <$> prettyFriendlyInCtx var2
-              return $ "rejected-assertion" <+> parens ("contains" <+> var1Doc <+> "and" <+> var2Doc <+> "from same tensor")
+              return $ "invalid-bound" <+> parens ("contains" <+> var1Doc <+> "and" <+> var2Doc <+> "from same tensor")
             compileNonBoundComparison (op, args)
         Right (TensorOp2Args dims e1 e2) -> do
           lossDims <- convertDims dims
@@ -458,9 +456,19 @@ compileComparison (op, args)
             comparisonToAssertion op linX linY
 
           case errorOrAssertion of
-            Left _uncompilable -> compileNonBoundComparison (op, args)
-            Right (Left trivialValue) -> return $ Trivial trivialValue
-            Right (Right assertion) -> return $ NonTrivial $ singletonConstrainedPartition assertion
+            Left uncompilable -> do
+              logDebugM MaxDetail $ do
+                doc <- prettyFriendlyInCtx uncompilable
+                return $ "invalid-bound" <+> parens ("unable to unblock" <+> doc)
+              compileNonBoundComparison (op, args)
+            Right (Left trivialValue) -> do
+              logDebug MaxDetail $ "invalid-bound" <+> parens ("trivially" <+> pretty trivialValue)
+              return $ Trivial trivialValue
+            Right (Right assertion) -> do
+              logDebugM MaxDetail $ do
+                doc <- prettyFriendlyInCtx assertion
+                return $ "valid-bound: " <+> doc
+              return $ NonTrivial $ singletonConstrainedPartition assertion
 
 compileNonBoundComparison ::
   (MonadDomain m) =>
@@ -508,7 +516,6 @@ data PurificationError
 type MonadPurifyAssertion m =
   ( MonadPurify m,
     MonadError PurificationError m,
-    MonadState (Map UserTensorVariable UserSliceVariable) m,
     MonadReadableTensorBoundContext m
   )
 
@@ -519,14 +526,13 @@ purifyAssertion ::
   m (Either PurificationError (TensorOp2Args (Value Builtin)))
 purifyAssertion op args = do
   callDepth <- getCallDepth
-  runExceptT $
-    flip evalStateT mempty $ do
-      errorOrResult <- tryPurifyAssertion purifyUnblockingActions op args
-      case errorOrResult of
-        Left err -> do
-          setCallDepth callDepth
-          throwError $ ImpureButProgress err
-        Right value -> return value
+  runExceptT $ do
+    errorOrResult <- tryPurifyAssertion purifyUnblockingActions op args
+    case errorOrResult of
+      Left err -> do
+        setCallDepth callDepth
+        throwError $ ImpureButProgress err
+      Right value -> return value
 
 purifyUnblockingActions :: (MonadPurifyAssertion m) => UnblockingActions m
 purifyUnblockingActions =
@@ -543,16 +549,7 @@ purifyBoundVar lv = do
   (_, maybeUserVars) <- lookupVariableInNestedCtx lv
   case maybeUserVars of
     Nothing -> return $ VBoundVar lv []
-    Just (tensorVar, sliceVar) -> do
-      let userTensorVar = coerce $ toLv tensorVar
-      let userSliceVar = coerce sliceVar
-      seenUserVars <- get
-      let (maybeExistingVar, newMap) = Map.insertLookupWithKey (\_ n _ -> n) userTensorVar userSliceVar seenUserVars
-      case maybeExistingVar of
-        Just other -> throwError $ ContainsMultipleUserVariablesFromSameSlice userTensorVar userSliceVar other
-        Nothing -> do
-          put newMap
-          return $ VBoundVar lv []
+    Just (_tensorVar, sliceVar) -> replaceTensorVariableWithStackedChildren sliceVar
 
 --------------------------------------------------------------------------------
 -- Compiling linear expressions

--- a/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination.hs
+++ b/vehicle/src/Vehicle/Backend/Solver/UserVariableElimination.hs
@@ -31,9 +31,8 @@ import Vehicle.Data.Code.Interface
 import Vehicle.Data.Code.TypedView
 import Vehicle.Data.Code.Value
 import Vehicle.Data.MaybeTrivial
-import Vehicle.Data.Tensor (HasShape (..))
 import Vehicle.Data.Variable.Bound.Context.Name (getNameContext, prettyFriendlyInCtx)
-import Vehicle.Data.Variable.Bound.Context.Tensor.Class
+import Vehicle.Data.Variable.Bound.Context.Tensor (replaceTensorVariableWithStackedChildren)
 import Vehicle.Data.Variable.Bound.Level
 import Vehicle.Verify.Core (inputShape)
 import Vehicle.Verify.QueryFormat (QueryFormat (..), supportsStrictInequalities)
@@ -188,21 +187,8 @@ unblockQuantifiedBoundVar ::
   (MonadQuantifierBody m) =>
   Lv ->
   m (Value Builtin)
-unblockQuantifiedBoundVar lv = do
-  nestedVar <- lookupNestedSliceVariable (SliceVariable lv)
-  case (childVariablesOf nestedVar, shapeOf nestedVar) of
-    (Nothing, []) -> return $ VBoundVar lv []
-    (Just childVars, d : ds) ->
-      return $
-        fromRatTensorValue $
-          VRatStackTensor $
-            StackTensorArgs
-              { stackType = IRatType,
-                stackFirstDim = INatLiteral d,
-                stackRemainingDims = mkDims ds,
-                stackElements = flip map childVars $ \v -> VBoundVar (toLv v) []
-              }
-    _ -> developerError "mismatched children and shape"
+unblockQuantifiedBoundVar lv =
+  replaceTensorVariableWithStackedChildren (SliceVariable lv)
 
 unblockNetworkApplication ::
   (MonadQuantifierBody m) =>

--- a/vehicle/src/Vehicle/Data/Variable/Bound/Context/Tensor.hs
+++ b/vehicle/src/Vehicle/Data/Variable/Bound/Context/Tensor.hs
@@ -6,7 +6,6 @@ where
 
 import Vehicle.Data.Builtin.Standard.Core
 import Vehicle.Data.Code.Interface
-import Vehicle.Data.Code.Interface.Args
 import Vehicle.Data.Code.TypedView
 import Vehicle.Data.Code.Value
 import Vehicle.Data.Tensor (HasShape (..))

--- a/vehicle/src/Vehicle/Data/Variable/Bound/Context/Tensor.hs
+++ b/vehicle/src/Vehicle/Data/Variable/Bound/Context/Tensor.hs
@@ -1,11 +1,44 @@
 module Vehicle.Data.Variable.Bound.Context.Tensor
   ( module Export,
+    replaceTensorVariableWithStackedChildren,
   )
 where
 
+import Vehicle.Data.Builtin.Standard.Core
+import Vehicle.Data.Code.Interface
+import Vehicle.Data.Code.Interface.Args
+import Vehicle.Data.Code.TypedView
+import Vehicle.Data.Code.Value
+import Vehicle.Data.Tensor (HasShape (..))
 import Vehicle.Data.Variable.Bound.Context.Name.Class as Export
 import Vehicle.Data.Variable.Bound.Context.Name.Core as Export
 import Vehicle.Data.Variable.Bound.Context.Name.Instance as Export
 import Vehicle.Data.Variable.Bound.Context.Tensor.Class as Export
 import Vehicle.Data.Variable.Bound.Context.Tensor.Core as Export
 import Vehicle.Data.Variable.Bound.Context.Tensor.Instance as Export
+import Vehicle.Data.Variable.Bound.Level
+import Vehicle.Prelude (developerError)
+
+-- | Given a variable `x`:
+--   - if not a tensor variable errors
+--   - if an element variable then returns `x`
+--   - if not an element variable returns `[x!0, x!1, ..., x!n]
+replaceTensorVariableWithStackedChildren ::
+  (MonadReadableTensorBoundContext m) =>
+  SliceVariable ->
+  m (Value Builtin)
+replaceTensorVariableWithStackedChildren var = do
+  nestedVar <- lookupNestedSliceVariable var
+  case (childVariablesOf nestedVar, shapeOf nestedVar) of
+    (Nothing, []) -> return $ VBoundVar (toLv var) []
+    (Just childVars, d : ds) ->
+      return $
+        fromRatTensorValue $
+          VRatStackTensor $
+            StackTensorArgs
+              { stackType = IRatType,
+                stackFirstDim = INatLiteral d,
+                stackRemainingDims = mkDims ds,
+                stackElements = flip map childVars $ \v -> VBoundVar (toLv v) []
+              }
+    _ -> developerError "mismatched children and shape"

--- a/vehicle/src/Vehicle/Data/Variable/Bound/Context/Tensor/Core.hs
+++ b/vehicle/src/Vehicle/Data/Variable/Bound/Context/Tensor/Core.hs
@@ -35,6 +35,9 @@ originalCtx = fmap fst . nestedVariableCtx
 emptyNestedCtx :: NestedTensorVariableCtx
 emptyNestedCtx = NestedTensorVariableCtx mempty mempty
 
+-- | Given a set of variables in the extended tensor context,
+-- returns a pair consisting of the Lv of the variable in the original context
+-- and the top-level tensor variable if the variable is a tensor variable.
 findCorrespondingVariableInOriginalCtx ::
   (VariableLike var) =>
   NestedTensorVariableCtx ->

--- a/vehicle/tests/golden/compile/issue1086/Loss.vcl.golden
+++ b/vehicle/tests/golden/compile/issue1086/Loss.vcl.golden
@@ -1,0 +1,3 @@
+@property;
+p : (Tensor Real -> Tensor Real) -> Tensor Real;
+p = \ f -> [ 1.0 ] / search[x] (\ e -> \ xs -> reduceMul e xs) [1] [ 0.0 ] [ 1.0 ] (\ x -> max 0.0 (f x))

--- a/vehicle/tests/golden/compile/issue1086/spec.vcl
+++ b/vehicle/tests/golden/compile/issue1086/spec.vcl
@@ -1,0 +1,6 @@
+@network
+f : Tensor Real [1] -> Real
+
+@property
+p : Bool
+p = forall x . (0 <= x ! 0 <= 1) => f x >= 0

--- a/vehicle/tests/golden/compile/issue1086/test.json
+++ b/vehicle/tests/golden/compile/issue1086/test.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Loss",
+    "run": "vehicle compile loss -s spec.vcl -l DL2Loss -o Loss.vcl",
+    "needs": ["spec.vcl"],
+    "produces": ["Loss.vcl"]
+  }
+]


### PR DESCRIPTION
An alternative fix to @ggustavs bug #1086 from the one proposed in #1084. In particular, expressions of the form `x ! 0` should be handled by the purification step before it gets to `compileLinearExpr`.