### PR TITLE
Add missing operators and backend support badges to docs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## Next release
 
+### General
+
+* Improved language documentation to show per-backend support.
+
+* Added undocumented operations to language documentation.
+
 ### Loss backend
 
 * Added the ability to declare custom Differentiable Logics internally in Vehicle (see documentation for details).

--- a/docs/_static/badge.css
+++ b/docs/_static/badge.css
@@ -1,0 +1,19 @@
+/* Remove vertical margins from line-blocks used to stack backend badges in table cells */
+td .line-block {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+}
+
+/* Keep badges at their designed pixel size in tables (RTD theme sets img max-width: 100%). */
+td .line-block img {
+    max-width: 198px !important;
+    width: 198px !important;
+    height: 20px;
+}
+
+/* Single-image cells (e.g. backendall_full) are wrapped in a paragraph, not a line-block. */
+td > p > img {
+    max-width: 198px !important;
+    width: 198px !important;
+    height: 20px;
+}

--- a/docs/_static/badge.css
+++ b/docs/_static/badge.css
@@ -12,7 +12,7 @@ td .line-block img {
 }
 
 /* Single-image cells (e.g. backendall_full) are wrapped in a paragraph, not a line-block. */
-td > p > img {
+ td > p > img.backend-badge {
     max-width: 198px !important;
     width: 198px !important;
     height: 20px;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,7 +150,11 @@ def _svg_badge_data_uri(
 
 
 def _image_substitution(name: str, url: str, alt_text: str) -> str:
-    return f".. |{name}| image:: {url}\n   :alt: {alt_text}\n"
+    return (
+        f".. |{name}| image:: {url}\n"
+        f"   :alt: {alt_text}\n"
+        "   :class: backend-badge\n"
+    )
 
 
 def _backend_status_substitutions() -> str:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@
 
 import os
 import sys
+from html import escape
+from urllib.parse import quote
 
 sys.path.insert(
     0,
@@ -80,6 +82,129 @@ myst_heading_anchors = 5
 # -- Options for HTML output
 
 html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+html_css_files = ["badge.css"]
+
+# -- Global RST substitutions -----------------------------------------------
+
+_BACKENDS = {
+    "all": {"label": "All backends"},
+    "loss": {"label": "Training"},
+    "verification": {"label": "Verification"},
+    "agda": {"label": "Agda"},
+    "rocq": {"label": "Rocq"},
+    "imandra": {"label": "Imandra"},
+    "isabelle": {"label": "Isabelle"},
+}
+
+_STATUSES = {
+    "full": {"label": "full support", "color": "#2ea043", "alt": "fully supported"},
+    "part": {"label": "restricted", "color": "#ff9900", "alt": "partially supported"},
+    "easy": {
+        "label": "no support",
+        "color": "#cc1414",
+        "alt": "not supported but easy to add",
+    },
+}
+
+
+def _svg_badge_data_uri(
+    label: str,
+    message: str,
+    color: str,
+    left_width: int = 96,
+    right_width: int = 102,
+    height: int = 20,
+) -> str:
+    """Create a fixed-width two-segment badge as an SVG data URI."""
+    total_width = left_width + right_width
+    label_x = left_width / 2
+    message_x = left_width + (right_width / 2)
+    text_y = height / 2
+    rx = 4
+
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}" height="{height}" '
+        f'viewBox="0 0 {total_width} {height}" '
+        f'role="img" aria-label="{escape(label)}: {escape(message)}">'
+        "<defs>"
+        f'<clipPath id="r"><rect width="{total_width}" height="{height}" rx="{rx}"/></clipPath>'
+        '<linearGradient id="s" x2="0" y2="1">'
+        '<stop offset="0" stop-color="#fff" stop-opacity=".15"/>'
+        '<stop offset="1" stop-opacity=".15"/>'
+        "</linearGradient>"
+        "</defs>"
+        '<g clip-path="url(#r)">'
+        f'<rect width="{left_width}" height="{height}" fill="#555"/>'
+        f'<rect x="{left_width}" width="{right_width}" height="{height}" fill="{color}"/>'
+        f'<rect width="{total_width}" height="{height}" fill="url(#s)"/>'
+        "</g>"
+        f'<g fill="#fff" text-anchor="middle" '
+        'font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="12" dominant-baseline="middle">'
+        f'<text x="{label_x}" y="{text_y}">{escape(label)}</text>'
+        f'<text x="{message_x}" y="{text_y}">{escape(message)}</text>'
+        "</g>"
+        "</svg>"
+    )
+    return f"data:image/svg+xml;utf8,{quote(svg)}"
+
+
+def _image_substitution(name: str, url: str, alt_text: str) -> str:
+    return f".. |{name}| image:: {url}\n   :alt: {alt_text}\n"
+
+
+def _backend_status_substitutions() -> str:
+    lines: list[str] = []
+    for backend_key, backend in _BACKENDS.items():
+        for status_key, status in _STATUSES.items():
+            sub_name = f"backend{backend_key}_{status_key}"
+            url = _svg_badge_data_uri(
+                label=backend["label"],
+                message=status["label"],
+                color=status["color"],
+            )
+            alt_text = f"{backend['label']} {status['alt']}"
+            lines.append(_image_substitution(sub_name, url, alt_text))
+    return "\n".join(lines)
+
+
+def _status_legend_substitutions() -> str:
+    lines: list[str] = []
+    for status_key, status in _STATUSES.items():
+        sub_name = f"status_{status_key}"
+        url = _svg_badge_data_uri(
+            label="status",
+            message=status["label"],
+            color=status["color"],
+            left_width=62,
+            right_width=102,
+        )
+        lines.append(_image_substitution(sub_name, url, status["alt"].capitalize()))
+
+    # Backwards-compatible alias used in docs/language/index.rst.
+    part = _STATUSES["part"]
+    lines.append(
+        _image_substitution(
+            "status_partial",
+            _svg_badge_data_uri(
+                label="status",
+                message=part["label"],
+                color=part["color"],
+                left_width=62,
+                right_width=102,
+            ),
+            part["alt"].capitalize(),
+        )
+    )
+    return "\n".join(lines)
+
+
+rst_epilog = "\n\n".join(
+    [
+        _backend_status_substitutions(),
+        _status_legend_substitutions(),
+    ]
+)
 
 # -- Options for EPUB output
 epub_show_urls = "footnote"

--- a/docs/language/arithmetic.rst
+++ b/docs/language/arithmetic.rst
@@ -14,49 +14,34 @@ The type of natural numbers is written as ``Nat``.
 The available operations over naturals are:
 
 .. list-table::
-   :widths: 25 15 40 20
+   :widths: 18 14 35 33
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
-   * - Addition
-     - :code:`+`
-     - :code:`Nat -> Nat -> Nat`
+     - Support
+   * - Add
      - :code:`x + y`
-   * - Multiplication
-     - :code:`*`
-     - :code:`Nat -> Nat -> Nat`
+     - :code:`Nat → Nat → Nat`
+     - |backendall_full|
+   * - Multiply
      - :code:`x * y`
-   * - Division
-     - :code:`/`
-     - :code:`Nat -> Nat -> Real`
+     - :code:`Nat → Nat → Nat`
+     - |backendall_full|
+   * - Divide
      - :code:`x / y`
-   * - Less than or equal
-     - :code:`<=`
-     - :code:`Nat -> Nat -> Bool`
-     - :code:`x <= y`
-   * - Less than
-     - :code:`<`
-     - :code:`Nat -> Nat -> Bool`
-     - :code:`x < y`
-   * - Greater than or equal
-     - :code:`>=`
-     - :code:`Nat -> Nat -> Bool`
-     - :code:`x >= y`
-   * - Greater than
-     - :code:`>`
-     - :code:`Nat -> Nat -> Bool`
-     - :code:`x >= y`
-   * - Min
-     - :code:`min`
-     - :code:`Nat -> Nat -> Bool`
-     - :code:`min x y`
-   * - Max
-     - :code:`max`
-     - :code:`Nat -> Nat -> Bool`
-     - :code:`max x y`
+     - :code:`Nat → Nat → Real`
+     - |backendall_full|
+   * - Compare
+     - | ``x < y``
+       | ``x > y``
+       | ``x <= y``
+       | ``x >= y``
+       | ``x == y``
+       | ``x != y``
+     - ``Nat → Nat → Bool``
+     - |backendall_full|
 
 Note that inequalities can be chained, so that ``x < y <= z`` will be
 expanded to ``x < y and y <= z``.
@@ -69,57 +54,60 @@ The type of real numbers is written as ``Real``.
 The available operations over reals are:
 
 .. list-table::
-   :widths: 25 15 40 20
+   :widths: 18 14 35 33
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
-   * - Addition
-     - :code:`+`
-     - :code:`Real -> Real -> Real`
+     - Support
+   * - Add
      - :code:`x + y`
-   * - Subtraction
-     - :code:`-`
-     - :code:`Real -> Real -> Real`
+     - :code:`Real → Real → Real`
+     - |backendall_full|
+   * - Subtract
      - :code:`x - y`
-   * - Multiplication
-     - :code:`*`
-     - :code:`Real -> Real -> Real`
+     - :code:`Real → Real → Real`
+     - |backendall_full|
+   * - Multiply
      - :code:`x * y`
-   * - Division
-     - :code:`/`
-     - :code:`Real -> Real -> Real`
+     - :code:`Real → Real → Real`
+     - | |backendloss_full|
+       | |backendverification_part| (:ref:`⤴ <verifying-linearity-limitations>`)
+       | |backendagda_full|
+       | |backendrocq_full|
+       | |backendimandra_full|
+       | |backendisabelle_full|
+   * - Divide
      - :code:`x / y`
+     - :code:`Real → Real → Real`
+     - | |backendloss_full|
+       | |backendverification_part| (:ref:`⤴ <verifying-linearity-limitations>`)
+       | |backendagda_full|
+       | |backendrocq_full|
+       | |backendimandra_full|
+       | |backendisabelle_full|
    * - Negation
-     - :code:`-`
-     - :code:`Real -> Real`
      - :code:`- y`
-   * - Less than or equal
-     - :code:`<=`
-     - :code:`Real -> Real -> Bool`
-     - :code:`x <= y`
-   * - Less than
-     - :code:`<`
-     - :code:`Real -> Real -> Bool`
-     - :code:`x < y`
-   * - Greater than or equal
-     - :code:`>=`
-     - :code:`Real -> Real -> Bool`
-     - :code:`x >= y`
-   * - Greater than
-     - :code:`>`
-     - :code:`Real -> Real -> Bool`
-     - :code:`x >= y`
+     - :code:`Real → Real`
+     - |backendall_full|
+   * - Compare
+     - | ``x < y``
+       | ``x > y``
+       | ``x <= y``
+       | ``x >= y``
+       | ``x == y``
+       | ``x != y``
+     - ``Real → Real → Bool``
+     - |backendall_full|
    * - Min
-     - :code:`min`
-     - :code:`Real -> Real -> Bool`
      - :code:`min x y`
+     - :code:`Real → Real → Bool`
+     - |backendall_full|
    * - Max
-     - :code:`max`
-     - :code:`Real -> Real -> Bool`
      - :code:`max x y`
+     - :code:`Real → Real → Bool`
+     - |backendall_full|
 
 
 .. note::

--- a/docs/language/arithmetic.rst
+++ b/docs/language/arithmetic.rst
@@ -102,11 +102,11 @@ The available operations over reals are:
      - |backendall_full|
    * - Min
      - :code:`min x y`
-     - :code:`Real → Real → Bool`
+     - :code:`Real → Real → Real`
      - |backendall_full|
    * - Max
      - :code:`max x y`
-     - :code:`Real → Real → Bool`
+     - :code:`Real → Real → Real`
      - |backendall_full|
 
 

--- a/docs/language/datasets.rst
+++ b/docs/language/datasets.rst
@@ -1,6 +1,8 @@
 Datasets
 ========
 
+|backendall_full|
+
 .. contents::
    :depth: 1
    :local:

--- a/docs/language/differentiable-logics.rst
+++ b/docs/language/differentiable-logics.rst
@@ -1,6 +1,8 @@
 Differentiable Logics
 =====================
 
+|backendall_full|
+
 .. contents::
    :depth: 1
    :local:

--- a/docs/language/functions.rst
+++ b/docs/language/functions.rst
@@ -1,6 +1,8 @@
 Functions
 =========
 
+|backendall_full|
+
 .. contents::
    :depth: 1
    :local:

--- a/docs/language/lists.rst
+++ b/docs/language/lists.rst
@@ -20,21 +20,21 @@ Operations
 The following operations over lists are currently supported:
 
 .. list-table::
-   :widths: 15 12 43 30
+   :widths: 14 17 37 32
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
+     - Support
    * - Map
-     - :code:`map`
-     - :code:`(A -> B) -> List A -> List B`
-     - :code:`map (\\x -> x + 1) xs`
+     - :code:`map f xs`
+     - :code:`(A → B) → List A → List B`
+     - |backendall_full|
    * - Fold
-     - :code:`fold`
-     - :code:`(A -> B -> B) -> B -> List A -> B`
-     - :code:`fold (\\x y -> x + y) 0 xs`
+     - :code:`fold f e xs`
+     - :code:`(A → B → B) → B → List A → B`
+     - |backendall_full|
 
 Absence of a lookup function
 ----------------------------

--- a/docs/language/logic.rst
+++ b/docs/language/logic.rst
@@ -14,42 +14,49 @@ Like many languages, Vehicle has booleans. The type of boolean values is
 The available operations over booleans are:
 
 .. list-table::
-   :widths: 25 15 40 20
+   :widths: 17 24 26 33
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
+     - Support
    * - Conjunction
-     - :code:`and`
-     - :code:`Bool -> Bool -> Bool`
      - :code:`x and y`
+     - :code:`Bool → Bool → Bool`
+     - |backendall_full|
    * - Disjunction
-     - :code:`or`
-     - :code:`Bool -> Bool -> Bool`
      - :code:`x or y`
+     - :code:`Bool → Bool → Bool`
+     - |backendall_full|
    * - Implication
-     - :code:`=>`
-     - :code:`Bool -> Bool -> Bool`
      - :code:`x => y`
+     - :code:`Bool → Bool → Bool`
+     - |backendall_full|
    * - Negation
-     - :code:`not`
-     - :code:`Bool -> Bool`
      - :code:`not x`
+     - :code:`Bool → Bool`
+     - |backendall_full|
+   * - Conditional
+     - :code:`if x then y else z`
+     - :code:`Bool → A → A → A`
+     - | |backendloss_part|
+       | |backendverification_full|
+       | |backendagda_full|
+       | |backendrocq_full|
+       | |backendimandra_full|
+       | |backendisabelle_full|
 
 Conditionals
 ------------
 
-Conditional statements are written using the syntax :code:`if .. then .. else ..`
-and have type :code:`Bool -> A -> A -> A` for any type :code:`A`.
-For example:
+Conditional statements are written as follows:
 
 .. code-block:: agda
 
    if f x > 0 then x < 0 else x > 0
 
-In a functional language like Vehicle (and unlike in imperative languages)
+In a functional language like Vehicle
 all statements must return a value. Therefore it is not possible to
 omit the :code:`else` branch when writing a conditional.
 
@@ -65,7 +72,7 @@ Equality
 Two expressions of the same type can be tested for equality/inequality
 using the :code:`==` and :code:`!=` operators respectively.
 
-The type of these operators are :code:`A -> A -> Bool` where :code:`A` can be any
+The type of these operators are :code:`A → A → Bool` where :code:`A` can be any
 of the following types:
 
 - :code:`Bool`, :code:`Nat`, :code:`Int`, :code:`Real`.

--- a/docs/language/networks.rst
+++ b/docs/language/networks.rst
@@ -1,6 +1,8 @@
 Networks
 ========
 
+|backendall_full|
+
 .. contents::
    :depth: 1
    :local:

--- a/docs/language/parameters.rst
+++ b/docs/language/parameters.rst
@@ -1,6 +1,8 @@
 Parameters
 ==========
 
+|backendall_full|
+
 .. contents::
    :depth: 1
    :local:
@@ -11,8 +13,8 @@ the value may not be known ahead of time, or you might want to reuse the
 same spec with multiple different values e.g. assign different values
 for epsilon in a robustness specification.
 
-Basics
-------
+Explicit Parameters
+-------------------
 
 Parameters can be declared using the ``@parameter`` annotation as follows:
 
@@ -28,7 +30,7 @@ Similar to networks and datasets, parameters are passed in at compile time via
 the :code:`--parameter` command line option. For example setting :code:`epsilon` to
 the value :code:`0.1` can be achieved using :code:`--parameter epsilon:0.1`.
 
-Inferable parameters
+Inferable Parameters
 --------------------
 
 Sometimes the value of the parameter can be inferred from other parts of the

--- a/docs/language/properties.rst
+++ b/docs/language/properties.rst
@@ -8,6 +8,8 @@ Properties
 Single properties
 -----------------
 
+|backendall_full|
+
 A property is any self-contained statement that you wish to check using Vehicle.
 Properties are declared by annotating declarations with the ``@property`` annotation:
 
@@ -23,6 +25,13 @@ element of the ``Vector`` or ``Tensor`` individually.
 
 Multiple properties
 -------------------
+
+| |backendloss_easy|
+| |backendverification_full|
+| |backendagda_full|
+| |backendrocq_full|
+| |backendimandra_full|
+| |backendisabelle_full|
 
 Vehicle also supports marking vectors or tensors of Booleans as properties.
 This is particularly useful when checking that a property holds over

--- a/docs/language/quantifiers.rst
+++ b/docs/language/quantifiers.rst
@@ -8,6 +8,13 @@ Quantifiers
 Quantifying over infinite sets
 ------------------------------
 
+| |backendloss_full|
+| |backendverification_part| (:ref:`⤴ <verifying-quantifier-limitations>`)
+| |backendagda_full|
+| |backendrocq_full|
+| |backendimandra_full|
+| |backendisabelle_full|
+
 One of the main advantages of Vehicle compared to a testing framework is
 that it can be used to state and prove specifications that describe the
 network's behaviour over an infinite set of values.
@@ -69,12 +76,14 @@ with an implication as follows:
 Quantifying over finite sets
 ----------------------------
 
+|backendall_full|
+
 While most specifications will quantify over at least one variable
 with an infinite domain, sometimes one might also want to quantify
 over a finite set of values. There are multiple ways of doing this:
 
-Quantifying over an ``Index`` type
-++++++++++++++++++++++++++++++++++
+Quantifying over an ``Index``
++++++++++++++++++++++++++++++
 
 The first approach is to quantify over a variable with the ``Index``
 type. For example:
@@ -95,8 +104,8 @@ The type annotation ``Index 3`` on the quantified variable ``i`` is
 included for clarity but are not need in practice as it can be inferred
 by the compiler.
 
-The ``in`` keyword
-++++++++++++++++++
+Quantifying over a collection
++++++++++++++++++++++++++++++
 
 Alternatively quantifiers can be modified with the ``in`` keyword to
 quantify over all the values contained within a ``List``, ``Vector`` or ``Tensor``:

--- a/docs/language/records.rst
+++ b/docs/language/records.rst
@@ -8,6 +8,13 @@ Records
 Basics
 ------
 
+| |backendloss_easy|
+| |backendverification_full|
+| |backendagda_full|
+| |backendrocq_full|
+| |backendimandra_full|
+| |backendisabelle_full|
+
 Records allow you to group logical sets of parameters to together.
 The syntax for defining a record is as follows:
 

--- a/docs/language/tensors.rst
+++ b/docs/language/tensors.rst
@@ -66,57 +66,147 @@ Operations
 The following operations over tensors are currently supported:
 
 .. list-table::
-   :widths: 15 10 30 15 30
+   :widths: 11 22 34 33
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
-     - Description
+     - Support
    * - Lookup
-     - ``!``
-     - ``Tensor A [d, ds] -> Index d -> Tensor A ds``
-     - ``t ! i``
-     - Extract the value at a given index of the tensor.
+     - ``e ! i``
+     - | ``Tensor A [d, ds] →``
+       | ``Index d →``
+       | ``Tensor A ds``
+     - |backendall_full|
    * - Foreach
-     - ``!``
-     - ``(Index d -> Tensor A ds) -> Tensor A [d, ds]``
-     - ``foreach i . 0``
-     - Constructs a new tensor by specifying each outermost row in terms of the row's index.
+     - ``foreach i . e``
+     - | ``(Index d → Tensor A ds) →``
+       | ``Tensor A [d, ds]``
+     - | |backendloss_part|
+       | |backendverification_full|
+       | |backendagda_full|
+       | |backendrocq_full|
+       | |backendimandra_full|
+       | |backendisabelle_full|
    * - Comparisons
-     - | ``<=``
-       | ``<``
-       | ``>=``
-       | ``>``
-       | ``==``
-       | ``!=``
-     - ``Tensor A ds -> Tensor A ds -> Bool``
-     - ``t1 <= t2``
-     - Check that all pairs of elements in the tensor satisfy the comparison.
-   * - Pointwise comparisons
-     - | ``.<=``
-       | ``.<``
-       | ``.>=``
-       | ``.>``
-       | ``.==``
-       | ``.!=``
-     - ``Tensor A ds -> Tensor A ds -> Tensor Bool ds``
-     - ``t1 .<= t2``
-     - Compare all the elements of the tensor pointwise.
-   * - Pointwise addition
-     - ``+``
-     - ``Tensor A ds -> Tensor A ds -> Tensor A ds``
+     - | ``x < y``
+       | ``x > y``
+       | ``x <= y``
+       | ``x >= y``
+       | ``x == y``
+       | ``x != y``
+     - | ``Tensor A ds →``
+       | ``Tensor A ds →``
+       | ``Bool``
+       | (if ``A`` supports comparisons)
+     - |backendall_full|
+   * - | Pointwise
+       | comparisons
+     - | ``x .< y``
+       | ``x .> y``
+       | ``x .<= y``
+       | ``x .>= y``
+       | ``x .== y``
+       | ``x .!= y``
+     - | ``Tensor A ds →``
+       | ``Tensor A ds →``
+       | ``Tensor A ds``
+       | (if ``A`` supports comparisons)
+     - |backendall_full|
+   * - | Pointwise
+       | and
+     - ``t1 and t2``
+     - | ``Tensor Bool ds →``
+       | ``Tensor Bool ds →``
+       | ``Tensor Bool ds``
+     - |backendall_full|
+   * - | Pointwise
+       | or
+     - ``t1 or t2``
+     - | ``Tensor Bool ds →``
+       | ``Tensor Bool ds →``
+       | ``Tensor Bool ds``
+     - |backendall_full|
+   * - | Reduce
+       | and
+     - ``reduceAnd e t``
+     - | ``Tensor Bool ds →``
+       | ``Bool →``
+       | ``Bool``
+     - |backendall_full|
+   * - | Reduce
+       | or
+     - ``reduceOr e t``
+     - | ``Tensor Bool ds →``
+       | ``Bool →``
+       | ``Bool``
+     - |backendall_full|
+   * - | Pointwise
+       | add
      - ``t1 + t2``
-     - Pointwise add the values in two tensors together. Only valid
-       if addition is defined for the type of elements ``A``.
-   * - Pointwise subtraction
-     - ``-``
-     - ``Tensor A ds -> Tensor A ds -> Tensor A ds``
+     - | ``Tensor A ds →``
+       | ``Tensor A ds →``
+       | ``Tensor A ds``
+       | (if ``A`` supports addition)
+     - |backendall_full|
+   * - | Pointwise
+       | subtract
      - ``t1 - t2``
-     - Pointwise subtract the values in the first tensor from the values
-       in the second. Only valid if subtraction is defined for the type of
-       elements ``A``.
+     - | ``Tensor A ds →``
+       | ``Tensor A ds →``
+       | ``Tensor A ds``
+       | (if ``A`` supports subtraction)
+     - |backendall_full|
+   * - | Pointwise
+       | multiply
+     - ``t1 * t2``
+     - | ``Tensor A ds →``
+       | ``Tensor A ds →``
+       | ``Tensor A ds``
+       | (if ``A`` supports multiplication)
+     - |backendall_full|
+   * - | Pointwise
+       | divide
+     - ``t1 / t2``
+     - | ``Tensor A ds →``
+       | ``Tensor A ds →``
+       | ``Tensor A ds``
+       | (if ``A`` supports division)
+     - |backendall_full|
+   * - | Reduce
+       | add
+     - ``reduceAdd e t``
+     - | ``Tensor A ds →``
+       | ``A →``
+       | ``A``
+       | (if ``A`` supports addition)
+     - |backendall_full|
+   * - | Reduce
+       | multiply
+     - ``reduceMul e t``
+     - | ``Tensor A ds →``
+       | ``A →``
+       | ``A``
+       | (if ``A`` supports multiplication)
+     - |backendall_full|
+   * - | Reduce
+       | min
+     - ``reduceMin e t``
+     - | ``Tensor A ds →``
+       | ``A →``
+       | ``A``
+       | (if ``A`` supports minimums)
+     - |backendall_full|
+   * - | Reduce
+       | max
+     - ``reduceMax e t``
+     - | ``Tensor A ds →``
+       | ``A →``
+       | ``A``
+       | (if ``A`` supports maximums)
+     - |backendall_full|
+
 
 
 Non-constant dimensions
@@ -126,7 +216,6 @@ As with vectors, although the dimensions of a tensor are usually a
 list of constants (e.g. ``[1, 2, 3]``), in practice they can be any
 valid expression of type ``List Nat``.
 For example:
-
   -  ``Tensor Real [2 + d]`` is the type of vectors of length ``2 + d``.
 
   -  ``Tensor Real (10 :: ds)`` is the type of tensors whose first dimension

--- a/docs/language/tensors.rst
+++ b/docs/language/tensors.rst
@@ -111,7 +111,7 @@ The following operations over tensors are currently supported:
        | ``x .!= y``
      - | ``Tensor A ds →``
        | ``Tensor A ds →``
-       | ``Tensor A ds``
+       | ``Tensor Bool ds``
        | (if ``A`` supports comparisons)
      - |backendall_full|
    * - | Pointwise
@@ -131,15 +131,15 @@ The following operations over tensors are currently supported:
    * - | Reduce
        | and
      - ``reduceAnd e t``
-     - | ``Tensor Bool ds →``
-       | ``Bool →``
+     - | ``Bool →``
+       | ``Tensor Bool ds →``
        | ``Bool``
      - |backendall_full|
    * - | Reduce
        | or
      - ``reduceOr e t``
-     - | ``Tensor Bool ds →``
-       | ``Bool →``
+     - | ``Bool →``
+       | ``Tensor Bool ds →``
        | ``Bool``
      - |backendall_full|
    * - | Pointwise
@@ -148,7 +148,7 @@ The following operations over tensors are currently supported:
      - | ``Tensor A ds →``
        | ``Tensor A ds →``
        | ``Tensor A ds``
-       | (if ``A`` supports addition)
+       | (if ``A`` supports ``+``)
      - |backendall_full|
    * - | Pointwise
        | subtract
@@ -156,7 +156,7 @@ The following operations over tensors are currently supported:
      - | ``Tensor A ds →``
        | ``Tensor A ds →``
        | ``Tensor A ds``
-       | (if ``A`` supports subtraction)
+       | (if ``A`` supports ``-``)
      - |backendall_full|
    * - | Pointwise
        | multiply
@@ -164,7 +164,7 @@ The following operations over tensors are currently supported:
      - | ``Tensor A ds →``
        | ``Tensor A ds →``
        | ``Tensor A ds``
-       | (if ``A`` supports multiplication)
+       | (if ``A`` supports ``*``)
      - |backendall_full|
    * - | Pointwise
        | divide
@@ -172,39 +172,31 @@ The following operations over tensors are currently supported:
      - | ``Tensor A ds →``
        | ``Tensor A ds →``
        | ``Tensor A ds``
-       | (if ``A`` supports division)
+       | (if ``A`` supports ``/``)
      - |backendall_full|
    * - | Reduce
        | add
      - ``reduceAdd e t``
-     - | ``Tensor A ds →``
-       | ``A →``
-       | ``A``
-       | (if ``A`` supports addition)
+     - | ``A → Tensor A ds → A``
+       | (if ``A`` supports ``+``)
      - |backendall_full|
    * - | Reduce
        | multiply
      - ``reduceMul e t``
-     - | ``Tensor A ds →``
-       | ``A →``
-       | ``A``
-       | (if ``A`` supports multiplication)
+     - | ``A → Tensor A ds → A``
+       | (if ``A`` supports ``*``)
      - |backendall_full|
    * - | Reduce
        | min
      - ``reduceMin e t``
-     - | ``Tensor A ds →``
-       | ``A →``
-       | ``A``
-       | (if ``A`` supports minimums)
+     - | ``A → Tensor A ds → A``
+       | (if ``A`` supports ``min``)
      - |backendall_full|
    * - | Reduce
        | max
      - ``reduceMax e t``
-     - | ``Tensor A ds →``
-       | ``A →``
-       | ``A``
-       | (if ``A`` supports maximums)
+     - | ``A → Tensor A ds → A``
+       | (if ``A`` supports ``max``)
      - |backendall_full|
 
 

--- a/docs/language/type-synonyms.rst
+++ b/docs/language/type-synonyms.rst
@@ -1,6 +1,8 @@
 Type synonyms
 =============
 
+|backendall_full|
+
 Although Vehicle's builtin types are sufficient to write a wide range
 of specifications, specifications can often be made more readable by using
 the :code:`type` keyword to defining meaningful synonyms for those that are

--- a/docs/language/vectors.rst
+++ b/docs/language/vectors.rst
@@ -85,24 +85,21 @@ Operations
 The following operations over vectors are currently supported:
 
 .. list-table::
-   :widths: 15 12 38 15 20
+   :widths: 14 20 33 33
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
-     - Description
+     - Support
    * - Lookup
-     - :code:`!`
-     - :code:`Vector A d -> Index d -> A`
-     - :code:`v ! i`
-     - Extract the value at a given index of the vector.
+     - :code:`e ! i`
+     - :code:`Vector A d → Index d → A`
+     - |backendall_full|
    * - Foreach
-     - ``!``
-     - ``(Index d -> A) -> Vector A d``
-     - ``foreach i . 0``
-     - Constructs a new vector by specifying each element in terms of its index.
+     - ``foreach i . e``
+     - ``(Index d → A) → Vector A d``
+     - |backendall_full|
 
 Indexing
 --------
@@ -142,37 +139,22 @@ results in ``7`` which is not a member of ``Index 5``. Consequently
 the set of operations supported by ``Index`` types is extremely limited:
 
 .. list-table::
-   :widths: 25 15 40 20
+   :widths: 17 15 37 33
    :header-rows: 1
 
    * - Operation
-     - Symbol
+     - Syntax
      - Type
-     - Example
-   * - Less than or equal
-     - :code:`<=`
-     - :code:`Index d1 -> Index d2 -> Bool`
-     - :code:`x <= y`
-   * - Less than
-     - :code:`<`
-     - :code:`Index d1 -> Index d2 -> Bool`
-     - :code:`x < y`
-   * - Greater than or equal
-     - :code:`>=`
-     - :code:`Index d1 -> Index d2 -> Bool`
-     - :code:`x >= y`
-   * - Greater than
-     - :code:`>`
-     - :code:`Index d1 -> Index d2 -> Bool`
-     - :code:`x >= y`
-   * - Min
-     - :code:`min`
-     - :code:`Index d1 -> Index d2 -> Bool`
-     - :code:`min x y`
-   * - Max
-     - :code:`max`
-     - :code:`Index d1 -> Index d2 -> Bool`
-     - :code:`max x y`
+     - Support
+   * - Comparisons
+     - | ``x < y``
+       | ``x > y``
+       | ``x <= y``
+       | ``x >= y``
+       | ``x == y``
+       | ``x != y``
+     - :code:`Index d1 → Index d2 → Bool`
+     - |backendall_full|
 
 Non-constant sizes
 ------------------

--- a/docs/verifying.rst
+++ b/docs/verifying.rst
@@ -305,6 +305,8 @@ Limitations of verification
 As you might expect, verification is a very hard problem. Therefore there are
 several limitations that users should be aware of.
 
+.. _verifying-linearity-limitations:
+
 Linearity
 +++++++++
 
@@ -331,6 +333,8 @@ value ``x * y``.
 In the case where you do try to verify a non-linear property, Vehicle will use
 its sophisticated auxiliary type-system to help you pinpoint the source of the
 non-linearity.
+
+.. _verifying-quantifier-limitations:
 
 Quantifiers
 +++++++++++

--- a/vehicle/src/Vehicle/Backend/ITP/Agda.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Agda.hs
@@ -358,7 +358,7 @@ compileRecordDecl p ident telescope fields = do
   t' <-
     if null telescope
       then return (compileType 0)
-      else throwError $ UnimplementedFeature p "Compiling parameterised records to Rocq"
+      else throwError $ UnimplementedFeature p "Compiling parameterised records to Agda"
   fs' <- traverseRecordFields compileExpr fields
 
   return $


### PR DESCRIPTION
Adds a bunch of missing operators that have been added to the language but never updated in the documentation. 

We're about to add a load more operations only supported on the loss backend, therefore I've also gone through each language feature adding some shiny backend support badges describing which backends support that feature.

<img width="763" height="464" alt="image" src="https://github.com/user-attachments/assets/726cd375-582b-43e7-afa3-5ade61d05866" />

Note that I rolled our own SVG code for badges as badge services don't seem to support fixing the width of a badge.