### PR TITLE
Remove Wen from Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @MatthewDaggitt and @wenkokke will be requested for
+# @MatthewDaggitt will be requested for
 # review when someone opens a pull request.
-* @MatthewDaggitt @wenkokke
+* @MatthewDaggitt


### PR DESCRIPTION
Stops Wen from being pinged for every review.