### PR TITLE
Improve Python bindings to the List command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,10 @@
 
 * Fixed a bug where networks were recursively unblocked without changes. Backends now control when recursive unblocking happens.
 
+### Python bindings
+
+* The `vehicle_lang.list` command now outputs structured objects rather than raw JSON.
+
 ## v0.24.1
 
 ### General

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,7 @@
 
 ### Python bindings
 
-* The `vehicle_lang.list` command now outputs structured objects rather than raw JSON.
+* Breaking change: the `vehicle_lang.list` Python API now returns structured Python objects instead of a JSON string. Callers relying on the previous `str` output will need to be updated.
 
 ## v0.24.1
 

--- a/vehicle-python/src/vehicle_lang/list/__init__.py
+++ b/vehicle-python/src/vehicle_lang/list/__init__.py
@@ -1,15 +1,110 @@
+import json
+from abc import ABCMeta
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Generic, List, Optional
+
+from typing_extensions import TypeAlias
+from typing_extensions import TypeVar as TypingTypeVar
 
 from .. import session
 from ..error import VehicleError
+from ..loss._ast._decode import JsonValue, decode
+from ..loss._ast._nodes import Provenance
+
+Quantifier: TypeAlias = str
 
 
-def list(specification: str | Path) -> str:
+@dataclass(frozen=True)
+class SharedData:
+    provenance: Provenance
+    name: str
+    typeText: str
+
+
+@dataclass(frozen=True)
+class NetworkSummary:
+    sharedData: SharedData
+
+
+@dataclass(frozen=True)
+class DatasetSummary:
+    sharedData: SharedData
+
+
+@dataclass(frozen=True)
+class ParameterSummary:
+    sharedData: SharedData
+    inferable: bool
+
+
+_T = TypingTypeVar("_T")
+
+
+@dataclass(frozen=True, init=False)
+class MultiPropertyTree(Generic[_T], metaclass=ABCMeta):
+    def __init__(self) -> None:
+        raise TypeError("Cannot instantiate abstract class MultiPropertyTree")
+
+
+@dataclass(frozen=True)
+class SingleProperty(MultiPropertyTree[_T]):
+    value: _T
+
+
+@dataclass(frozen=True)
+class MultiProperty(MultiPropertyTree[_T]):
+    values: list[MultiPropertyTree[_T]]
+
+
+@dataclass(frozen=True)
+class QuantifiedVariableSummary:
+    sharedData: SharedData
+    quantifier: Quantifier
+
+
+@dataclass(frozen=True)
+class PropertySummary:
+    sharedData: SharedData
+    subcomponents: Optional[MultiPropertyTree[list[QuantifiedVariableSummary]]]
+
+
+@dataclass(frozen=True, init=False)
+class ListableEntity(metaclass=ABCMeta):
+    def __init__(self) -> None:
+        raise TypeError("Cannot instantiate abstract class ListableEntity")
+
+
+@dataclass(frozen=True)
+class Network(ListableEntity):
+    summary: NetworkSummary
+
+
+@dataclass(frozen=True)
+class Dataset(ListableEntity):
+    summary: DatasetSummary
+
+
+@dataclass(frozen=True)
+class Parameter(ListableEntity):
+    summary: ParameterSummary
+
+
+@dataclass(frozen=True)
+class Property(ListableEntity):
+    summary: PropertySummary
+
+
+def _decode_listable_entities(value: JsonValue) -> List[ListableEntity]:
+    return decode(List[ListableEntity], value)
+
+
+def list(specification: str | Path) -> List[ListableEntity]:
     """
     List all networks, datasets, parameters, and properties in the specification.
 
     :param specification: The path to the Vehicle specification file to list entities for.
-    :return: list of entities as JSON.
+    :return: list of structured listable entities.
     """
     args = ["list", "--specification", str(specification), "--json"]
 
@@ -20,6 +115,30 @@ def list(specification: str | Path) -> str:
     if exc != 0:
         raise VehicleError(f"{err}")
     elif not out:
-        return ""
+        return []
 
-    return out
+    try:
+        return _decode_listable_entities(json.loads(out))
+    except Exception as exc:
+        raise VehicleError(str(exc)) from exc
+
+
+__all__ = [
+    "Dataset",
+    "DatasetSummary",
+    "ListableEntity",
+    "MultiProperty",
+    "MultiPropertyTree",
+    "Network",
+    "NetworkSummary",
+    "Parameter",
+    "ParameterSummary",
+    "Property",
+    "PropertySummary",
+    "Provenance",
+    "QuantifiedVariableSummary",
+    "Quantifier",
+    "SharedData",
+    "SingleProperty",
+    "list",
+]

--- a/vehicle-python/tests/test_golden_specs.py
+++ b/vehicle-python/tests/test_golden_specs.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-
 import vehicle_lang as vcl
 from vehicle_lang.loss import _ast as loss_ast
 

--- a/vehicle-python/tests/test_golden_specs.py
+++ b/vehicle-python/tests/test_golden_specs.py
@@ -3,11 +3,16 @@
 from pathlib import Path
 
 import pytest
+
 import vehicle_lang as vcl
 from vehicle_lang.loss import _ast as loss_ast
 
 GOLDEN_SPECS_BASE = (
-    Path(__file__).parent.parent.parent / "vehicle" / "tests" / "golden" / "compile"
+    Path(__file__).parent.parent.parent
+    / "vehicle"
+    / "tests"
+    / "golden"
+    / "specifications"
 )
 
 GOLDEN_SPEC_FILES = [
@@ -21,6 +26,13 @@ GOLDEN_SPEC_FILES = [
 def test_golden_spec_load(spec_path: Path) -> None:
     """Test that golden specs can be loaded into AST."""
     loss_ast.load(spec_path, target=vcl.DifferentiableLogic.DL2)
+
+
+@pytest.mark.parametrize("spec_path", GOLDEN_SPEC_FILES)  # type: ignore[untyped-decorator]
+def test_golden_spec_list_decode(spec_path: Path) -> None:
+    """Test that golden specs can be listed and decoded into structured entities."""
+    entities = vcl.list(spec_path)
+    assert isinstance(entities, list)
 
 
 @pytest.mark.parametrize("spec_path", GOLDEN_SPEC_FILES)  # type: ignore[untyped-decorator]

--- a/vehicle-python/uv.lock
+++ b/vehicle-python/uv.lock
@@ -1644,6 +1644,8 @@ name = "vehicle-lang"
 source = { editable = "." }
 dependencies = [
     { name = "jaxtyping" },
+    { name = "pre-commit" },
+    { name = "pytest" },
     { name = "typing-extensions" },
 ]
 
@@ -1691,14 +1693,16 @@ requires-dist = [
     { name = "build", marker = "extra == 'wheel'" },
     { name = "delocate", marker = "sys_platform == 'darwin' and extra == 'wheel'" },
     { name = "jax", marker = "extra == 'jax'", specifier = ">=0.4.26" },
-    { name = "jaxtyping", specifier = ">=0.2,<0.3" },
+    { name = "jaxtyping", specifier = ">=0.2,<0.4" },
     { name = "numpy", marker = "extra == 'numpy'", specifier = ">=1.21,<3" },
     { name = "numpy", marker = "extra == 'test'", specifier = ">=1.21,<3" },
     { name = "packaging", marker = "extra == 'test'", specifier = ">=23" },
+    { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
     { name = "pygments", marker = "extra == 'pygments'", specifier = ">=2.14,<3" },
     { name = "pygments", marker = "extra == 'test'", specifier = ">=2.14,<3" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.1,<9" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.1,<10" },
     { name = "tensorflow", marker = "(python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'tensorflow') or (python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'tensorflow') or (python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'tensorflow') or (python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tensorflow')", specifier = ">=2,<3" },
     { name = "torch", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and extra == 'pytorch'", specifier = ">=2,<3" },
     { name = "types-pygments", marker = "extra == 'mypy'", specifier = ">=2.14,<3" },

--- a/vehicle/src/Vehicle/List.hs
+++ b/vehicle/src/Vehicle/List.hs
@@ -5,7 +5,7 @@ module Vehicle.List
 where
 
 import Control.Monad.Writer (MonadWriter (tell), execWriterT)
-import Data.Aeson (ToJSON (..))
+import Data.Aeson (ToJSON (..), genericToJSON)
 import Data.Foldable (traverse_)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text, pack)
@@ -174,7 +174,8 @@ data ListableEntity
   | Property PropertySummary
   deriving (Generic)
 
-instance ToJSON ListableEntity
+instance ToJSON ListableEntity where
+  toJSON = genericToJSON jsonOptions
 
 --------------------------------------------------------------------------------
 -- Shared data
@@ -186,7 +187,8 @@ data SharedData = SharedData
   }
   deriving (Generic)
 
-instance ToJSON SharedData
+instance ToJSON SharedData where
+  toJSON = genericToJSON jsonOptions
 
 mkSharedData ::
   Provenance ->
@@ -208,7 +210,8 @@ newtype NetworkSummary = NetworkSummary
   }
   deriving (Generic)
 
-instance ToJSON NetworkSummary
+instance ToJSON NetworkSummary where
+  toJSON = genericToJSON jsonOptions
 
 --------------------------------------------------------------------------------
 -- Data
@@ -218,7 +221,8 @@ newtype DatasetSummary = DatasetSummary
   }
   deriving (Generic)
 
-instance ToJSON DatasetSummary
+instance ToJSON DatasetSummary where
+  toJSON = genericToJSON jsonOptions
 
 --------------------------------------------------------------------------------
 -- Parameter
@@ -229,7 +233,8 @@ data ParameterSummary = ParameterSummary
   }
   deriving (Generic)
 
-instance ToJSON ParameterSummary
+instance ToJSON ParameterSummary where
+  toJSON = genericToJSON jsonOptions
 
 --------------------------------------------------------------------------------
 -- Property
@@ -240,7 +245,8 @@ data PropertySummary = PropertySummary
   }
   deriving (Generic)
 
-instance ToJSON PropertySummary
+instance ToJSON PropertySummary where
+  toJSON = genericToJSON jsonOptions
 
 --------------------------------------------------------------------------------
 -- Quantified variable
@@ -251,4 +257,5 @@ data QuantifiedVariableSummary = QuantifiedVariableSummary
   }
   deriving (Generic)
 
-instance ToJSON QuantifiedVariableSummary
+instance ToJSON QuantifiedVariableSummary where
+  toJSON = genericToJSON jsonOptions

--- a/vehicle/tests/golden/specifications/acasXu/List.out.golden
+++ b/vehicle/tests/golden/specifications/acasXu/List.out.golden
@@ -2,8 +2,10 @@
   {
     "tag": "Network",
     "contents": {
+      "tag": "NetworkSummary",
       "sharedData": {
         "typeText": "Tensor Real [5] -> OutputVector",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -20,12 +22,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -43,6 +48,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -59,12 +65,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -82,6 +91,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -98,12 +108,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -121,6 +134,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -137,12 +151,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -160,6 +177,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -176,12 +194,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -199,6 +220,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -215,12 +237,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -238,6 +263,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -254,12 +280,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -277,6 +306,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -293,12 +323,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -316,6 +349,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -332,12 +366,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -355,6 +392,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -371,12 +409,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [5]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -394,6 +435,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [

--- a/vehicle/tests/golden/specifications/mnist-robustness/List.out.golden
+++ b/vehicle/tests/golden/specifications/mnist-robustness/List.out.golden
@@ -2,8 +2,10 @@
   {
     "tag": "Network",
     "contents": {
+      "tag": "NetworkSummary",
       "sharedData": {
         "typeText": "Tensor Real [28, 28] -> Tensor Real [10]",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -20,8 +22,10 @@
   {
     "tag": "Parameter",
     "contents": {
+      "tag": "ParameterSummary",
       "sharedData": {
         "typeText": "Real",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -39,8 +43,10 @@
   {
     "tag": "Parameter",
     "contents": {
+      "tag": "ParameterSummary",
       "sharedData": {
         "typeText": "Nat",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -58,8 +64,10 @@
   {
     "tag": "Dataset",
     "contents": {
+      "tag": "DatasetSummary",
       "sharedData": {
         "typeText": "Vector (Tensor Real [28, 28]) n",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -76,8 +84,10 @@
   {
     "tag": "Dataset",
     "contents": {
+      "tag": "DatasetSummary",
       "sharedData": {
         "typeText": "Vector (Index 10) n",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -94,9 +104,11 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": null,
       "sharedData": {
         "typeText": "Vector Bool n",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [

--- a/vehicle/tests/golden/specifications/mnist-robustness/ListWithParams.out.golden
+++ b/vehicle/tests/golden/specifications/mnist-robustness/ListWithParams.out.golden
@@ -2,8 +2,10 @@
   {
     "tag": "Network",
     "contents": {
+      "tag": "NetworkSummary",
       "sharedData": {
         "typeText": "Tensor Real [28, 28] -> Tensor Real [10]",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -20,6 +22,7 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "MultiProperty",
         "contents": [
@@ -27,8 +30,10 @@
             "tag": "SingleProperty",
             "contents": [
               {
+                "tag": "QuantifiedVariableSummary",
                 "sharedData": {
                   "typeText": "Tensor Real [28, 28]",
+                  "tag": "SharedData",
                   "provenance": {
                     "tag": "Provenance",
                     "contents": [
@@ -48,8 +53,10 @@
             "tag": "SingleProperty",
             "contents": [
               {
+                "tag": "QuantifiedVariableSummary",
                 "sharedData": {
                   "typeText": "Tensor Real [28, 28]",
+                  "tag": "SharedData",
                   "provenance": {
                     "tag": "Provenance",
                     "contents": [
@@ -69,6 +76,7 @@
       },
       "sharedData": {
         "typeText": "Vector Bool 2",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [

--- a/vehicle/tests/golden/specifications/windController/List.out.golden
+++ b/vehicle/tests/golden/specifications/windController/List.out.golden
@@ -2,8 +2,10 @@
   {
     "tag": "Network",
     "contents": {
+      "tag": "NetworkSummary",
       "sharedData": {
         "typeText": "Tensor Real [2] -> OutputVector",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [
@@ -20,12 +22,15 @@
   {
     "tag": "Property",
     "contents": {
+      "tag": "PropertySummary",
       "subcomponents": {
         "tag": "SingleProperty",
         "contents": [
           {
+            "tag": "QuantifiedVariableSummary",
             "sharedData": {
               "typeText": "Tensor Real [2]",
+              "tag": "SharedData",
               "provenance": {
                 "tag": "Provenance",
                 "contents": [
@@ -43,6 +48,7 @@
       },
       "sharedData": {
         "typeText": "Bool",
+        "tag": "SharedData",
         "provenance": {
           "tag": "Provenance",
           "contents": [


### PR DESCRIPTION
The `vehicle_lang.list` command now outputs structured objects rather than raw JSON. Also prevents us from accidentally silently changing the output format.