### PR TITLE
Updated Rocq backend to avoid problematic notation

### DIFF
--- a/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
@@ -747,9 +747,7 @@ compileTensorLiteral compileElement t = annotate ([MathcompImport Algebra, Open 
     toTensor :: TensorShape -> [Code] -> Code
     toTensor shape values = case shape of
       [] -> "ntensor_of_tuple (x := " <> pretty (length values) <> "%:posnat) [tuple of" <+> concatWith (surround " :: ") values <> " :: [::]]"
-      -- [] -> "[tensor^^=" <+> concatWith (surround "; ") values <> "]"
       _ -> "nstack_tuple (x := " <> pretty (length values) <> "%:posnat) [tuple of" <+> concatWith (surround " :: ") values <> " :: [::]]"
-      -- _ -> "[tensor^^" <+> concatWith (surround "; ") values <> "]"
 
 compileBoolLiteral :: Bool -> Code
 compileBoolLiteral = \case

--- a/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
@@ -746,8 +746,10 @@ compileTensorLiteral compileElement t = annotate ([MathcompImport Algebra, Open 
   where
     toTensor :: TensorShape -> [Code] -> Code
     toTensor shape values = case shape of
-      [] -> "[tensor^^=" <+> concatWith (surround "; ") values <> "]"
-      _ -> "[tensor^^" <+> concatWith (surround "; ") values <> "]"
+      [] -> "ntensor_of_tuple (x := " <> pretty (length values) <> "%:posnat) [tuple of" <+> concatWith (surround " :: ") values <> " :: [::]]"
+      -- [] -> "[tensor^^=" <+> concatWith (surround "; ") values <> "]"
+      _ -> "nstack_tuple (x := " <> pretty (length values) <> "%:posnat) [tuple of" <+> concatWith (surround " :: ") values <> " :: [::]]"
+      -- _ -> "[tensor^^" <+> concatWith (surround "; ") values <> "]"
 
 compileBoolLiteral :: Bool -> Code
 compileBoolLiteral = \case

--- a/vehicle/tests/golden/features/quantifierIn/Rocq.v.golden
+++ b/vehicle/tests/golden/features/quantifierIn/Rocq.v.golden
@@ -16,7 +16,7 @@ Parameter R : realType.
 
 Parameter f : 'nT[R]_[2] -> 'nT[R]_[1].
 
-Definition dataset : seq 'nT[R]_[2] := [tensor^^= (1 / 2 : R); (1 : R)] :: nil.
+Definition dataset : seq 'nT[R]_[2] := ntensor_of_tuple (x := 2%:posnat) [tuple of (1 / 2 : R) :: (1 : R) :: [::]] :: nil.
 
 Axiom empty : forallInList (fun x => True) dataset.
 

--- a/vehicle/tests/golden/features/tensor/Rocq.v.golden
+++ b/vehicle/tests/golden/features/tensor/Rocq.v.golden
@@ -22,7 +22,7 @@ Definition zeroD : 'sT[R] := const_t (5 / 2 : R).
 
 Definition oneD : 'nT[R]_[2] := nstack_tuple [tuple zeroD; const_t (1 : R)].
 
-Definition twoD : 'nT[R]_[2, 2] := nstack_tuple [tuple oneD; [tensor^^= (2 : R); (3 : R)]].
+Definition twoD : 'nT[R]_[2, 2] := nstack_tuple [tuple oneD; ntensor_of_tuple (x := 2%:posnat) [tuple of (2 : R) :: (3 : R) :: [::]]].
 
 Definition lookup2D : 'sT[R] := (twoD ^^ 0) ^^ 1.
 

--- a/vehicle/tests/golden/specifications/acasXu/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/acasXu/Rocq.v.golden
@@ -52,7 +52,7 @@ Definition maximumInputValues : UnnormalisedInputVector := nstack_tuple [tuple c
 
 Definition validInput (x : UnnormalisedInputVector) : Prop := forallIndex (fun i => minimumInputValues ^^ i <= x ^^ i /\ x ^^ i <= maximumInputValues ^^ i).
 
-Definition meanScalingValues : UnnormalisedInputVector := [tensor^^= (19791091 / 1000 : R); (0 : R); (0 : R); (650 : R); (600 : R)].
+Definition meanScalingValues : UnnormalisedInputVector := ntensor_of_tuple (x := 5%:posnat) [tuple of (19791091 / 1000 : R) :: (0 : R) :: (0 : R) :: (650 : R) :: (600 : R) :: [::]].
 
 Definition normalise (x : UnnormalisedInputVector) : InputVector := nstack (fun i => (x ^^ i - meanScalingValues ^^ i) / (maximumInputValues ^^ i - minimumInputValues ^^ i)).
 

--- a/vehicle/tests/golden/specifications/reachability/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/reachability/Rocq.v.golden
@@ -17,4 +17,4 @@ Parameter R : realType.
 
 Parameter f : 'nT[R]_[2] -> 'sT[R].
 
-Axiom reachable : exists x, ([tensor^^= (0 : R); (0 : R)] <= x /\ x <= [tensor^^= (1 : R); (1 : R)]) /\ f x == const_t (0 : R).
+Axiom reachable : exists x, (ntensor_of_tuple (x := 2%:posnat) [tuple of (0 : R) :: (0 : R) :: [::]] <= x /\ x <= ntensor_of_tuple (x := 2%:posnat) [tuple of (1 : R) :: (1 : R) :: [::]]) /\ f x == const_t (0 : R).


### PR DESCRIPTION
The tensor library in its current state has some notation that can cause issues. To avoid this, a small change has been made to expand the notation to avoid it.

Previously,

```coq
[tensor^^= ...]
```
Now:

``` coq
ntensor_of_tuple (x := s%:posnat) [...]
```
Where `s` is the size of the tuple provided.
