### PR TITLE
fix: package def and build instructions for Rocq backend

### DIFF
--- a/.github/workflows/test-integration-rocq.yml
+++ b/.github/workflows/test-integration-rocq.yml
@@ -88,8 +88,29 @@ jobs:
       - name: 🛠️ Add Rocq opam repository
         run: opam repo add rocq-released https://rocq-prover.org/opam/released
 
-      - name: 🛠️ Install Rocq
-        run: opam install -y rocq-core.${{ matrix.rocq.version }}
+      - name: 💾 Restore opam cache
+        uses: actions/cache/restore@v5
+        if: ${{ !env.ACT }}
+        id: cache-opam
+        env:
+          key: opam-${{ matrix.os.name }}-ocaml-${{ matrix.ocaml.version }}-rocq-${{ matrix.rocq.version }}
+        with:
+          path: ~/.opam
+          key: ${{ env.key }}-deps-${{ hashFiles('vehicle-rocq/vehicle-rocq.opam') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: 🛠️ Install Rocq + vehicle-rocq deps
+        if: ${{ env.ACT || steps.cache-opam.outputs.cache-hit != 'true' }}
+        run: |
+          opam install -y rocq-core.${{ matrix.rocq.version }}
+          opam install -y --deps-only ./vehicle-rocq
+
+      - name: 💾 Save opam cache
+        uses: actions/cache/save@v5
+        if: ${{ !env.ACT && steps.cache-opam.outputs.cache-hit != 'true' }}
+        with:
+          path: ~/.opam
+          key: ${{ steps.cache-opam.outputs.cache-primary-key }}
 
       - name: 🛠️ Install vehicle-rocq
         run: opam install -y ./vehicle-rocq

--- a/.github/workflows/test-integration-rocq.yml
+++ b/.github/workflows/test-integration-rocq.yml
@@ -91,15 +91,6 @@ jobs:
       - name: 🛠️ Install Rocq
         run: opam install -y rocq-core.${{ matrix.rocq.version }}
 
-      # The Rocq backend currently compiles against math-comp master, soon to be
-      # released as 2.6.0. Analysis and finmap master need to be pinned as well to
-      # master, as current releases do not compile with math-comp master.
-      - name: 🛠️ Pin math-comp+finmap+analysis to master
-        run: |
-          opam pin add -y -k git https://github.com/math-comp/math-comp.git#master
-          opam pin add -y -k git https://github.com/math-comp/finmap.git#master
-          opam pin add -y -k git https://github.com/math-comp/analysis.git#master
-
       - name: 🛠️ Install vehicle-rocq
         run: opam install -y ./vehicle-rocq
 

--- a/vehicle-rocq/README.md
+++ b/vehicle-rocq/README.md
@@ -9,26 +9,40 @@ Companion Rocq library for the Vehicle compiler's Rocq backend. Two pieces:
   tactic, which discharges `@property` obligations against a pre-computed
   verification cache.
 
-## Building
+## Installing
 
-This package uses [dune](https://dune.build) (≥ 3.13). With Rocq 9.0+ and
-mathcomp on the path:
+vehicle-rocq currently tracks `math-comp` master (post tensor-PR #1535) plus
+matching `finmap` and `analysis` commits. The exact pins are declared in
+`vehicle-rocq.opam`'s `pin-depends` field and opam will follow them
+automatically. Because those pins shadow any released versions of
+`rocq-mathcomp-*` and `rocq-mathcomp-{finmap,classical,reals}`, we recommend
+that you **use a dedicated opam switch** rather than your default one,
+otherwise you'll overwrite stable math-comp on which other projects depend.
+
+```sh
+# 1. Create a dedicated switch (any compatible ocaml is fine)
+opam switch create vehicle 5.4.1
+eval $(opam env --switch=vehicle)
+
+# 2. Add the Rocq opam repository
+opam repo add rocq-released https://rocq-prover.org/opam/released
+
+# 3. Install vehicle-rocq — opam follows pin-depends and pulls in
+#    math-comp / finmap / analysis at the pinned commits.
+opam install -y ./vehicle-rocq
+```
+
+This installs the `.v` files and the plugin's `.cmxs` so that
+generated Vehicle files can do `From vehicle Require Import utils.` and
+(if compiled with `--cache`) `From vehicle Require Import validate.`.
+
+If you only want to build locally (no install), the package uses
+[dune](https://dune.build) (≥ 3.13):
 
 ```sh
 cd vehicle-rocq
 dune build
-dune install
 ```
-
-Or via opam:
-
-```sh
-opam install ./vehicle-rocq.opam
-```
-
-Either form installs the `.v` files and the plugin's `.cmxs` so that
-generated Vehicle files can do `From vehicle Require Import utils.` and
-(if compiled with `--cache`) `From vehicle Require Import validate.`.
 
 ## The `vehicle_validate` tactic
 

--- a/vehicle-rocq/vehicle-rocq.opam
+++ b/vehicle-rocq/vehicle-rocq.opam
@@ -36,6 +36,20 @@ depends: [
   "rocq-mathcomp-reals" { >= "1.14.0" }
 ]
 
+# Pin math-comp / finmap / analysis to the commits vehicle-rocq is built
+# against. Bump once math-comp 2.6.0 is released and remove this section.
+pin-depends: [
+  [ "rocq-mathcomp-boot.dev"          "git+https://github.com/math-comp/math-comp.git#072513312e0cd7ce1301d9d9d8ebdc3168e1e8c6" ]
+  [ "rocq-mathcomp-ssreflect.dev"     "git+https://github.com/math-comp/math-comp.git#072513312e0cd7ce1301d9d9d8ebdc3168e1e8c6" ]
+  [ "rocq-mathcomp-order.dev"         "git+https://github.com/math-comp/math-comp.git#072513312e0cd7ce1301d9d9d8ebdc3168e1e8c6" ]
+  [ "rocq-mathcomp-fingroup.dev"      "git+https://github.com/math-comp/math-comp.git#072513312e0cd7ce1301d9d9d8ebdc3168e1e8c6" ]
+  [ "rocq-mathcomp-finite-group.dev"  "git+https://github.com/math-comp/math-comp.git#072513312e0cd7ce1301d9d9d8ebdc3168e1e8c6" ]
+  [ "rocq-mathcomp-algebra.dev"       "git+https://github.com/math-comp/math-comp.git#072513312e0cd7ce1301d9d9d8ebdc3168e1e8c6" ]
+  [ "rocq-mathcomp-finmap.dev"        "git+https://github.com/math-comp/finmap.git#53239c7997b1143592d7814ec51a0e3404844b54" ]
+  [ "rocq-mathcomp-classical.dev"     "git+https://github.com/math-comp/analysis.git#b185302d6efc5ba942adffebe27534acb85027d4" ]
+  [ "rocq-mathcomp-reals.dev"         "git+https://github.com/math-comp/analysis.git#b185302d6efc5ba942adffebe27534acb85027d4" ]
+]
+
 authors: [
   "Joshua Smart"
   "Alessandro Bruni"


### PR DESCRIPTION
The Rocq backend currently depends on the master branch of upstream mathcomp / analysis / finmap.
This PR pins the Rocq backend to the specific hashes of those packages that are known to work properly.
If not merged before a mathcomp release, it is intended to be updated to the released versions of mathcomp & co.
Enables caching to save ~45 mintues of build time per platform.