### PR TITLE
fix(rocq): align notation precedences/associativity with mathcomp

### DIFF
--- a/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
@@ -223,7 +223,7 @@ compileApplication dependencies fun args = do
       then return (getPrecedence fun, fun)
       else do
         compiledArgs <- traverseArgs compileExpr args
-        bracketedArgs <- bracketArgs functionApplicationPrecedence compiledArgs
+        bracketedArgs <- bracketArgs (replicate (length compiledArgs) functionApplicationPrecedence) compiledArgs
         return (functionApplicationPrecedence, hsep (fun : bracketedArgs))
 
   return $ annotate (Set.fromList dependencies, precedence) annDoc
@@ -237,11 +237,11 @@ compileNotationAndArgs ::
   Maybe Text ->
   [Arg DecidabilityBuiltin] ->
   m Code
-compileNotationAndArgs dependencies _associativity precedence op mFn args
+compileNotationAndArgs dependencies associativity precedence op mFn args
   | not (all isExplicit args) = fallback
   | otherwise = do
       compiledArgs <- traverseArgs compileExpr args
-      bracketedArgs <- bracketArgs precedence compiledArgs
+      bracketedArgs <- bracketArgs (operandLevels associativity precedence (length compiledArgs)) compiledArgs
       let doc = insertNotationArgs op bracketedArgs
       maybe fallback (return . annotate (Set.fromList dependencies, precedence)) doc
   where
@@ -528,7 +528,7 @@ compileBuiltin b args = case b of
   StandardBuiltinFunction f -> case f of
     And -> compileNotationAndArgs [] LeftAssociative (Just 40) "$0 && $1" (Just "andb") args
     Or -> compileNotationAndArgs [] LeftAssociative (Just 50) "$0 || $1" (Just "orb") args
-    Not -> compileNotationAndArgs [MathcompImport Boot] LeftAssociative (Just 35) "~~ $0" (Just "negb") args
+    Not -> compileNotationAndArgs [MathcompImport Boot] RightAssociative (Just 35) "~~ $0" (Just "negb") args
     Implies -> compileNotationAndArgs [MathcompImport Boot] RightAssociative (Just 55) "$0 ==> $1" (Just "implb") args
     Add AddNat -> compileNotationAndArgs [MathcompImport Algebra, Open RingScope] LeftAssociative (Just 50) "$0 + $1" (Just "+%R") args
     Mul MulNat -> compileNotationAndArgs [MathcompImport Algebra, Open RingScope] LeftAssociative (Just 40) "$0 * $1" (Just "*%R") args
@@ -536,7 +536,7 @@ compileBuiltin b args = case b of
     Sub SubRatTensor -> compileNotationAndArgs [MathcompImport Algebra] LeftAssociative (Just 50) "$0 - $1" Nothing args
     Mul MulRatTensor -> compileNotationAndArgs [MathcompImport Algebra] LeftAssociative (Just 40) "$0 * $1" (Just "*%R") args
     Div DivRatTensor -> compileNotationAndArgs [MathcompImport Algebra] LeftAssociative (Just 40) "$0 / $1" Nothing args
-    Neg NegRatTensor -> compileNotationAndArgs [MathcompImport Algebra] NotAssociative (Just 80) "- $0" (Just "-%R") args
+    Neg NegRatTensor -> compileNotationAndArgs [MathcompImport Algebra] RightAssociative (Just 35) "- $0" (Just "-%R") args
     Min MinRatTensor -> compileApplication [MathcompImport Algebra, Import OrderDef] "min" args
     Max MaxRatTensor -> compileApplication [MathcompImport Algebra, Import OrderDef] "max" args
     CompareIndex op -> compileComparison CIndex op args
@@ -554,8 +554,8 @@ compileBuiltin b args = case b of
     QuantifyRatTensor q -> case reverse args of
       (ExplicitArg _ (Lam _ binder body)) : _ -> compileTypeLevelQuantifier q [binder] body
       _ -> unsupportedArgsError
-    AtTensor -> compileNotationAndArgs [MathcompImport Algebra, Open RingScope] LeftAssociative (Just 30) "$0 ^^ $1" (Just "nindex") args
-    If -> compileNotationAndArgs [MathcompImport Boot] NotAssociative (Just 0) "if $0 then $1 else $2" Nothing args
+    AtTensor -> compileNotationAndArgs [MathcompImport Algebra, Open RingScope] NotAssociative (Just 30) "$0 ^^ $1" (Just "nindex") args
+    If -> compileNotationAndArgs [MathcompImport Boot] NotAssociative (Just 200) "if $0 then $1 else $2" Nothing args
     ForeachTensor -> compileApplication [MathcompImport Algebra] "nstack" args
     StackTensor -> compileStack args
     AtVector -> compileApplication [MathcompImport Boot] "tnth" args
@@ -612,7 +612,7 @@ compileBuiltin b args = case b of
           <+> quotePretty (show b)
 
 compileFunctionType :: (MonadRocqCompile m) => [Arg DecidabilityBuiltin] -> m Code
-compileFunctionType = compileNotationAndArgs [MathcompImport Boot] RightAssociative (Just 100) "$0 -> $1" (Just "implies")
+compileFunctionType = compileNotationAndArgs [MathcompImport Boot] RightAssociative (Just 99) "$0 -> $1" (Just "implies")
 
 compileApp :: (MonadRocqCompile m) => Expr DecidabilityBuiltin -> NonEmpty (Arg DecidabilityBuiltin) -> m Code
 compileApp fun args = do
@@ -673,25 +673,23 @@ compileTypeLevelQuantifier q binders body = do
   quant <- case q of
     Forall -> return "forall"
     Exists -> return "exists"
-  return $ annotate (mempty, Just 100) (quant <+> hsep cBinders <> "," <+> cBody)
+  return $ annotate (mempty, Just 200) (quant <+> hsep cBinders <> "," <+> cBody)
 
-bracketArgs :: (MonadRocqCompile m) => Maybe Precedence -> [GenericArg Code] -> m [Code]
-bracketArgs maybeParentPrecedence = traverse bracketArg
+operandLevels :: Associativity -> Maybe Precedence -> Int -> [Maybe Precedence]
+operandLevels associativity precedence numArgs =
+  [if onAssociativeSide index then fmap (+ 1) precedence else precedence | index <- [0 .. numArgs - 1]]
   where
-    bracketArg :: (MonadRocqCompile m) => GenericArg Code -> m Code
-    bracketArg arg = do
+    onAssociativeSide index = case associativity of
+      LeftAssociative -> index == 0
+      RightAssociative -> index == numArgs - 1
+      NotAssociative -> False
+
+bracketArgs :: (MonadRocqCompile m) => [Maybe Precedence] -> [GenericArg Code] -> m [Code]
+bracketArgs argLevels args = traverse bracketArg (zip argLevels args)
+  where
+    bracketArg :: (MonadRocqCompile m) => (Maybe Precedence, GenericArg Code) -> m Code
+    bracketArg (maybeParentPrecedence, arg) = do
       let body = argExpr arg
-      logDebug MaxDetail $
-        "!!!"
-          <+> body
-          <+> parens
-            ( "precedence"
-                <+> pretty (getPrecedence body)
-                <+> ">="
-                <+> pretty maybeParentPrecedence
-                <+> "="
-                <+> pretty (getPrecedence body >= maybeParentPrecedence)
-            )
       return $ case visibilityOf arg of
         Instance {} -> annotate (mempty, Nothing) $ braces (braces body)
         Implicit {} -> annotate (mempty, Nothing) $ braces body
@@ -755,7 +753,7 @@ compileDimList = go []
     compileDimElem e = compileExpr e
 
 compileTensorLiteral :: (a -> Code) -> Tensor a -> Code
-compileTensorLiteral compileElement t = annotate ([MathcompImport Algebra, Open RingScope], Nothing) $ case (shapeOf t, toList t) of
+compileTensorLiteral compileElement t = annotate ([MathcompImport Algebra, Open RingScope], functionApplicationPrecedence) $ case (shapeOf t, toList t) of
   ([], [x]) -> "const_t" <+> compileElement x
   _ -> foldMapTensor compileElement toTensor t
   where
@@ -782,7 +780,7 @@ compileLam :: (MonadRocqCompile m) => Binder DecidabilityBuiltin -> Expr Decidab
 compileLam binder expr = do
   let (binders, body) = foldLamBinders binder expr
   (cBinders, cBody) <- compileBinders (binder : binders) (compileExpr body)
-  return $ annotate (mempty, Just 100) ("fun" <+> hsep cBinders <+> "=>" <+> cBody)
+  return $ annotate (mempty, Just 200) ("fun" <+> hsep cBinders <+> "=>" <+> cBody)
 
 data ComparisonDomain
   = CIndex

--- a/vehicle/tests/golden/features/arithmetic/Rocq.v.golden
+++ b/vehicle/tests/golden/features/arithmetic/Rocq.v.golden
@@ -15,7 +15,7 @@ Local Open Scope form_scope.
 
 Parameter R : realType.
 
-Definition precedence (x : 'sT[R]) (y : 'sT[R]) (z : 'sT[R]) : 'sT[R] := (x + const_t (2 : R) * y) - z / y.
+Definition precedence (x : 'sT[R]) (y : 'sT[R]) (z : 'sT[R]) : 'sT[R] := x + const_t (2 : R) * y - z / y.
 
 Definition natLitNatLitDiv : 'sT[R] := const_t (1 : R) / const_t (2 : R).
 

--- a/vehicle/tests/golden/features/if/Rocq.v.golden
+++ b/vehicle/tests/golden/features/if/Rocq.v.golden
@@ -17,8 +17,8 @@ Parameter R : realType.
 
 Parameter f : 'nT[R]_[1] -> 'nT[R]_[1].
 
-Axiom prop1 : forall x, const_t (0 : R) < x /\ x < const_t (1 : R) -> if (x > const_t (1 / 2 : R)) then (f (nstack_tuple (x := 1%:posnat) [tuple x]) ^^ 0 > const_t (0 : R)) else (f (nstack_tuple (x := 1%:posnat) [tuple x]) ^^ 0 <= const_t (0 : R)).
+Axiom prop1 : forall x, const_t (0 : R) < x /\ x < const_t (1 : R) -> (if x > const_t (1 / 2 : R) then f (nstack_tuple (x := 1%:posnat) [tuple x]) ^^ 0 > const_t (0 : R) else f (nstack_tuple (x := 1%:posnat) [tuple x]) ^^ 0 <= const_t (0 : R)).
 
-Axiom prop2 : exists x, (const_t (0 : R) < x /\ x < const_t (1 : R)) /\ f (nstack_tuple (x := 1%:posnat) [tuple if (x > const_t (1 / 2 : R)) then x else const_t (1 / 5 : R)]) ^^ 0 >= const_t (0 : R).
+Axiom prop2 : exists x, (const_t (0 : R) < x /\ x < const_t (1 : R)) /\ f (nstack_tuple (x := 1%:posnat) [tuple if x > const_t (1 / 2 : R) then x else const_t (1 / 5 : R)]) ^^ 0 >= const_t (0 : R).
 
-Axiom prop3 : exists x, (const_t (0 : R) < x /\ x < const_t (1 : R)) /\ if (f (nstack_tuple (x := 1%:posnat) [tuple x]) ^^ 0 > const_t (0 : R)) then (x >= const_t (1 / 2 : R)) else (x < const_t (1 / 2 : R)).
+Axiom prop3 : exists x, (const_t (0 : R) < x /\ x < const_t (1 : R)) /\ (if f (nstack_tuple (x := 1%:posnat) [tuple x]) ^^ 0 > const_t (0 : R) then x >= const_t (1 / 2 : R) else x < const_t (1 / 2 : R)).

--- a/vehicle/tests/golden/features/logic/Rocq.v.golden
+++ b/vehicle/tests/golden/features/logic/Rocq.v.golden
@@ -18,16 +18,16 @@ Parameter R : realType.
 Record DifferentiableLogic : Type :=
   { true : 'sT[R]
   ; false : 'sT[R]
-  ; conjunction : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; disjunction : 'sT[R] -> ('sT[R] -> 'sT[R])
+  ; conjunction : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; disjunction : 'sT[R] -> 'sT[R] -> 'sT[R]
   ; negation : 'sT[R] -> 'sT[R]
-  ; implication : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; lt : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; le : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; gt : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; ge : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; equals : 'sT[R] -> ('sT[R] -> 'sT[R])
-  ; notEquals : 'sT[R] -> ('sT[R] -> 'sT[R])
+  ; implication : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; lt : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; le : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; gt : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; ge : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; equals : 'sT[R] -> 'sT[R] -> 'sT[R]
+  ; notEquals : 'sT[R] -> 'sT[R] -> 'sT[R]
   }.
 
 Definition myLogic : DifferentiableLogic := {| true := - const_t (100000 : R)

--- a/vehicle/tests/golden/specifications/acasXu/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/acasXu/Rocq.v.golden
@@ -63,42 +63,42 @@ Definition maximalScore (i : 'I_5%N) (x : UnnormalisedInputVector) : Prop := for
 
 Definition scaleCOCOutput (x : 'sT[R]) : 'sT[R] := (x - const_t (1879721 / 250000 : R)) / const_t (2337187 / 6250 : R).
 
-Definition intruderDistantAndSlower (x : UnnormalisedInputVector) : Prop := x ^^ distanceToIntruder >= const_t (55947691 / 1000 : R) /\ (x ^^ speed >= const_t (1145 : R) /\ x ^^ intruderSpeed <= const_t (60 : R)).
+Definition intruderDistantAndSlower (x : UnnormalisedInputVector) : Prop := x ^^ distanceToIntruder >= const_t (55947691 / 1000 : R) /\ x ^^ speed >= const_t (1145 : R) /\ x ^^ intruderSpeed <= const_t (60 : R).
 
-Axiom property1 : forall x, validInput x /\ intruderDistantAndSlower x -> normAcasXu x ^^ clearOfConflict <= scaleCOCOutput const_t (1500 : R).
+Axiom property1 : forall x, validInput x /\ intruderDistantAndSlower x -> normAcasXu x ^^ clearOfConflict <= scaleCOCOutput (const_t (1500 : R)).
 
 Axiom property2 : forall x, validInput x /\ intruderDistantAndSlower x -> ~ maximalScore clearOfConflict x.
 
-Definition directlyAhead (x : UnnormalisedInputVector) : Prop := (const_t (1500 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (1800 : R)) /\ ((- const_t (3 / 50 : R)) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= const_t (3 / 50 : R)).
+Definition directlyAhead (x : UnnormalisedInputVector) : Prop := (const_t (1500 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (1800 : R)) /\ - const_t (3 / 50 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= const_t (3 / 50 : R).
 
-Definition movingTowards (x : UnnormalisedInputVector) : Prop := x ^^ intruderHeading >= const_t (31 / 10 : R) /\ (x ^^ speed >= const_t (980 : R) /\ x ^^ intruderSpeed >= const_t (960 : R)).
+Definition movingTowards (x : UnnormalisedInputVector) : Prop := x ^^ intruderHeading >= const_t (31 / 10 : R) /\ x ^^ speed >= const_t (980 : R) /\ x ^^ intruderSpeed >= const_t (960 : R).
 
-Axiom property3 : forall x, validInput x /\ (directlyAhead x /\ movingTowards x) -> ~ minimalScore clearOfConflict x.
+Axiom property3 : forall x, validInput x /\ directlyAhead x /\ movingTowards x -> ~ minimalScore clearOfConflict x.
 
-Definition movingAway (x : UnnormalisedInputVector) : Prop := x ^^ intruderHeading == const_t (0 : R) /\ (const_t (1000 : R) <= x ^^ speed /\ (const_t (700 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (800 : R))).
+Definition movingAway (x : UnnormalisedInputVector) : Prop := x ^^ intruderHeading == const_t (0 : R) /\ const_t (1000 : R) <= x ^^ speed /\ const_t (700 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (800 : R).
 
-Axiom property4 : forall x, validInput x /\ (directlyAhead x /\ movingAway x) -> ~ minimalScore clearOfConflict x.
+Axiom property4 : forall x, validInput x /\ directlyAhead x /\ movingAway x -> ~ minimalScore clearOfConflict x.
 
-Definition nearAndApproachingFromLeft (x : UnnormalisedInputVector) : Prop := (const_t (250 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (400 : R)) /\ ((const_t (1 / 5 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= const_t (2 / 5 : R)) /\ (((- pi) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= (- pi) + const_t (1 / 200 : R)) /\ ((const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (400 : R)) /\ (const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (400 : R))))).
+Definition nearAndApproachingFromLeft (x : UnnormalisedInputVector) : Prop := (const_t (250 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (400 : R)) /\ (const_t (1 / 5 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= const_t (2 / 5 : R)) /\ (- pi <= x ^^ intruderHeading /\ x ^^ intruderHeading <= - pi + const_t (1 / 200 : R)) /\ (const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (400 : R)) /\ const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (400 : R).
 
 Axiom property5 : forall x, validInput x /\ nearAndApproachingFromLeft x -> minimalScore strongRight x.
 
-Definition intruderFarAway (x : UnnormalisedInputVector) : Prop := (const_t (12000 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (62000 : R)) /\ (((- pi) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= (- const_t (7 / 10 : R)) \/ const_t (7 / 10 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= pi) /\ (((- pi) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= (- pi) + const_t (1 / 200 : R)) /\ ((const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ (const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R))))).
+Definition intruderFarAway (x : UnnormalisedInputVector) : Prop := (const_t (12000 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (62000 : R)) /\ (- pi <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= - const_t (7 / 10 : R) \/ const_t (7 / 10 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= pi) /\ (- pi <= x ^^ intruderHeading /\ x ^^ intruderHeading <= - pi + const_t (1 / 200 : R)) /\ (const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R).
 
 Axiom property6 : forall x, validInput x /\ intruderFarAway x -> minimalScore clearOfConflict x.
 
-Definition largeVerticalSeparation (x : UnnormalisedInputVector) : Prop := (const_t (0 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (60760 : R)) /\ (((- pi) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= pi) /\ (((- pi) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= pi) /\ ((const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ (const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R))))).
+Definition largeVerticalSeparation (x : UnnormalisedInputVector) : Prop := (const_t (0 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (60760 : R)) /\ (- pi <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= pi) /\ (- pi <= x ^^ intruderHeading /\ x ^^ intruderHeading <= pi) /\ (const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R).
 
 Axiom property7 : forall x, validInput x /\ largeVerticalSeparation x -> ~ minimalScore strongLeft x /\ ~ minimalScore strongRight x.
 
-Definition largeVerticalSeparationAndPreviousWeakLeft (x : UnnormalisedInputVector) : Prop := (const_t (0 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (60760 : R)) /\ (((- pi) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= (- const_t (3 / 4 : R)) * pi) /\ (((- const_t (1 / 10 : R)) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= const_t (1 / 10 : R)) /\ ((const_t (600 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ (const_t (600 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R))))).
+Definition largeVerticalSeparationAndPreviousWeakLeft (x : UnnormalisedInputVector) : Prop := (const_t (0 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (60760 : R)) /\ (- pi <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= - const_t (3 / 4 : R) * pi) /\ (- const_t (1 / 10 : R) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= const_t (1 / 10 : R)) /\ (const_t (600 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ const_t (600 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R).
 
 Axiom property8 : forall x, validInput x /\ largeVerticalSeparationAndPreviousWeakLeft x -> minimalScore clearOfConflict x \/ minimalScore weakLeft x.
 
-Definition previousWeakRightAndNearbyIntruder (x : UnnormalisedInputVector) : Prop := (const_t (2000 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (7000 : R)) /\ (((- const_t (2 / 5 : R)) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= (- const_t (7 / 50 : R))) /\ (((- pi) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= (- pi) + const_t (1 / 100 : R)) /\ ((const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (150 : R)) /\ (const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (150 : R))))).
+Definition previousWeakRightAndNearbyIntruder (x : UnnormalisedInputVector) : Prop := (const_t (2000 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (7000 : R)) /\ (- const_t (2 / 5 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= - const_t (7 / 50 : R)) /\ (- pi <= x ^^ intruderHeading /\ x ^^ intruderHeading <= - pi + const_t (1 / 100 : R)) /\ (const_t (100 : R) <= x ^^ speed /\ x ^^ speed <= const_t (150 : R)) /\ const_t (0 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (150 : R).
 
 Axiom property9 : forall x, validInput x /\ previousWeakRightAndNearbyIntruder x -> minimalScore strongLeft x.
 
-Definition intruderFarAway2 (x : UnnormalisedInputVector) : Prop := (const_t (36000 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (60760 : R)) /\ ((const_t (7 / 10 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= pi) /\ (((- pi) <= x ^^ intruderHeading /\ x ^^ intruderHeading <= (- pi) + const_t (1 / 100 : R)) /\ ((const_t (900 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ (const_t (600 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R))))).
+Definition intruderFarAway2 (x : UnnormalisedInputVector) : Prop := (const_t (36000 : R) <= x ^^ distanceToIntruder /\ x ^^ distanceToIntruder <= const_t (60760 : R)) /\ (const_t (7 / 10 : R) <= x ^^ angleToIntruder /\ x ^^ angleToIntruder <= pi) /\ (- pi <= x ^^ intruderHeading /\ x ^^ intruderHeading <= - pi + const_t (1 / 100 : R)) /\ (const_t (900 : R) <= x ^^ speed /\ x ^^ speed <= const_t (1200 : R)) /\ const_t (600 : R) <= x ^^ intruderSpeed /\ x ^^ intruderSpeed <= const_t (1200 : R).
 
 Axiom property10 : forall x, validInput x /\ intruderFarAway2 x -> minimalScore clearOfConflict x.

--- a/vehicle/tests/golden/specifications/andGate/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/andGate/Rocq.v.golden
@@ -23,6 +23,6 @@ Definition falsey (x : 'sT[R]) : Prop := x <= const_t (1 / 2 : R).
 
 Definition validInput (x : 'sT[R]) : Prop := const_t (0 : R) <= x /\ x <= const_t (1 : R).
 
-Definition correctOutput (x1 : 'sT[R]) (x2 : 'sT[R]) : Prop := let y := andGate (nstack_tuple (x := 2%:posnat) [tuple x1; x2]) ^^ 0 in (truthy x1 /\ truthy x2 -> truthy y) /\ ((truthy x1 /\ falsey x2 -> falsey y) /\ ((falsey x1 /\ truthy x2 -> falsey y) /\ (falsey x1 /\ falsey x2 -> falsey y))).
+Definition correctOutput (x1 : 'sT[R]) (x2 : 'sT[R]) : Prop := let y := andGate (nstack_tuple (x := 2%:posnat) [tuple x1; x2]) ^^ 0 in (truthy x1 /\ truthy x2 -> truthy y) /\ (truthy x1 /\ falsey x2 -> falsey y) /\ (falsey x1 /\ truthy x2 -> falsey y) /\ (falsey x1 /\ falsey x2 -> falsey y).
 
 Axiom andGateCorrect : forall x1, forall x2, validInput x1 /\ validInput x2 -> correctOutput x1 x2.

--- a/vehicle/tests/golden/specifications/dogsHierarchy/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/dogsHierarchy/Rocq.v.golden
@@ -26,9 +26,9 @@ Definition chihuahua : 'I_6%N := 4.
 
 Definition pekinese : 'I_6%N := 5.
 
-Definition smallDogs : seq Dog := chihuahua :: (pekinese :: nil).
+Definition smallDogs : seq Dog := chihuahua :: pekinese :: nil.
 
-Definition bigDogs : seq Dog := greatDane :: (germanShepherd :: nil).
+Definition bigDogs : seq Dog := greatDane :: germanShepherd :: nil.
 
 Definition Image : Type := 'nT[R]_[4, 4].
 

--- a/vehicle/tests/golden/specifications/monotonicity/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/monotonicity/Rocq.v.golden
@@ -16,4 +16,4 @@ Parameter R : realType.
 
 Parameter f : 'sT[R] -> 'sT[R].
 
-Axiom monotonic : forall x1, forall x2, (const_t (0 : R) < x1 /\ x1 < const_t (1 : R)) /\ ((const_t (0 : R) < x2 /\ x2 < const_t (1 : R)) /\ x1 <= x2) -> f x1 <= f x2.
+Axiom monotonic : forall x1, forall x2, (const_t (0 : R) < x1 /\ x1 < const_t (1 : R)) /\ (const_t (0 : R) < x2 /\ x2 < const_t (1 : R)) /\ x1 <= x2 -> f x1 <= f x2.

--- a/vehicle/tests/golden/specifications/windController/Rocq.v.golden
+++ b/vehicle/tests/golden/specifications/windController/Rocq.v.golden
@@ -28,8 +28,8 @@ Parameter controller : InputVector -> OutputVector.
 
 Definition normalise (x : InputVector) : InputVector := nstack (fun i => (x ^^ i + const_t (4 : R)) / const_t (8 : R)).
 
-Definition safeInput (x : InputVector) : Prop := forallIndex (fun i => (- const_t (13 / 4 : R)) <= x ^^ i /\ x ^^ i <= const_t (13 / 4 : R)).
+Definition safeInput (x : InputVector) : Prop := forallIndex (fun i => - const_t (13 / 4 : R) <= x ^^ i /\ x ^^ i <= const_t (13 / 4 : R)).
 
-Definition safeOutput (x : InputVector) : Prop := let y := controller (normalise x) ^^ velocity in (- const_t (5 / 4 : R)) < (y + const_t (2 : R) * x ^^ currentSensor) - x ^^ previousSensor /\ (y + const_t (2 : R) * x ^^ currentSensor) - x ^^ previousSensor < const_t (5 / 4 : R).
+Definition safeOutput (x : InputVector) : Prop := let y := controller (normalise x) ^^ velocity in - const_t (5 / 4 : R) < y + const_t (2 : R) * x ^^ currentSensor - x ^^ previousSensor /\ y + const_t (2 : R) * x ^^ currentSensor - x ^^ previousSensor < const_t (5 / 4 : R).
 
 Axiom safe : forall x, safeInput x -> safeOutput x.


### PR DESCRIPTION
The Rocq backend annotated several notations with precedences that don't match the real Coq/mathcomp levels, and `compileNotationAndArgs` already received an `Associativity` argument (passed by all call sites) but discarded it (`_associativity`), so `bracketArgs` was associativity-blind. Because the bracketing test is conservative (parenthesise on `>=`), most of the resulting errors were redundant parentheses, but two wrong levels were latent mis-parses that current specs happened not to trigger.

Corrected levels/associativity (truth via `Print Notation`, mathcomp master):
- if/then/else:       0  -> 200   (was under-bracketed as an operand)
- unary minus (opp):  80 -> 35, NotAssoc -> Right
- forall / fun:       100 -> 200
- (->):               100 -> 99
- tensor literals:    Nothing -> application precedence (bracket as an argument)
- negb (~~):          Left -> Right
- nindex (^^):        Left -> NotAssoc

Validation: all Rocq compile goldens regenerated; full RocqVerify suite compiles the de-bracketed output against the pinned mathcomp. Rocq.hs-only change.

fixes: #1174