### PR TITLE
refactor: remove unused matplotlib.cm import

### DIFF
--- a/scripts/benchmark-histogram/benchmark_histogram/main.py
+++ b/scripts/benchmark-histogram/benchmark_histogram/main.py
@@ -6,7 +6,6 @@ import re
 import typing
 
 import click
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns


### PR DESCRIPTION
### 问题背景
在文件 `scripts/benchmark-histogram/benchmark_histogram/main.py` 中，`matplotlib.cm` 被导入但未使用。这可能导致代码混乱、增加不必要的依赖，并触发 lint 警告，影响代码质量和可维护性。

### 修改内容
- 删除了未使用的导入 `import matplotlib.cm as cm`。
- 此修改提高了代码的清晰度和一致性，符合 lint 优化标准，避免潜在的性能或维护问题。

### 验证方式
- 运行现有测试套件以确保功能不变（无测试时，可手动验证脚本是否正常工作）。
- 使用 lint 工具（如 flake8）检查是否还有类似问题。
- 由于是简单代码清理，无需添加新测试。

### 其他信息
- 无 breaking changes。
- 不需要更新文档。
- 无已知限制。