### PR TITLE
Fix: record quantification in Rocq backend for Issue#1189

### DIFF
--- a/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
@@ -552,16 +552,14 @@ compileBuiltin b args = case b of
     ReduceMaxRatTensor -> unsupportedError
     ReduceMulRatTensor -> compileApplication [] "reduceMul" args
     ConstTensor -> compileApplication [MathcompImport Algebra] "const_t" args
-    QuantifyRatTensor q -> case reverse args of
-      (ExplicitArg _ (Lam _ binder body)) : _ -> compileTypeLevelQuantifier q [binder] body
-      _ -> unsupportedArgsError
+    QuantifyRatTensor q -> compileQuantifierFunction q args 
     AtTensor -> compileNotationAndArgs [MathcompImport Algebra, Open RingScope] NotAssociative (Just 30) "$0 ^^ $1" (Just "nindex") args
     If -> compileNotationAndArgs [MathcompImport Boot] NotAssociative (Just 200) "if $0 then $1 else $2" Nothing args
     ForeachTensor -> compileApplication [MathcompImport Algebra] "nstack" args
     StackTensor -> compileStack args
     AtVector -> compileApplication [MathcompImport Boot] "tnth" args
     ForeachVector -> compileApplication [VehicleImport VehicleUtils] "foreachTuple" args
-    QuantifyRecord _ -> unsupportedTensorLikeQuantifier
+    QuantifyRecord q -> compileQuantifierFunction q args
     Iterate -> unsupportedError
     Pow {} -> unsupportedError
     Log {} -> unsupportedError
@@ -596,15 +594,6 @@ compileBuiltin b args = case b of
     unsupportedError =
       developerError $
         "compilation of builtin" <+> quotePretty b <+> "to Rocq unsupported"
-
-    unsupportedArgsError :: (MonadRocqCompile m) => m a
-    unsupportedArgsError = do
-      compilerDeveloperError $
-        "compilation of"
-          <+> quotePretty b
-          <+> "with args"
-          <+> prettyVerbose args
-          <+> "to Rocq unsupported"
 
     monoError :: a
     monoError =
@@ -662,6 +651,13 @@ compileDerivedFunction fn args = case fn of
       Builtin _ (StandardBuiltinConstructor (IndexLiteral n)) -> Just n
       App (Builtin _ (StandardBuiltinConstructor (IndexLiteral n))) _ -> Just n
       _ -> Nothing
+
+compileQuantifierFunction :: (MonadRocqCompile m) => Quantifier -> [Arg DecidabilityBuiltin] -> m Code
+compileQuantifierFunction q args = case reverse args of
+  (ExplicitArg _ (Lam _ binder body)) : _ -> compileTypeLevelQuantifier q [binder] body
+  _ -> 
+    compilerDeveloperError $ 
+    "compilation of quantifier" <+> quotePretty q <+> "with args" <+> prettyVerbose args <+> "to Rocq unsupported"
 
 compileTypeLevelQuantifier ::
   (MonadRocqCompile m) =>

--- a/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
@@ -552,7 +552,7 @@ compileBuiltin b args = case b of
     ReduceMaxRatTensor -> unsupportedError
     ReduceMulRatTensor -> compileApplication [] "reduceMul" args
     ConstTensor -> compileApplication [MathcompImport Algebra] "const_t" args
-    QuantifyRatTensor q -> compileQuantifierFunction q args 
+    QuantifyRatTensor q -> compileQuantifierFunction q args
     AtTensor -> compileNotationAndArgs [MathcompImport Algebra, Open RingScope] NotAssociative (Just 30) "$0 ^^ $1" (Just "nindex") args
     If -> compileNotationAndArgs [MathcompImport Boot] NotAssociative (Just 200) "if $0 then $1 else $2" Nothing args
     ForeachTensor -> compileApplication [MathcompImport Algebra] "nstack" args
@@ -655,8 +655,8 @@ compileDerivedFunction fn args = case fn of
 compileQuantifierFunction :: (MonadRocqCompile m) => Quantifier -> [Arg DecidabilityBuiltin] -> m Code
 compileQuantifierFunction q args = case reverse args of
   (ExplicitArg _ (Lam _ binder body)) : _ -> compileTypeLevelQuantifier q [binder] body
-  _ -> 
-    compilerDeveloperError $ 
+  _ ->
+    compilerDeveloperError $
     "compilation of quantifier" <+> quotePretty q <+> "with args" <+> prettyVerbose args <+> "to Rocq unsupported"
 
 compileTypeLevelQuantifier ::


### PR DESCRIPTION
 Fixes the error that comes up when trying to export the [windControllerNew ](https://github.com/vehicle-lang/vehicle/tree/dev/examples/windController-newStyle) to Rocq:

```
 Error: Quantification over TensorLikes is unsupported.
Stack:
CallStack (from HasCallStack):
  developerError, called at src/Vehicle/Compile/Error.hs:283:35 in vehicle-0.26.0-inplace:Vehicle.Compile.Error
  unsupportedTensorLikeQuantifier 
```

- This was done by reusing the `QuantifyRatTensor` binder logic in `QuantifyRecord.`
- A new helper function `compileQuantifierFunction` was created to make the code cleaner and keep it more consistent with the [Agda](https://github.com/vehicle-lang/vehicle/blob/dev/vehicle/src/Vehicle/Backend/ITP/Agda.hs) backend.
- Removed unsupportedArgsError from compileBuiltin's where block since the new helper handles errors and it is not used anywhere else.

Tested the fix locally on a few small specifications and the windControllerNew example, and it successfully generates working Rocq proofs.