### PR TITLE
add label to loading declarations section to fix link

### DIFF
--- a/docs/training.rst
+++ b/docs/training.rst
@@ -3,6 +3,8 @@ Training with a specification
 Vehicle compiles each ``@property`` in your specification into a callable loss function. Use one of the backend modules (PyTorch or TensorFlow) to load the compiled declarations into Python.
 
 
+.. _loading-declarations:
+
 Loading declarations
 --------------------
 


### PR DESCRIPTION
I forgot to include this when adding the support badges to the parameters section. One of them should link to this section but it was missing its label.