### PR TITLE
Expose disjuncts produced during loss conversion

### DIFF
--- a/vehicle/src/Vehicle/Backend/Loss.hs
+++ b/vehicle/src/Vehicle/Backend/Loss.hs
@@ -18,6 +18,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Data.Builtin.Loss
 import Vehicle.Data.Builtin.Standard
 import Vehicle.Data.Builtin.Standard.Normalise ()
+import Vehicle.Data.Code.BooleanExpr (unDisjunctAll)
 import Vehicle.Data.Code.ForcedValue
 import Vehicle.Data.DifferentiableLogic
 import Vehicle.Data.Variable.Bound.Context.Tensor (TensorBoundContextT)
@@ -111,4 +112,8 @@ convertDeclType :: (MonadLogic m) => UnforcedType Builtin -> m (Type LossBuiltin
 convertDeclType typ = unnormalise 0 <$> convertThunk Nothing typ
 
 convertMultiProperty :: (MonadLogic m) => Thunk Builtin -> m (Expr LossBuiltin)
-convertMultiProperty body = unnormalise 0 <$> convertThunk (Just compileQuantifier) body
+convertMultiProperty body = do
+  let compQuantifier args = do
+        disjuncts <- compileQuantifier args
+        foldrM1 orLossValue $ unDisjunctAll disjuncts
+  unnormalise 0 <$> convertThunk (Just compQuantifier) body

--- a/vehicle/src/Vehicle/Backend/Loss/Domain.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Domain.hs
@@ -1,5 +1,6 @@
 module Vehicle.Backend.Loss.Domain
   ( compileQuantifier,
+    orLossValue,
   )
 where
 
@@ -50,17 +51,17 @@ import Vehicle.Prelude.Warning (CompileWarning (..))
 compileQuantifier ::
   (MonadLogic m) =>
   (Quantifier, QuantifyRatTensorArgs (Thunk Builtin) (Closure Builtin)) ->
-  m (Thunk LossBuiltin)
+  m (DisjunctAll (Thunk LossBuiltin))
 compileQuantifier (q, args) = do
   maybePartitions <- compileQuantifierInternal (q, args)
   case maybePartitions of
-    Trivial b ->
+    Trivial b -> do
       -- TODO add a warning
-      Forced <$> convertBoolTensorLiteral (ZeroDimTensor b)
+      value <- Forced <$> convertBoolTensorLiteral (ZeroDimTensor b)
+      return $ DisjunctAll [value]
     NonTrivial partitions -> do
       let disjunctedPartitions = partitionsToDisjuncts partitions
-      DisjunctAll (v :| vs) <- traverse checkFinalPartitionUnconstrained disjunctedPartitions
-      foldrM orLossValue v vs
+      traverse checkFinalPartitionUnconstrained disjunctedPartitions
 
 checkFinalPartitionUnconstrained ::
   (MonadLogic m) =>
@@ -291,21 +292,6 @@ type MonadDomain m =
     MonadFreeContext LossBuiltin m,
     MonadTensorBoundContext m
   )
-
-orLossValue :: (MonadDomain m) => Thunk LossBuiltin -> Thunk LossBuiltin -> m (Thunk LossBuiltin)
-orLossValue e1 e2 =
-  convertBooleanOp PointwiseDisjunction $
-    mkExpr accessSpine (TensorOp2Args (Forced IDimNil) e1 e2)
-
-andLossValue :: (MonadDomain m) => Thunk LossBuiltin -> Thunk LossBuiltin -> m (Thunk LossBuiltin)
-andLossValue e1 e2 =
-  convertBooleanOp PointwiseConjunction $
-    mkExpr accessSpine (TensorOp2Args (Forced IDimNil) e1 e2)
-
-notLossValue :: (MonadDomain m) => Thunk LossBuiltin -> Thunk LossBuiltin -> m (Thunk LossBuiltin)
-notLossValue dims e =
-  convertBooleanOp PointwiseNegation $
-    mkExpr accessSpine (TensorOp1Args dims e)
 
 notConstraint :: (MonadDomain m) => UserVariableConstraint LossBuiltin -> m (BooleanExpr (UserVariableConstraint LossBuiltin))
 notConstraint (NormalisedRelation rel expr) = do

--- a/vehicle/src/Vehicle/Backend/Loss/LossCompilation.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/LossCompilation.hs
@@ -3,6 +3,9 @@ module Vehicle.Backend.Loss.LossCompilation
     convertBoolTensorLiteral,
     convertQuantifierlessExprToLoss,
     convertBooleanOp,
+    orLossValue,
+    andLossValue,
+    notLossValue,
   )
 where
 
@@ -265,6 +268,24 @@ convertBoolTensorLiteral tensor = do
         let args = implicit (INatLiteral dim) : dims : implicit INatType : fmap explicit elems
         VBuiltin (LossBuiltinFunction StackTensor) (fmap (fmap Forced) args)
   return $ foldMapTensor convertBool foldLayer tensor
+
+--------------------------------------------------------------------------------
+-- Utils
+
+orLossValue :: (MonadLogic m) => Thunk LossBuiltin -> Thunk LossBuiltin -> m (Thunk LossBuiltin)
+orLossValue e1 e2 =
+  convertBooleanOp PointwiseDisjunction $
+    mkExpr accessSpine (TensorOp2Args (Forced IDimNil) e1 e2)
+
+andLossValue :: (MonadLogic m) => Thunk LossBuiltin -> Thunk LossBuiltin -> m (Thunk LossBuiltin)
+andLossValue e1 e2 =
+  convertBooleanOp PointwiseConjunction $
+    mkExpr accessSpine (TensorOp2Args (Forced IDimNil) e1 e2)
+
+notLossValue :: (MonadLogic m) => Thunk LossBuiltin -> Thunk LossBuiltin -> m (Thunk LossBuiltin)
+notLossValue dims e =
+  convertBooleanOp PointwiseNegation $
+    mkExpr accessSpine (TensorOp1Args dims e)
 
 --------------------------------------------------------------------------------
 -- Utils


### PR DESCRIPTION
Exposes a future fix for the `andGate` issue in #1211.