### PR TITLE
Simplify `SearchRatTensor` implementation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,15 @@
 * Added the `transpose` operator on tensors.
   See [tensors](docs/language/tensors.rst) for documentation.
 
+### Loss backend
+
+* BREAKING: all DifferentiableLogic implementations must now represent losses so that `false` is mapped to strictly larger values than `true`.
+
+* BREAKING: correspondingly the `Sampler.get_loss` method in the Python bindings no longer takes a `minimise` parameter.
+
+* The implementation of quantifier search has changed slightly so that samples returned by `Sampler` classes
+  are no longer aggregated by the implementation `reduceConjunction` provided by the logic but instead the maximum value is taken.
+
 ### ITP backends
 
 * Fixed bug where the Isabelle backend mis-compiled declarations referencing `@network`, `@dataset`, or `@parameter` resources (#1195).

--- a/vehicle-python/src/vehicle_lang/_ast/_nodes.py
+++ b/vehicle-python/src/vehicle_lang/_ast/_nodes.py
@@ -315,12 +315,10 @@ class ReduceMaxRatTensor(Expression):
 class SearchRatTensor(Expression):
 
     name: str
-    reduction_op: Expression
     dims: Expression
     lower_bound: Expression
     upper_bound: Expression
     search_lambda: Expression
-    minimise: bool
 
 
 @dataclass(frozen=True)

--- a/vehicle-python/src/vehicle_lang/loss/_abc/_samplers.py
+++ b/vehicle-python/src/vehicle_lang/loss/_abc/_samplers.py
@@ -31,6 +31,6 @@ class ABCSampler(
             search_lambda: A callable representing the search lambda.
         Returns:
             Sequence[vcl.Tensor]: The computed loss as a 1D tensor. If the size is greater than 1,
-            the losses will be combined with reductionOp from the SearchRatTensor node.
+            the losses will be combined by taking the maximum.
         """
         ...

--- a/vehicle-python/src/vehicle_lang/loss/_abc/_samplers.py
+++ b/vehicle-python/src/vehicle_lang/loss/_abc/_samplers.py
@@ -20,7 +20,6 @@ class ABCSampler(
         lower_bound: vcl.Tensor,
         upper_bound: vcl.Tensor,
         search_lambda: Callable[[vcl.Tensor], vcl.Tensor],
-        minimise: bool,
     ) -> Float[vcl.Tensor, "1 losses"]:
         """
         Calculates the loss based on the provided bounds and search lambda.
@@ -30,7 +29,6 @@ class ABCSampler(
             lower_bound: The lower bound tensor.
             upper_bound: The upper bound tensor.
             search_lambda: A callable representing the search lambda.
-            minimise: A flag indicating whether to minimise the search_lambda.
         Returns:
             Sequence[vcl.Tensor]: The computed loss as a 1D tensor. If the size is greater than 1,
             the losses will be combined with reductionOp from the SearchRatTensor node.

--- a/vehicle-python/src/vehicle_lang/loss/_python/_translation.py
+++ b/vehicle-python/src/vehicle_lang/loss/_python/_translation.py
@@ -322,11 +322,7 @@ class PythonTranslation(ABCTranslation[py.Module, py.stmt, py.expr]):
         )
 
     def translate_SearchRatTensor(self, expression: vcl.SearchRatTensor) -> py.expr:
-        """Translate SearchRatTensor to builtin call.
-
-        The reduction_op is a curried function (λxs. reduce xs) where:
-        - xs is the sequence of samples to reduce
-        """
+        """Translate SearchRatTensor to builtin call."""
         # Call sampler once to get samples
         sampler_call = py_app(
             py_subscript(
@@ -338,35 +334,11 @@ class PythonTranslation(ABCTranslation[py.Module, py.stmt, py.expr]):
             self.translate_expression(expression.lower_bound),
             self.translate_expression(expression.upper_bound),
             self.translate_expression(expression.search_lambda),
-            py.Constant(value=expression.minimise, **asdict(vcl.MISSING)),
             provenance=vcl.MISSING,
         )
 
-        # Apply as: (λsamples. reduction_op(len(samples))(samples).
-        # We cannot know the number of samples at compile time, so we pass both the samples and their length to the reduction_op.
-        # The number of samples is important as it may use them to construct constant tensors of the relevant dimension.
-        samples_name = "_samples"
-        samples_var = py_name(samples_name, provenance=vcl.MISSING)
         return py_app(
-            py.Lambda(
-                args=py_binder(
-                    py.arg(arg=samples_name, annotation=None, **asdict(vcl.MISSING))
-                ),
-                body=py_app(
-                    py_app(
-                        self.translate_expression(expression.reduction_op),
-                        py_app(
-                            py_name("len", provenance=vcl.MISSING),
-                            samples_var,
-                            provenance=vcl.MISSING,
-                        ),
-                        provenance=vcl.MISSING,
-                    ),
-                    samples_var,
-                    provenance=vcl.MISSING,
-                ),
-                **asdict(vcl.MISSING),
-            ),
+            py_builtin("ReduceMaxRatTensor", provenance=vcl.MISSING),
             sampler_call,
             provenance=vcl.MISSING,
         )

--- a/vehicle-python/src/vehicle_lang/loss/_pytorch/samplers.py
+++ b/vehicle-python/src/vehicle_lang/loss/_pytorch/samplers.py
@@ -24,7 +24,6 @@ class PyTorchSampler(ABCSampler[Sequence[int], torch.Tensor]):
         lower_bound: torch.Tensor,
         upper_bound: torch.Tensor,
         search_lambda: Callable[[torch.Tensor], torch.Tensor],
-        minimise: bool,
     ) -> Float[torch.Tensor, "1 losses"]: ...
 
 
@@ -58,10 +57,9 @@ class DefaultPyTorchSampler(PyTorchSampler):
         lower_bound: torch.Tensor,
         upper_bound: torch.Tensor,
         search_lambda: Callable[[torch.Tensor], torch.Tensor],
-        minimise: bool,
     ) -> Float[torch.Tensor, "1 losses"]:
         """
-        Use FGSM to generate adversarial samples and evaluate the search lambda.
+        Use PGD to generate adversarial samples and evaluate the search lambda.
 
         The step size is automatically inferred from the bounds to provide
         an out-of-the-box implementation that works for most applications.
@@ -74,7 +72,7 @@ class DefaultPyTorchSampler(PyTorchSampler):
             minimise: Whether to minimize (True) or maximize (False) the search_lambda
 
         Returns:
-            A sequence of loss values evaluated at the FGSM-perturbed points
+            A sequence of loss values evaluated at the PGD-perturbed points
         """
         # Set seed for reproducibility if provided
         if self.seed is not None:
@@ -93,8 +91,8 @@ class DefaultPyTorchSampler(PyTorchSampler):
                 lower_bound + torch.rand((), dtype=lower_bound.dtype) * range_size
             )
 
-            # Perform FGSM iterations from this starting point
-            # IMPORTANT: During FGSM, we only want gradients w.r.t. the INPUT to find
+            # Perform PGD iterations from this starting point
+            # IMPORTANT: During PGD, we only want gradients w.r.t. the INPUT to find
             # adversarial examples. We must NOT accumulate gradients in network parameters,
             # as that would interfere with the actual training gradients computed later.
             for _ in range(self.num_steps):
@@ -130,18 +128,9 @@ class DefaultPyTorchSampler(PyTorchSampler):
                     gradient = torch.zeros_like(current_point_var)
 
                 # FGSM: perturb in the direction of the gradient sign
-                # The compiled loss is often -aggregation(search_lambda), so to find worst-case
-                # inputs that make the training loss high, we need to minimize search_lambda.
-                # When minimise=True (we want to minimize training loss), find worst violations
-                # by MINIMIZING search_lambda (which after negation/aggregation gives high loss)
-                sign_grad = torch.sign(gradient)
-
-                if minimise:
-                    # Find worst violations by minimizing search_lambda
-                    perturbation = -epsilon * sign_grad
-                else:
-                    # Find best satisfactions by maximizing search_lambda
-                    perturbation = epsilon * sign_grad
+                # To find worst-case inputs that make the loss high, we need to
+                # move in the direction of the gradient (gradient ascent).
+                perturbation = epsilon * torch.sign(gradient)
 
                 # Apply perturbation and clip to bounds
                 current_point = torch.clamp(

--- a/vehicle-python/src/vehicle_lang/loss/_pytorch/samplers.py
+++ b/vehicle-python/src/vehicle_lang/loss/_pytorch/samplers.py
@@ -69,7 +69,6 @@ class DefaultPyTorchSampler(PyTorchSampler):
             lower_bound: The lower bound tensor
             upper_bound: The upper bound tensor
             search_lambda: A callable representing the property to evaluate
-            minimise: Whether to minimize (True) or maximize (False) the search_lambda
 
         Returns:
             A sequence of loss values evaluated at the PGD-perturbed points

--- a/vehicle-python/src/vehicle_lang/loss/_tensorflow/samplers.py
+++ b/vehicle-python/src/vehicle_lang/loss/_tensorflow/samplers.py
@@ -24,7 +24,6 @@ class TensorFlowSampler(ABCSampler[Sequence[int], tf.Tensor]):
         lower_bound: tf.Tensor,
         upper_bound: tf.Tensor,
         search_lambda: Callable[[tf.Tensor], tf.Tensor],
-        minimise: bool,
     ) -> Float[tf.Tensor, "1 losses"]: ...
 
 
@@ -58,10 +57,9 @@ class DefaultTensorFlowSampler(TensorFlowSampler):
         lower_bound: tf.Tensor,
         upper_bound: tf.Tensor,
         search_lambda: Callable[[tf.Tensor], tf.Tensor],
-        minimise: bool,
     ) -> Float[tf.Tensor, "1 losses"]:
         """
-        Use FGSM to generate adversarial samples and evaluate the search lambda.
+        Use PGD to generate adversarial samples and evaluate the search lambda.
 
         The step size is automatically inferred from the bounds to provide
         an out-of-the-box implementation that works for most applications.
@@ -71,10 +69,9 @@ class DefaultTensorFlowSampler(TensorFlowSampler):
             lower_bound: The lower bound tensor
             upper_bound: The upper bound tensor
             search_lambda: A callable representing the property to evaluate
-            minimise: Whether to minimize (True) or maximize (False) the search_lambda
 
         Returns:
-            A sequence of loss values evaluated at the FGSM-perturbed points
+            A sequence of loss values evaluated at the PGD-perturbed points
         """
         if self.seed is not None:
             tf.random.set_seed(self.seed)
@@ -97,7 +94,7 @@ class DefaultTensorFlowSampler(TensorFlowSampler):
                 tf.multiply(tf.random.uniform(shape=(), dtype=tf.float32), range_size),
             )
 
-            # Perform FGSM iterations from this starting point
+            # Perform PGD iterations from this starting point
             for _ in range(self.num_steps):
                 # Create a variable for gradient computation
                 x = tf.Variable(current_point, dtype=tf.float32)
@@ -118,18 +115,9 @@ class DefaultTensorFlowSampler(TensorFlowSampler):
                     )
 
                 # FGSM: perturb in the direction of the gradient sign
-                # The compiled loss is often -aggregation(search_lambda), so to find worst-case
-                # inputs that make the training loss high, we need to minimize search_lambda.
-                # When minimise=True (we want to minimize training loss), find worst violations
-                # by MINIMIZING search_lambda (which after negation/aggregation gives high loss)
-                sign_grad = tf.sign(gradient)
-
-                if minimise:
-                    # Find worst violations by minimizing search_lambda
-                    perturbation = -epsilon * sign_grad
-                else:
-                    # Find best satisfactions by maximizing search_lambda
-                    perturbation = epsilon * sign_grad
+                # To find worst-case inputs that make the loss high, we need to
+                # move in the direction of the gradient (gradient ascent).
+                perturbation = epsilon * tf.sign(gradient)
 
                 # Apply perturbation and clip to bounds
                 current_point = tf.clip_by_value(current_point + perturbation, lb, ub)
@@ -157,7 +145,6 @@ class ConstantTensorFlowSampler(TensorFlowSampler):
         lower_bound: tf.Tensor,
         upper_bound: tf.Tensor,
         search_lambda: Callable[[tf.Tensor], tf.Tensor],
-        minimise: bool,
     ) -> Any:
         """Returns the original constant value."""
         results = []

--- a/vehicle/src/Vehicle/Backend/Loss/Core.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Core.hs
@@ -63,17 +63,10 @@ getDeclProvenance = do
   return prov
 
 getLogicField :: (MonadLogic m) => TensorDifferentiableLogicField -> m (Expr LossBuiltin)
-getLogicField field = do
-  (logic, _) <- getLogic
-  return $ lookupLogicField field logic
+getLogicField field = lookupLogicField field <$> getLogic
 
 getLogicFieldValue :: (MonadLogic m) => TensorDifferentiableLogicField -> m (Thunk LossBuiltin)
 getLogicFieldValue field = Unforced emptyBoundEnv <$> getLogicField field
-
-getLogicDirection :: (MonadLogic m) => m Bool
-getLogicDirection = do
-  (_, minimise) <- getLogic
-  return minimise
 
 lookupLogicField :: (Ord field, Pretty field) => field -> Map field value -> value
 lookupLogicField field logic = case Map.lookup field logic of

--- a/vehicle/src/Vehicle/Backend/Loss/Domain.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Domain.hs
@@ -201,15 +201,6 @@ compileSearch varName dims binder closure (Domain lowerBound upperBound) = do
   lossBinder <- traverse convertQuantifierlessExprToLoss binder
   lossDims <- convertQuantifierlessExprToLoss dims
 
-  -- Generate the operation for doing the reduction
-  -- We do not know how many samples the quantifier will generate so we must append
-  -- an explicit lambda that takes them and then applies them appropriately.
-  -- The sample implementation will then provide them at run time.
-  genericReductionOp <- getLogicField ReduceDisjunction
-  let explicitDimsBinder = mkExplicitBinder (IListType INatType) (Just (mempty, "dims"))
-  let explicitDimsReductionOp = Lam mempty explicitDimsBinder (normAppList genericReductionOp [implicitIrrelevant (BoundVar mempty (Ix 0))])
-  let reductionOp = Unforced emptyBoundEnv explicitDimsReductionOp
-
   -- Reform the predicate as if we had no tensor variables at all
   let lossPredicate = Forced $ VLam lossBinder closure
 
@@ -219,13 +210,11 @@ compileSearch varName dims binder closure (Domain lowerBound upperBound) = do
         mkExpr accessSpine $
           SearchRatTensorArgs
             { searchDims = lossDims,
-              searchReductionOp = reductionOp,
               searchLowerBound = tensorValue $ lowerBoundValue lowerBound,
               searchUpperBound = tensorValue $ upperBoundValue upperBound,
               searchPredicate = lossPredicate
             }
-  minimise <- getLogicDirection
-  return $ Forced $ VBuiltin (LossBuiltinExtraFunction $ SearchRatTensor varName minimise) spine
+  return $ Forced $ VBuiltin (LossBuiltinExtraFunction $ SearchRatTensor varName) spine
 
 findTensorBounds ::
   forall m.

--- a/vehicle/src/Vehicle/Backend/Loss/JSON.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/JSON.hs
@@ -429,7 +429,7 @@ convertTranspose convert spine = case getExpr accessSpine spine of
   Nothing -> arityError L.Transpose 3 spine
 
 convertSearch :: (MonadJSON m) => Name -> UnforcedSpine LossBuiltin -> m JExpr
-convertSearch name = convertNonNullaryOp (L.SearchRatTensor name) 5 $
+convertSearch name = convertNonNullaryOp (L.SearchRatTensor name) 4 $
   \(SearchRatTensorArgs dims lowerBound upperBound fn) ->
     SearchRatTensor name <$> convertValue dims <*> convertValue lowerBound <*> convertValue upperBound <*> convertValue fn
 

--- a/vehicle/src/Vehicle/Backend/Loss/JSON.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/JSON.hs
@@ -102,7 +102,7 @@ data JExpr
   | StackTensor [JExpr]
   | ForeachTensor JExpr JExpr
   | AtTensor JExpr JExpr
-  | SearchRatTensor Name JExpr JExpr JExpr JExpr JExpr L.LogicDirection -- (Dims, ReductionOp, LowerBound, UpperBound, SearchLambda, Minimise)
+  | SearchRatTensor Name JExpr JExpr JExpr JExpr -- (Dims, LowerBound, UpperBound, SearchLambda)
   | -- Vector
     VectorLiteral [JExpr]
   | AtVector JExpr JExpr
@@ -319,7 +319,7 @@ convertBuiltin b spine = case b of
     L.ReverseList -> unsupportedError b
     L.AppendList -> unsupportedError b
   L.LossBuiltinExtraFunction f -> case f of
-    L.SearchRatTensor name minimise -> convertSearch name minimise spine
+    L.SearchRatTensor name -> convertSearch name spine
 
 convertNullaryOp :: (MonadJSON m) => LossBuiltin -> a -> UnforcedSpine LossBuiltin -> m a
 convertNullaryOp b fn = \case
@@ -428,10 +428,10 @@ convertTranspose convert spine = case getExpr accessSpine spine of
   Just (TransposeTensorArgs _t _ds xs) -> Transpose <$> convert xs
   Nothing -> arityError L.Transpose 3 spine
 
-convertSearch :: (MonadJSON m) => Name -> Bool -> UnforcedSpine LossBuiltin -> m JExpr
-convertSearch name minimise = convertNonNullaryOp (L.SearchRatTensor name minimise) 5 $
-  \(SearchRatTensorArgs dims unaryOp lowerBound upperBound fn) ->
-    SearchRatTensor name <$> convertValue unaryOp <*> convertValue dims <*> convertValue lowerBound <*> convertValue upperBound <*> convertValue fn <*> pure minimise
+convertSearch :: (MonadJSON m) => Name -> UnforcedSpine LossBuiltin -> m JExpr
+convertSearch name = convertNonNullaryOp (L.SearchRatTensor name) 5 $
+  \(SearchRatTensorArgs dims lowerBound upperBound fn) ->
+    SearchRatTensor name <$> convertValue dims <*> convertValue lowerBound <*> convertValue upperBound <*> convertValue fn
 
 arityError :: (MonadCompile m, Pretty fn) => fn -> Arity -> UnforcedSpine LossBuiltin -> m a
 arityError fun arity explicitArgs =
@@ -528,7 +528,7 @@ fromJExpr = \case
   ReduceMulRatTensor xs -> toFunction L.ReduceMulRatTensor [xs]
   ReduceMinRatTensor xs -> toFunction L.ReduceMinRatTensor [xs]
   ReduceMaxRatTensor xs -> toFunction L.ReduceMaxRatTensor [xs]
-  SearchRatTensor name dims e1 e2 e3 e4 minimise -> toExtraFunction (L.SearchRatTensor name minimise) [dims, e1, e2, e3, e4]
+  SearchRatTensor name dims lower upper lambda -> toExtraFunction (L.SearchRatTensor name) [dims, lower, upper, lambda]
   Dimension d -> toConstructor (L.NatLiteral d) []
   DimensionNil -> toConstructor L.Nil []
   DimensionCons e1 e2 -> toConstructor L.Cons [e1, e2]

--- a/vehicle/src/Vehicle/Backend/Loss/LogicCompilation.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/LogicCompilation.hs
@@ -23,7 +23,7 @@ import Vehicle.Compile.Prelude
 import Vehicle.Compile.Print
 import Vehicle.Compile.Unblock (noUnblocking, unblockBoolExpr)
 import Vehicle.Data.Builtin.Interface (Accessor (..))
-import Vehicle.Data.Builtin.Loss (ComparisonOp (..), LogicDirection, LossBuiltin)
+import Vehicle.Data.Builtin.Loss (ComparisonOp (..), LossBuiltin)
 import Vehicle.Data.Builtin.Standard (Builtin)
 import Vehicle.Data.Code.ForcedValue
 import Vehicle.Data.Code.Interface
@@ -142,26 +142,29 @@ compileLogic logicID declProv fields = do
     -- Lift fields to the tensor level
     let tensorLogicFields = [minBound .. maxBound] :: [TensorDifferentiableLogicField]
     lossTensorImplementation <- foldM (compileLogicField logicID declProv fields) mempty tensorLogicFields
-    minimise <- calculateLogicDirection declProv fields
+    checkLogicDirection declProv fields
     -- Convert fields to loss tensors
-    return (lossTensorImplementation, minimise)
+    return lossTensorImplementation
 
-calculateLogicDirection ::
+checkLogicDirection ::
   (MonadLoss m) =>
   DeclProvenance ->
   OMap FieldName (Thunk Builtin) ->
-  m LogicDirection
-calculateLogicDirection declProv fields = do
+  m ()
+checkLogicDirection declProv fields = do
   let expr = do
         let trueValue = lookupLogicField TruthityElement fields
         let falseValue = lookupLogicField FalsityElement fields
         let args = TensorComparisonArgs (Forced IDimNil) (Forced IDimNil) trueValue falseValue
-        Forced $ mkExpr accessCompareRatTensor (Le, args)
+        Forced $ mkExpr accessCompareRatTensor (Lt, args)
 
   errorOrResult <- runExceptT $ runFreshNameBoundContextT $ forceThunk =<< unblockBoolExpr noUnblocking expr
   case errorOrResult of
+    Right (IBoolLiteral result) ->
+      if result
+        then return ()
+        else throwError $ BackwardsDifferentiableLogic declProv expr
     Left blockingErr -> throwError $ UnorderableDifferentiableLogic declProv expr (Left blockingErr)
-    Right (IBoolLiteral b) -> return b
     Right result -> throwError $ UnorderableDifferentiableLogic declProv expr (Right result)
 
 compileLogicField ::
@@ -178,7 +181,7 @@ compileLogicField logicID declProv fields impl field =
     logDebug MaxDetail $ "input:" <+> prettyFriendlyEmptyCtx tensorValue
     lossTensorExpr <-
       runFreshFreeContextT (Proxy @LossBuiltin) $ do
-        runMonadLogicT logicID (mempty, True) declProv $ do
+        runMonadLogicT logicID mempty declProv $ do
           convertQuantifierlessExprToLoss tensorValue
     logDebug MaxDetail $ "output:" <+> prettyFriendlyEmptyCtx lossTensorExpr
     return $ Map.insert field (unnormalise 0 lossTensorExpr) impl

--- a/vehicle/src/Vehicle/Compile/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Error.hs
@@ -232,6 +232,7 @@ data CompileError
   | UnableToLiftLogicFieldToTensors DifferentiableLogicID TensorDifferentiableLogicField (BooleanDifferentiableLogicField, Thunk Builtin) NamedBoundCtx (Thunk Builtin)
   | NoQuantifierDomainFound DeclProvenance (UnforcedBinder Builtin) (These (NonEmpty TensorIndices) (NonEmpty TensorIndices))
   | UnorderableDifferentiableLogic DeclProvenance (Thunk Builtin) (Either BlockingReason (ForcedValue Builtin))
+  | BackwardsDifferentiableLogic DeclProvenance (Thunk Builtin)
   | -- ITP backend errors
     UnimplementedFeature Provenance (Doc Void)
   | UnusedMonomorphisableDeclaration Provenance Identifier

--- a/vehicle/src/Vehicle/Compile/Print/Error.hs
+++ b/vehicle/src/Vehicle/Compile/Print/Error.hs
@@ -993,7 +993,7 @@ formatCompileError = \case
             <> line
             <> "Internally Vehicle computes the result of:" <+> lineIndent comp
             <> line
-            <> "in order to work out whether the loss should be maximised or minimised."
+            <> "in order to check that the logic orders true and false correctly."
             <> line
             <> "However, Vehicle was unable to establish the truth value of"
             <> lineIndent (prettyFriendlyEmptyCtx expr)
@@ -1007,6 +1007,29 @@ formatCompileError = \case
         fix =
           Just $
             "ensure that the expression" <+> squotes comp <+> "evaluates to either `true` or `false`."
+      }
+    where
+      comp = pretty TruthityElement <+> "<" <+> pretty FalsityElement
+  BackwardsDifferentiableLogic (ident, p) expr ->
+    VehicleUserError
+      { provenance = Just p,
+        problem =
+          "Unable to compile differentiable logic"
+            <+> quotePretty (nameOf ident)
+            <> "."
+            <> line
+            <> "The logic must produce a loss value, i.e. false values must result in a higher value than true values."
+            <> line
+            <> "However, the following expression:" <+> lineIndent comp
+            <> line
+            <> "i.e."
+            <> lineIndent (prettyFriendlyEmptyCtx expr)
+            <> line
+            <> "evaluated to:"
+            <> lineIndent "False",
+        fix =
+          Just
+            "please reverse the direction of your logic."
       }
     where
       comp = pretty TruthityElement <+> "<" <+> pretty FalsityElement

--- a/vehicle/src/Vehicle/Data/Builtin/Loss.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Loss.hs
@@ -149,13 +149,13 @@ instance Pretty LossBuiltinFunction where
 --------------------------------------------------------------------------------
 -- Extra loss builtin functions
 
-data LossBuiltinExtraFunction
-  = SearchRatTensor Name LogicDirection
+newtype LossBuiltinExtraFunction
+  = SearchRatTensor Name
   deriving (Show, Eq, Ord, Generic)
 
 instance Pretty LossBuiltinExtraFunction where
   pretty = \case
-    SearchRatTensor name _direction -> "search[" <> pretty name <> "]"
+    SearchRatTensor name -> "search[" <> pretty name <> "]"
 
 --------------------------------------------------------------------------------
 -- Builtin datatype

--- a/vehicle/src/Vehicle/Data/Code/Interface/Args.hs
+++ b/vehicle/src/Vehicle/Data/Code/Interface/Args.hs
@@ -726,7 +726,6 @@ instance IsArgs TensorTypeArgs where
 
 data SearchRatTensorArgs expr = SearchRatTensorArgs
   { searchDims :: expr,
-    searchReductionOp :: expr,
     searchLowerBound :: expr,
     searchUpperBound :: expr,
     searchPredicate :: expr
@@ -736,19 +735,17 @@ instance IsArgs SearchRatTensorArgs where
   accessSpine =
     Access
       { getExpr = \case
-          (fmap argExpr -> [dims, op, lower, upper, predicate]) ->
+          (fmap argExpr -> [dims, lower, upper, predicate]) ->
             Just $
               SearchRatTensorArgs
                 { searchDims = dims,
-                  searchReductionOp = op,
                   searchLowerBound = lower,
                   searchUpperBound = upper,
                   searchPredicate = predicate
                 }
           _ -> Nothing,
-        mkExpr = \(SearchRatTensorArgs dims op lower upper predicate) ->
+        mkExpr = \(SearchRatTensorArgs dims lower upper predicate) ->
           [ implicitIrrelevant dims,
-            explicit op,
             explicit lower,
             explicit upper,
             explicit predicate

--- a/vehicle/src/Vehicle/Data/DifferentiableLogic.hs
+++ b/vehicle/src/Vehicle/Data/DifferentiableLogic.hs
@@ -81,10 +81,7 @@ comparisonOpToField = \case
 --------------------------------------------------------------------------------
 -- Tensor implementation
 
-type DifferentiableLogicImplementation =
-  ( Map TensorDifferentiableLogicField (Expr LossBuiltin),
-    LogicDirection
-  )
+type DifferentiableLogicImplementation = Map TensorDifferentiableLogicField (Expr LossBuiltin)
 
 elementLogicName :: Name
 elementLogicName = "DifferentiableElementLogic"

--- a/vehicle/tests/golden/errors/differentiableLogic/backwardsLogicDirection/Loss.err.golden
+++ b/vehicle/tests/golden/errors/differentiableLogic/backwardsLogicDirection/Loss.err.golden
@@ -1,0 +1,9 @@
+Error in file 'spec.vcl' at Line 6, Columns 1-11: Unable to compile differentiable logic 'CustomLoss'.
+The logic must produce a loss value, i.e. false values must result in a higher value than true values.
+However, the following expression: 
+  TruthityElement < FalsityElement
+i.e.
+  1.0 < 0.0
+evaluated to:
+  False
+Fix: please reverse the direction of your logic.

--- a/vehicle/tests/golden/errors/differentiableLogic/backwardsLogicDirection/spec.vcl
+++ b/vehicle/tests/golden/errors/differentiableLogic/backwardsLogicDirection/spec.vcl
@@ -1,0 +1,21 @@
+@network
+f : Real -> Real
+
+-- Does not represent a loss as `falseElement <= trueElement` and therefore
+-- logic is backwards.
+CustomLoss : DifferentiableTensorLogic
+CustomLoss =
+  { trueElement                = 1
+  , falseElement               = 0
+  , pointwiseNegation          = \x -> -x
+  , pointwiseConjunction       = \x y -> max x y
+  , pointwiseDisjunction       = \x y -> min x y
+  , pointwiseLessThan          = \x y -> x - y
+  , pointwiseLessEqualThan     = \x y -> x - y
+  , pointwiseGreaterThan       = \x y -> y - x
+  , pointwiseGreaterEqualThan  = \x y -> y - x
+  , pointwiseEqual             = \x y -> min (x - y) (y - x)
+  , pointwiseNotEqual          = \x y -> max (x - y) (y - x)
+  , reduceConjunction          = \xs -> reduceMax xs
+  , reduceDisjunction          = \xs -> reduceMin xs
+  }

--- a/vehicle/tests/golden/errors/differentiableLogic/backwardsLogicDirection/test.json
+++ b/vehicle/tests/golden/errors/differentiableLogic/backwardsLogicDirection/test.json
@@ -1,0 +1,6 @@
+  {
+    "name": "Loss",
+    "run": "vehicle compile loss -s spec.vcl -l CustomLoss -o loss.vcl",
+    "needs": ["spec.vcl"],
+    "produces": []
+  }

--- a/vehicle/tests/golden/errors/differentiableLogic/unknownLogicDirection/Loss.err.golden
+++ b/vehicle/tests/golden/errors/differentiableLogic/unknownLogicDirection/Loss.err.golden
@@ -1,8 +1,8 @@
 Error in file 'spec.vcl' at Line 6, Columns 1-11: Unable to compile differentiable logic 'CustomLoss'.
 Internally Vehicle computes the result of: 
   TruthityElement < FalsityElement
-in order to work out whether the loss should be maximised or minimised.
+in order to check that the logic orders true and false correctly.
 However, Vehicle was unable to establish the truth value of
-  f 0.0 <= 1000000.0
+  f 0.0 < 1000000.0
 because it could not evaluate 'f'
 Fix: ensure that the expression 'TruthityElement < FalsityElement' evaluates to either `true` or `false`.

--- a/vehicle/tests/golden/features/constantInput/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/constantInput/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 spec : (Tensor Real -> Tensor Real) -> Tensor Real;
-spec = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x, 0.0] - 0.0))
+spec = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x, 0.0] - 0.0))

--- a/vehicle/tests/golden/features/foreach/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/foreach/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 safe : (Tensor Real -> Tensor Real) -> Tensor Real;
-safe = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> max (const 0.0 nil) (f (x + (const 4.0 [2])) ! 0 - 0.0))
+safe = \ f -> const 1.0 nil / search[x] [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> max (const 0.0 nil) (f (x + (const 4.0 [2])) ! 0 - 0.0))

--- a/vehicle/tests/golden/features/gaussianElim/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/gaussianElim/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 test1 : (Tensor Real -> Tensor Real) -> Tensor Real;
-test1 = \ f -> search[a] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ a -> reduceAdd (- (max (const 0.0 [1]) (f [a + 2.0] - (const 0.0 [1])) + max (const 0.0 [1]) ((const 0.0 [1]) - f [a + 2.0]))))
+test1 = \ f -> search[a] nil 0.0 1.0 (\ a -> reduceAdd (- (max (const 0.0 [1]) (f [a + 2.0] - (const 0.0 [1])) + max (const 0.0 [1]) ((const 0.0 [1]) - f [a + 2.0]))))

--- a/vehicle/tests/golden/features/lossOutputs/DefaultOnlyProperty.vcl.golden
+++ b/vehicle/tests/golden/features/lossOutputs/DefaultOnlyProperty.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 belowOne : (Tensor Real -> Tensor Real) -> Tensor Real;
-belowOne = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))
+belowOne = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))

--- a/vehicle/tests/golden/features/lossOutputs/PropertyAndNonProperty.vcl.golden
+++ b/vehicle/tests/golden/features/lossOutputs/PropertyAndNonProperty.vcl.golden
@@ -4,4 +4,4 @@ predicted = \ f -> f (const 0.0 [4])
 
 @property;
 belowOne : (Tensor Real -> Tensor Real) -> Tensor Real;
-belowOne = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))
+belowOne = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))

--- a/vehicle/tests/golden/features/pruneDecls/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/pruneDecls/DL2Loss.vcl.golden
@@ -1,7 +1,7 @@
 @property;
 p1 : (Tensor Real -> Tensor Real) -> Tensor Real;
-p1 = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - (0.0 + 1.0)))
+p1 = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - (0.0 + 1.0)))
 
 @property;
 p2 : (Tensor Real -> Tensor Real) -> Tensor Real;
-p2 = \ g -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (g x - 0.0))
+p2 = \ g -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (g x - 0.0))

--- a/vehicle/tests/golden/features/quantifier/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/quantifier/DL2Loss.vcl.golden
@@ -1,7 +1,7 @@
 @property;
 expandedExpr : (Tensor Real -> Tensor Real) -> Tensor Real;
-expandedExpr = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (x - f x))
+expandedExpr = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (x - f x))
 
 @property;
 parallel : (Tensor Real -> Tensor Real) -> Tensor Real;
-parallel = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - 0.0)) + search[y] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ y -> max (const 0.0 nil) (5.0 - f y))
+parallel = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - 0.0)) + search[y] nil 0.0 1.0 (\ y -> max (const 0.0 nil) (5.0 - f y))

--- a/vehicle/tests/golden/issues/issue1067/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1067/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 boundedRobust : (Tensor Real -> Tensor Real) -> Tensor Real;
-boundedRobust = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) [1] (const -1.0 [1]) (const 1.0 [1]) (\ x -> search[x_hat] (\ dims -> \ xs -> reduceMul xs) [1] (const -1.0 [1]) (const 1.0 [1]) (\ x_hat -> reduceMul (max (const 0.0 [1]) (f x - f x_hat - - (const 1.0 [1]))) * reduceMul (max (const 0.0 [1]) ((const 1.0 [1]) - (f x - f x_hat)))))
+boundedRobust = \ f -> const 1.0 nil / search[x] [1] (const -1.0 [1]) (const 1.0 [1]) (\ x -> search[x_hat] [1] (const -1.0 [1]) (const 1.0 [1]) (\ x_hat -> reduceMul (max (const 0.0 [1]) (f x - f x_hat - - (const 1.0 [1]))) * reduceMul (max (const 0.0 [1]) ((const 1.0 [1]) - (f x - f x_hat)))))

--- a/vehicle/tests/golden/issues/issue1086/Loss.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1086/Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 p : (Tensor Real -> Tensor Real) -> Tensor Real;
-p = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) [1] (const 0.0 [1]) (const 1.0 [1]) (\ x -> max (const 0.0 nil) (f x - 0.0))
+p = \ f -> const 1.0 nil / search[x] [1] (const 0.0 [1]) (const 1.0 [1]) (\ x -> max (const 0.0 nil) (f x - 0.0))

--- a/vehicle/tests/golden/issues/issue1089/DL2Loss1.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1089/DL2Loss1.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 boundedByEpsilon : (Tensor Real -> Tensor Real) -> Tensor Real -> Tensor Real;
-boundedByEpsilon = \ net -> \ epsilon -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) [1] [-1.0 * epsilon] [-1.0 * (-1.0 * epsilon)] (\ x -> max (const 0.0 nil) (net x ! 0 - - epsilon) * max (const 0.0 nil) (epsilon - net x ! 0))
+boundedByEpsilon = \ net -> \ epsilon -> const 1.0 nil / search[x] [1] [-1.0 * epsilon] [-1.0 * (-1.0 * epsilon)] (\ x -> max (const 0.0 nil) (net x ! 0 - - epsilon) * max (const 0.0 nil) (epsilon - net x ! 0))

--- a/vehicle/tests/golden/issues/issue1089/DL2Loss2.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1089/DL2Loss2.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 boundedByEpsilonFactor : (Tensor Real -> Tensor Real) -> Tensor Real -> Tensor Real -> Tensor Real;
-boundedByEpsilonFactor = \ net -> \ epsilon -> \ factor -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) [1] [-1.0 * epsilon * factor] [-1.0 * (-1.0 * (epsilon * factor))] (\ x -> max (const 0.0 nil) (net x ! 0 - - (epsilon / factor)) * max (const 0.0 nil) (epsilon / factor - net x ! 0))
+boundedByEpsilonFactor = \ net -> \ epsilon -> \ factor -> const 1.0 nil / search[x] [1] [-1.0 * epsilon * factor] [-1.0 * (-1.0 * (epsilon * factor))] (\ x -> max (const 0.0 nil) (net x ! 0 - - (epsilon / factor)) * max (const 0.0 nil) (epsilon / factor - net x ! 0))

--- a/vehicle/tests/golden/specifications/bounded/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/bounded/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 bounded : (Tensor Real -> Tensor Real) -> Tensor Real;
-bounded = \ f -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x] ! 0 - 0.0) * max (const 0.0 nil) (1.0 - f [x] ! 0))
+bounded = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x] ! 0 - 0.0) * max (const 0.0 nil) (1.0 - f [x] ! 0))

--- a/vehicle/tests/golden/specifications/increasing/VehicleLoss.vcl.golden
+++ b/vehicle/tests/golden/specifications/increasing/VehicleLoss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 increasing : (Tensor Real -> Tensor Real) -> Tensor Real;
-increasing = \ f -> - search[x] (\ dims -> \ xs -> reduceMin xs) nil 0.0 1.0 (\ x -> f x - x)
+increasing = \ f -> - search[x] nil 0.0 1.0 (\ x -> f x - x)

--- a/vehicle/tests/golden/specifications/monotonicity/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/monotonicity/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 monotonic : (Tensor Real -> Tensor Real) -> Tensor Real;
-monotonic = \ f -> const 1.0 nil / search[x1] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x1 -> search[x2] (\ dims -> \ xs -> reduceMul xs) nil (max 0.0 x1) 1.0 (\ x2 -> max (const 0.0 nil) (f x2 - f x1)))
+monotonic = \ f -> const 1.0 nil / search[x1] nil 0.0 1.0 (\ x1 -> search[x2] nil (max 0.0 x1) 1.0 (\ x2 -> max (const 0.0 nil) (f x2 - f x1)))

--- a/vehicle/tests/golden/specifications/reachability/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/reachability/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 reachable : (Tensor Real -> Tensor Real) -> Tensor Real;
-reachable = \ f -> search[x] (\ dims -> \ xs -> reduceMul xs) [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> - (max (const 0.0 nil) (f x - 0.0) + max (const 0.0 nil) (0.0 - f x)))
+reachable = \ f -> search[x] [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> - (max (const 0.0 nil) (f x - 0.0) + max (const 0.0 nil) (0.0 - f x)))

--- a/vehicle/tests/golden/specifications/windController/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/windController/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 safe : (Tensor Real -> Tensor Real) -> Tensor Real;
-safe = \ controller -> const 1.0 nil / search[x] (\ dims -> \ xs -> reduceMul xs) [2] (const -3.25 [2]) (const 3.25 [2]) (\ x -> max (const 0.0 nil) (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1 - - 1.25) * max (const 0.0 nil) (1.25 - (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1)))
+safe = \ controller -> const 1.0 nil / search[x] [2] (const -3.25 [2]) (const 3.25 [2]) (\ x -> max (const 0.0 nil) (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1 - - 1.25) * max (const 0.0 nil) (1.25 - (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1)))

--- a/vehicle/tests/golden/warnings/boundsOnlyQuantifier/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/warnings/boundsOnlyQuantifier/DL2Loss.vcl.golden
@@ -1,7 +1,7 @@
 @property;
 prop1 : Tensor Real;
-prop1 = search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> 0.0)
+prop1 = search[x] nil 0.0 1.0 (\ x -> 0.0)
 
 @property;
 prop2 : Tensor Real;
-prop2 = search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.5 1.5 (\ x -> 0.0) * search[x] (\ dims -> \ xs -> reduceMul xs) nil 0.0 1.0 (\ x -> 0.0)
+prop2 = search[x] nil 0.5 1.5 (\ x -> 0.0) * search[x] nil 0.0 1.0 (\ x -> 0.0)


### PR DESCRIPTION
* Enforce the assumption that the logic gives a loss, thereby getting rid of the minimise parameter.
* Sampler results can therefore be aggregated via `max` rather than the interpretation of `reduceAnd`. Also leads to more interpretable results.