### PR TITLE
Moved `SearchRatTensor` from `LossBuiltin` to `Builtin` and convert `Builtin` rather `LossBuiltin` to JSON

### DIFF
--- a/vehicle-python/src/vehicle_lang/_ast/_nodes.py
+++ b/vehicle-python/src/vehicle_lang/_ast/_nodes.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from fractions import Fraction
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Generic, Literal, Optional, Sequence
 
 from typing_extensions import Self, TypeAlias
 from typing_extensions import TypeVar as TypingTypeVar
@@ -13,6 +13,7 @@ from ._decode import JsonValue, decode
 
 Name: TypeAlias = str
 UniverseLevel: TypeAlias = int
+ComparisonOp: TypeAlias = Literal["Eq", "Ne", "Le", "Lt", "Ge", "Gt"]
 
 
 @dataclass(frozen=True, init=False)
@@ -95,24 +96,23 @@ DType = TypingTypeVar("DType", bool, float, int, ExtendedFraction)
 
 
 @dataclass(frozen=True)
-class Tensor(AST):
+class Tensor(AST, Generic[DType]):
     shape: Sequence[int]
-    value: Sequence[ExtendedFraction] | ExtendedFraction
 
     def __init__(self) -> None:
         raise TypeError("Cannot instantiate abstract class Tensor")
 
 
 @dataclass(frozen=True)
-class DenseTensor(Tensor):
+class DenseTensor(Tensor[DType], Generic[DType]):
     shape: Sequence[int]
-    value: Sequence[ExtendedFraction]
+    values: Sequence[DType]
 
 
 @dataclass(frozen=True)
-class ConstantTensor(Tensor):
+class ConstantTensor(Tensor[DType], Generic[DType]):
     shape: Sequence[int]
-    value: ExtendedFraction
+    value: DType
 
 
 ################################################################################
@@ -137,6 +137,11 @@ class Pi(BuiltinType):
 @dataclass(frozen=True)
 class RatType(BuiltinType):
     """Rational number type: RatType"""
+
+
+@dataclass(frozen=True)
+class BoolType(BuiltinType):
+    """Boolean type: BoolType"""
 
 
 @dataclass(frozen=True)
@@ -214,9 +219,76 @@ class Var(Expression):
 
 
 @dataclass(frozen=True)
-class RatTensor(Expression):
+class BoolTensor(Expression):
+    contents: Tensor[bool]
 
-    contents: Tensor
+
+@dataclass(frozen=True)
+class BoolNot(Expression):
+    x: Expression
+
+
+@dataclass(frozen=True)
+class BoolAnd(Expression):
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class BoolOr(Expression):
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class BoolImplies(Expression):
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class BoolCompareIndex(Expression):
+    op: ComparisonOp
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class BoolCompareNat(Expression):
+    op: ComparisonOp
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class BoolCompareRatTensor(Expression):
+    op: ComparisonOp
+    p_dims: Expression
+    r_dims: Expression
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class BoolReduceAnd(Expression):
+    x: Expression
+
+
+@dataclass(frozen=True)
+class BoolReduceOr(Expression):
+    x: Expression
+
+
+@dataclass(frozen=True)
+class BoolIf(Expression):
+    c: Expression
+    x: Expression
+    y: Expression
+
+
+@dataclass(frozen=True)
+class RatTensor(Expression):
+    contents: Tensor[ExtendedFraction]
 
 
 @dataclass(frozen=True)

--- a/vehicle-python/src/vehicle_lang/loss/_abc/_builtins.py
+++ b/vehicle-python/src/vehicle_lang/loss/_abc/_builtins.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Generic, List, Sequence
 
 from typing_extensions import TypeAlias, TypeVar, override
 
-from ..._ast._nodes import Tensor
+from ..._ast._nodes import ExtendedFraction, Tensor
 from . import _types as vcl
 
 
@@ -22,7 +22,47 @@ class ABCBuiltins(
         return value
 
     @abstractmethod
-    def RatTensor(self, value: Tensor) -> vcl.Tensor: ...
+    def BoolTensor(self, x: Tensor[bool]) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolNot(self, x: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolAnd(self, x: vcl.Tensor, y: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolOr(self, x: vcl.Tensor, y: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolImplies(self, x: vcl.Tensor, y: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolCompareIndex(self, op: str, x: vcl.Index, y: vcl.Index) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolCompareNat(self, op: str, x: vcl.Index, y: vcl.Index) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolCompareRatTensor(
+        self,
+        op: str,
+        pointwise_dims: Sequence[vcl.Index],
+        reduce_dims: Sequence[vcl.Index],
+        x: vcl.Tensor,
+        y: vcl.Tensor,
+    ) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolReduceAnd(self, x: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolReduceOr(self, x: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def BoolIf(self, c: vcl.Tensor, x: vcl.Tensor, y: vcl.Tensor) -> vcl.Tensor: ...
+
+    @abstractmethod
+    def RatTensor(self, x: Tensor[ExtendedFraction]) -> vcl.Tensor: ...
 
     @abstractmethod
     def NegRatTensor(self, x: vcl.Tensor) -> vcl.Tensor: ...

--- a/vehicle-python/src/vehicle_lang/loss/_abc/_translation.py
+++ b/vehicle-python/src/vehicle_lang/loss/_abc/_translation.py
@@ -48,6 +48,28 @@ class ABCTranslation(
                 return self.translate_Lam(expression)
             case vcl_ast.Pi():
                 return self.translate_Pi(expression)
+            case vcl_ast.BoolTensor():
+                return self.translate_BoolTensor(expression)
+            case vcl_ast.BoolNot():
+                return self.translate_BoolNot(expression)
+            case vcl_ast.BoolAnd():
+                return self.translate_BoolAnd(expression)
+            case vcl_ast.BoolOr():
+                return self.translate_BoolOr(expression)
+            case vcl_ast.BoolImplies():
+                return self.translate_BoolImplies(expression)
+            case vcl_ast.BoolCompareIndex():
+                return self.translate_BoolCompareIndex(expression)
+            case vcl_ast.BoolCompareNat():
+                return self.translate_BoolCompareNat(expression)
+            case vcl_ast.BoolCompareRatTensor():
+                return self.translate_BoolCompareRatTensor(expression)
+            case vcl_ast.BoolReduceAnd():
+                return self.translate_BoolReduceAnd(expression)
+            case vcl_ast.BoolReduceOr():
+                return self.translate_BoolReduceOr(expression)
+            case vcl_ast.BoolIf():
+                return self.translate_BoolIf(expression)
             case vcl_ast.RatTensor():
                 return self.translate_RatTensor(expression)
             case vcl_ast.AddRatTensor():
@@ -118,6 +140,53 @@ class ABCTranslation(
 
     @abstractmethod
     def translate_Pi(self, expression: vcl_ast.Pi) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolTensor(
+        self, expression: vcl_ast.BoolTensor
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolNot(self, expression: vcl_ast.BoolNot) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolAnd(self, expression: vcl_ast.BoolAnd) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolOr(self, expression: vcl_ast.BoolOr) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolImplies(
+        self, expression: vcl_ast.BoolImplies
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolCompareIndex(
+        self, expression: vcl_ast.BoolCompareIndex
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolCompareNat(
+        self, expression: vcl_ast.BoolCompareNat
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolCompareRatTensor(
+        self, expression: vcl_ast.BoolCompareRatTensor
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolReduceAnd(
+        self, expression: vcl_ast.BoolReduceAnd
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolReduceOr(
+        self, expression: vcl_ast.BoolReduceOr
+    ) -> vcl_var.Expression: ...
+
+    @abstractmethod
+    def translate_BoolIf(self, expression: vcl_ast.BoolIf) -> vcl_var.Expression: ...
 
     @abstractmethod
     def translate_RatTensor(

--- a/vehicle-python/src/vehicle_lang/loss/_python/_translation.py
+++ b/vehicle-python/src/vehicle_lang/loss/_python/_translation.py
@@ -190,6 +190,94 @@ class PythonTranslation(ABCTranslation[py.Module, py.stmt, py.expr]):
     def translate_Pi(self, expression: vcl.Pi) -> py.expr:
         raise EraseType()
 
+    def translate_BoolTensor(self, expression: vcl.BoolTensor) -> py.expr:
+        return py_tensor(expression.contents, provenance=vcl.MISSING)
+
+    def translate_BoolNot(self, expression: vcl.BoolNot) -> py.expr:
+        return py_app(
+            py_builtin("BoolNot", provenance=vcl.MISSING),
+            self.translate_expression(expression.x),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolAnd(self, expression: vcl.BoolAnd) -> py.expr:
+        return py_app(
+            py_builtin("BoolAnd", provenance=vcl.MISSING),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolOr(self, expression: vcl.BoolOr) -> py.expr:
+        return py_app(
+            py_builtin("BoolOr", provenance=vcl.MISSING),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolImplies(self, expression: vcl.BoolImplies) -> py.expr:
+        return py_app(
+            py_builtin("BoolImplies", provenance=vcl.MISSING),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolCompareIndex(self, expression: vcl.BoolCompareIndex) -> py.expr:
+        return py_app(
+            py_builtin("BoolCompareIndex", provenance=vcl.MISSING),
+            py.Constant(value=expression.op, **asdict(vcl.MISSING)),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolCompareNat(self, expression: vcl.BoolCompareNat) -> py.expr:
+        return py_app(
+            py_builtin("BoolCompareNat", provenance=vcl.MISSING),
+            py.Constant(value=expression.op, **asdict(vcl.MISSING)),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolCompareRatTensor(
+        self, expression: vcl.BoolCompareRatTensor
+    ) -> py.expr:
+        return py_app(
+            py_builtin("BoolCompareRatTensor", provenance=vcl.MISSING),
+            py.Constant(value=expression.op, **asdict(vcl.MISSING)),
+            self.translate_expression(expression.p_dims),
+            self.translate_expression(expression.r_dims),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolReduceAnd(self, expression: vcl.BoolReduceAnd) -> py.expr:
+        return py_app(
+            py_builtin("BoolReduceAnd", provenance=vcl.MISSING),
+            self.translate_expression(expression.x),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolReduceOr(self, expression: vcl.BoolReduceOr) -> py.expr:
+        return py_app(
+            py_builtin("BoolReduceOr", provenance=vcl.MISSING),
+            self.translate_expression(expression.x),
+            provenance=vcl.MISSING,
+        )
+
+    def translate_BoolIf(self, expression: vcl.BoolIf) -> py.expr:
+        return py_app(
+            py_builtin("BoolIf", provenance=vcl.MISSING),
+            self.translate_expression(expression.c),
+            self.translate_expression(expression.x),
+            self.translate_expression(expression.y),
+            provenance=vcl.MISSING,
+        )
+
     def translate_RatTensor(self, expression: vcl.RatTensor) -> py.expr:
         """Translate RatTensor to tensor creation."""
         return py_tensor(expression.contents, provenance=vcl.MISSING)
@@ -548,7 +636,7 @@ def py_tuple(elements: list[py.expr], provenance: vcl.Provenance) -> py.expr:
     )
 
 
-def py_tensor(tensor: vcl.Tensor, provenance: vcl.Provenance) -> py.expr:
+def py_tensor(tensor: vcl.Tensor[vcl.DType], provenance: vcl.Provenance) -> py.expr:
     """Make a tensor by calling appropriate builtin."""
     match tensor:
         case vcl.DenseTensor():
@@ -556,7 +644,7 @@ def py_tensor(tensor: vcl.Tensor, provenance: vcl.Provenance) -> py.expr:
             return py_app(
                 py_builtin("DenseTensor", provenance=provenance),
                 py_tuple(
-                    [py_scalar(val, provenance=provenance) for val in tensor.value],
+                    [py_scalar(val, provenance=provenance) for val in tensor.values],
                     provenance=provenance,
                 ),
                 py_tuple(

--- a/vehicle-python/src/vehicle_lang/loss/_pytorch/_builtins.py
+++ b/vehicle-python/src/vehicle_lang/loss/_pytorch/_builtins.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from fractions import Fraction
 from typing import TYPE_CHECKING, Any, Callable, List, Sequence, Tuple, cast
 
 from typing_extensions import override
@@ -43,6 +42,32 @@ def _extended_rational_to_float(value: _nodes.ExtendedFraction) -> float:
             raise ValueError(f"Unknown extended rational type: {type(value)}")
 
 
+def _value_to_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, _nodes.ExtendedFraction):
+        return bool(_extended_rational_to_float(value))
+    return bool(value)
+
+
+def _comparison(op: str, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    match op:
+        case "Eq":
+            return torch.eq(x, y)
+        case "Ne":
+            return torch.ne(x, y)
+        case "Le":
+            return torch.le(x, y)
+        case "Lt":
+            return torch.lt(x, y)
+        case "Ge":
+            return torch.ge(x, y)
+        case "Gt":
+            return torch.gt(x, y)
+        case _:
+            raise VehicleInternalError(f"Unknown comparison operation: {op}")
+
+
 ################################################################################
 ### Interpretations of Vehicle builtins in PyTorch
 ################################################################################
@@ -61,22 +86,87 @@ class PyTorchBuiltins(
     dtype_rat: torch.dtype = torch.float32
 
     @override
+    def BoolTensor(self, x: _nodes.Tensor[bool]) -> torch.Tensor:
+        match x:
+            case _nodes.DenseTensor():
+                values = x.values
+            case _nodes.ConstantTensor():
+                values = (x.value,)
+            case _:
+                raise VehicleInternalError(f"Unknown tensor type: {type(x)}.")
+
+        return _torch_tensor(data=values, dtype=torch.bool).reshape(x.shape)
+
+    @override
+    def BoolNot(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.logical_not(x)
+
+    @override
+    def BoolAnd(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.logical_and(x, y)
+
+    @override
+    def BoolOr(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.logical_or(x, y)
+
+    @override
+    def BoolImplies(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.logical_or(torch.logical_not(x), y)
+
+    @override
+    def BoolCompareIndex(self, op: str, x: int, y: int) -> torch.Tensor:
+        tx = _torch_tensor(data=x, dtype=self.dtype_index)
+        ty = _torch_tensor(data=y, dtype=self.dtype_index)
+        return _comparison(op, tx, ty)
+
+    @override
+    def BoolCompareNat(self, op: str, x: int, y: int) -> torch.Tensor:
+        tx = _torch_tensor(data=x, dtype=self.dtype_index)
+        ty = _torch_tensor(data=y, dtype=self.dtype_index)
+        return _comparison(op, tx, ty)
+
+    @override
+    def BoolCompareRatTensor(
+        self,
+        op: str,
+        pointwise_dims: Sequence[int],
+        reduce_dims: Sequence[int],
+        x: torch.Tensor,
+        y: torch.Tensor,
+    ) -> torch.Tensor:
+        _ = pointwise_dims
+        result = _comparison(op, torch.as_tensor(x), torch.as_tensor(y))
+        for _ in reduce_dims:
+            result = torch.all(result, dim=-1)
+        return result
+
+    @override
+    def BoolReduceAnd(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.all(x)
+
+    @override
+    def BoolReduceOr(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.any(x)
+
+    @override
+    def BoolIf(self, c: torch.Tensor, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.where(c, x, y)
+
+    @override
     def Index(self, value: int) -> int:
         return value
 
     @override
-    def RatTensor(self, value: _nodes.Tensor) -> torch.Tensor:
-        match value.value:
-            case _nodes.ExtendedFraction():
-                # Single value - expand to tensor shape
-                float_value = _extended_rational_to_float(value.value)
-                return _torch_tensor(data=float_value, dtype=self.dtype_rat)
+    def RatTensor(self, x: _nodes.Tensor[_nodes.ExtendedFraction]) -> torch.Tensor:
+        match x:
+            case _nodes.DenseTensor():
+                values = tuple(_extended_rational_to_float(val) for val in x.values)
+            case _nodes.ConstantTensor():
+                values = (_extended_rational_to_float(x.value),)
             case _:
-                # Sequence of values
-                return _torch_tensor(
-                    data=tuple(_extended_rational_to_float(val) for val in value.value),
-                    dtype=self.dtype_rat,
-                )
+                raise VehicleInternalError(f"Unknown tensor type: {type(x)}.")
+
+        return _torch_tensor(data=values, dtype=self.dtype_rat).reshape(x.shape)
 
     @override
     def NegRatTensor(self, x: torch.Tensor) -> torch.Tensor:

--- a/vehicle-python/src/vehicle_lang/loss/_tensorflow/_builtins.py
+++ b/vehicle-python/src/vehicle_lang/loss/_tensorflow/_builtins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc
 from dataclasses import dataclass
 from fractions import Fraction
 from typing import TYPE_CHECKING, Any, Callable, List, Sequence, Tuple, cast
@@ -43,6 +44,32 @@ def _extended_rational_to_float(value: _nodes.ExtendedFraction) -> float:
             raise ValueError(f"Unknown extended rational type: {type(value)}")
 
 
+def _value_to_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, _nodes.ExtendedFraction):
+        return bool(_extended_rational_to_float(value))
+    return bool(value)
+
+
+def _comparison(op: str, x: tf.Tensor, y: tf.Tensor) -> tf.Tensor:
+    match op:
+        case "Eq":
+            return tf.equal(x, y)
+        case "Ne":
+            return tf.not_equal(x, y)
+        case "Le":
+            return tf.less_equal(x, y)
+        case "Lt":
+            return tf.less(x, y)
+        case "Ge":
+            return tf.greater_equal(x, y)
+        case "Gt":
+            return tf.greater(x, y)
+        case _:
+            raise error.VehicleInternalError(f"Unknown comparison operation: {op}")
+
+
 ################################################################################
 ### Interpretations of Vehicle builtins in Tensorflow
 ################################################################################
@@ -61,23 +88,87 @@ class TensorFlowBuiltins(
     dtype_rat: tf.DType = tf.float32
 
     @override
-    def RatTensor(self, value: _nodes.Tensor) -> tf.Tensor:
-        match value.value:
-            case _nodes.ExtendedFraction():
-                # Single value - expand to tensor shape
-                float_value = _extended_rational_to_float(value.value)
-                return _tf_constant(
-                    value=float_value, dtype=self.dtype_rat, shape=value.shape
-                )
+    def BoolTensor(self, x: _nodes.Tensor[bool]) -> tf.Tensor:
+        match x:
+            case _nodes.DenseTensor():
+                values = x.values
+            case _nodes.ConstantTensor():
+                values = (x.value,)
             case _:
-                # Sequence of values
-                return _tf_constant(
-                    value=tuple(
-                        _extended_rational_to_float(val) for val in value.value
-                    ),
-                    dtype=self.dtype_rat,
-                    shape=value.shape,
+                raise error.VehicleInternalError(f"Unknown tensor type: {type(x)}.")
+
+        return _tf_constant(data=values, dtype=tf.bool, shape=x.shape)
+
+    @override
+    def BoolNot(self, x: tf.Tensor) -> tf.Tensor:
+        return tf.logical_not(x)
+
+    @override
+    def BoolAnd(self, x: tf.Tensor, y: tf.Tensor) -> tf.Tensor:
+        return tf.logical_and(x, y)
+
+    @override
+    def BoolOr(self, x: tf.Tensor, y: tf.Tensor) -> tf.Tensor:
+        return tf.logical_or(x, y)
+
+    @override
+    def BoolImplies(self, x: tf.Tensor, y: tf.Tensor) -> tf.Tensor:
+        return tf.logical_or(tf.logical_not(x), y)
+
+    @override
+    def BoolCompareIndex(self, op: str, x: int, y: int) -> tf.Tensor:
+        tx = _tf_constant(value=x, dtype=self.dtype_index)
+        ty = _tf_constant(value=y, dtype=self.dtype_index)
+        return _comparison(op, tx, ty)
+
+    @override
+    def BoolCompareNat(self, op: str, x: int, y: int) -> tf.Tensor:
+        tx = _tf_constant(value=x, dtype=self.dtype_index)
+        ty = _tf_constant(value=y, dtype=self.dtype_index)
+        return _comparison(op, tx, ty)
+
+    @override
+    def BoolCompareRatTensor(
+        self,
+        op: str,
+        pointwise_dims: Sequence[int],
+        reduce_dims: Sequence[int],
+        x: tf.Tensor,
+        y: tf.Tensor,
+    ) -> tf.Tensor:
+        _ = pointwise_dims
+        result = _comparison(op, x, y)
+        for _ in reduce_dims:
+            result = tf.reduce_all(result, axis=-1)
+        return result
+
+    @override
+    def BoolReduceAnd(self, x: tf.Tensor) -> tf.Tensor:
+        return tf.reduce_all(x)
+
+    @override
+    def BoolReduceOr(self, x: tf.Tensor) -> tf.Tensor:
+        return tf.reduce_any(x)
+
+    @override
+    def BoolIf(self, c: tf.Tensor, x: tf.Tensor, y: tf.Tensor) -> tf.Tensor:
+        return tf.where(c, x, y)
+
+    @override
+    def RatTensor(self, x: _nodes.Tensor[_nodes.ExtendedFraction]) -> tf.Tensor:
+        match x:
+            case _nodes.DenseTensor():
+                float_values = tuple(
+                    _extended_rational_to_float(val) for val in x.values
                 )
+            case _nodes.ConstantTensor():
+                float_values = (_extended_rational_to_float(x.value),)
+            case _:
+                raise error.VehicleInternalError(
+                    f"Unexpected type for RatTensor: {type(x)}"
+                )
+
+        return _tf_constant(value=float_values, dtype=self.dtype_rat, shape=x.shape)
 
     @override
     def NegRatTensor(self, x: tf.Tensor) -> tf.Tensor:

--- a/vehicle/src/Vehicle/Backend/ITP/Agda.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Agda.hs
@@ -615,6 +615,7 @@ compileBuiltinFunction p f args = case f of
   ForeachVector -> annotateApp [VehicleUtils] Nothing "foreachVector" args
   StackTensor {} -> annotateApp [DataTensor] Nothing "stack" args
   Transpose -> annotateApp [DataTensor] Nothing "transpose" args
+  SearchRatTensor {} -> unsupportedError "search"
   Iterate -> unsupportedError "Iterate"
   Pow {} -> unsupportedError "^"
   Log {} -> unsupportedError "log"

--- a/vehicle/src/Vehicle/Backend/ITP/Imandra.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Imandra.hs
@@ -700,6 +700,7 @@ compileBuiltin _isOutType moduleDefs b args = case b of
     Transpose -> annotateApp moduleDefs [RequireImport ImlVehicle] "tensor_transpose" args
     AtVector -> annotateApp moduleDefs [] "List.nth" args
     ForeachVector -> idxBasedOp moduleDefs "foreach_tuple" args
+    SearchRatTensor {} -> unsupportedError
     Iterate -> unsupportedError
     Pow {} -> unsupportedError
     Log {} -> unsupportedError

--- a/vehicle/src/Vehicle/Backend/ITP/Isabelle.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Isabelle.hs
@@ -870,6 +870,7 @@ compileBuiltin isOutType localeAssms b args = case b of
     StackTensor -> compileStack localeAssms args
     AtVector -> annotateApp localeAssms [] "tnth" args
     ForeachVector -> idxBasedOp localeAssms "foreachTuple" args
+    SearchRatTensor {} -> unsupportedError
     Iterate -> unsupportedError
     Pow {} -> unsupportedError
     Log {} -> unsupportedError

--- a/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
+++ b/vehicle/src/Vehicle/Backend/ITP/Rocq.hs
@@ -577,6 +577,7 @@ compileBuiltin b args = case b of
     AtVector -> compileApplication [MathcompImport Boot] "tnth" args
     ForeachVector -> compileApplication [VehicleImport VehicleUtils] "foreachTuple" args
     QuantifyRecord q -> compileQuantifierFunction q args
+    SearchRatTensor {} -> unsupportedError
     Iterate -> unsupportedError
     Pow {} -> unsupportedError
     Log {} -> unsupportedError

--- a/vehicle/src/Vehicle/Backend/Loss/Domain.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/Domain.hs
@@ -32,6 +32,7 @@ import Vehicle.Data.Bound
 import Vehicle.Data.Bound.FourierMotzkinElimination (fourierMotzkinTensorBoundsElimination)
 import Vehicle.Data.Builtin.Interface (Accessor (..))
 import Vehicle.Data.Builtin.Loss
+import Vehicle.Data.Builtin.Loss qualified as L
 import Vehicle.Data.Builtin.Standard
 import Vehicle.Data.Code.BooleanExpr (BooleanExpr (..), DisjunctAll (..), andBoolExpr, conjunctDisjunctsM, disjunctDisjuncts, disjunctsToList, elimIfTree, eliminateTrivialDisjunctions, flattenBoolExpr)
 import Vehicle.Data.Code.ForcedValue
@@ -184,19 +185,18 @@ compileConstraints finalCtx dims binder var (maybeConstraints, maybeRemainder) =
           remDoc <- maybe (return "") (fmap lineIndent . prettyFriendlyInCtx) remainingTree
           return $ "remaining-constraints:" <> remDoc
 
-        finalValue <- compileSearch varName dims binder remainder domain
+        finalValue <- compileSearch dims binder remainder domain
         return $ singletonPartition (remainingTree, Just finalValue)
     NonTrivial <$> disjunctPartitions newPartitions
 
 compileSearch ::
   (MonadLogic m) =>
-  Name ->
   Thunk Builtin ->
   UnforcedBinder Builtin ->
   Closure LossBuiltin ->
   Domain (DimensionedTensorValue LossBuiltin) ->
   m (Thunk LossBuiltin)
-compileSearch varName dims binder closure (Domain lowerBound upperBound) = do
+compileSearch dims binder closure (Domain lowerBound upperBound) = do
   -- Convert the binder and the dimensions.
   lossBinder <- traverse convertQuantifierlessExprToLoss binder
   lossDims <- convertQuantifierlessExprToLoss dims
@@ -214,7 +214,7 @@ compileSearch varName dims binder closure (Domain lowerBound upperBound) = do
               searchUpperBound = tensorValue $ upperBoundValue upperBound,
               searchPredicate = lossPredicate
             }
-  return $ Forced $ VBuiltin (LossBuiltinExtraFunction $ SearchRatTensor varName) spine
+  return $ Forced $ VBuiltin (LossBuiltinFunction $ L.SearchRatTensor) spine
 
 findTensorBounds ::
   forall m.

--- a/vehicle/src/Vehicle/Backend/Loss/JSON.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/JSON.hs
@@ -15,7 +15,7 @@ import Prettyprinter (Pretty (..), (<+>))
 import Vehicle.Compile.Arity
 import Vehicle.Compile.Error
 import Vehicle.Compile.Normalise.Force
-import Vehicle.Compile.Prelude (Ix (..))
+import Vehicle.Compile.Prelude (Ix (..), getBinderName)
 import Vehicle.Compile.Prelude qualified as S (Binder, Decl, Expr (..), GenericDecl (..), GenericProg (..), Prog)
 import Vehicle.Compile.Prelude.Utils (getNamedBinderInfo)
 import Vehicle.Compile.Print
@@ -25,11 +25,12 @@ import Vehicle.Data.AST.Decl
   )
 import Vehicle.Data.AST.Expr.Scoped (normAppList)
 import Vehicle.Data.Builtin.Interface (Accessor (..))
-import Vehicle.Data.Builtin.Loss (LossBuiltin (..), LossBuiltinConstructor, LossBuiltinExtraFunction, LossBuiltinFunction, LossBuiltinType)
-import Vehicle.Data.Builtin.Loss qualified as L
+import Vehicle.Data.Builtin.Standard.Core (Builtin (..), BuiltinConstructor, BuiltinFunction, BuiltinType)
+import Vehicle.Data.Builtin.Standard.Core qualified as B
+import Vehicle.Data.Builtin.Standard.Normalise ()
 import Vehicle.Data.Code.ForcedValue
 import Vehicle.Data.Code.Interface.Args
-import Vehicle.Data.Tensor (ExtendedRatTensor)
+import Vehicle.Data.Tensor (ExtendedRatTensor, Tensor)
 import Vehicle.Data.Variable.Bound.Context.Name
 import Vehicle.Data.Variable.Free.Context (MonadFreeContext, runFreshFreeContextT)
 import Vehicle.Prelude (Doc, GenericArg (..), HasName (..), HasType (..), Identifier (..), Name, Provenance, explicit, indent, jsonOptions, line, mkExplicitBinder, resolutionError, squotes, stdlibIdentifier, userModulePath)
@@ -40,15 +41,15 @@ import Vehicle.Prelude.Logging.Class
 -- Public method
 --------------------------------------------------------------------------------
 
-convertToJSONProg :: (MonadCompile m) => S.Prog LossBuiltin -> m JProg
+convertToJSONProg :: (MonadCompile m) => S.Prog Builtin -> m JProg
 convertToJSONProg prog =
   logCompilerSection2 MinDetail currentPass $ do
     -- relevantProg <- removeIrrelevantCodeFromProg prog
-    runFreshFreeContextT (Proxy @LossBuiltin) $
+    runFreshFreeContextT (Proxy @Builtin) $
       runFreshNameBoundContextT $
         convertProg prog
 
-convertFromJSONProg :: JProg -> S.Prog LossBuiltin
+convertFromJSONProg :: JProg -> S.Prog Builtin
 convertFromJSONProg = fromJProg
 
 --------------------------------------------------------------------------------
@@ -69,6 +70,7 @@ data JBinder
 
 data JType
   = Pi JType JType
+  | BoolType
   | RatType
   | TensorType JType
   | VectorType JType
@@ -82,6 +84,17 @@ data JExpr
   = -- Types
     Lam JBinder JExpr
   | Var Name [JExpr]
+  | BoolTensor (Tensor Bool)
+  | BoolNot JExpr
+  | BoolAnd JExpr JExpr
+  | BoolOr JExpr JExpr
+  | BoolImplies JExpr JExpr
+  | BoolCompareIndex B.ComparisonOp JExpr JExpr
+  | BoolCompareNat B.ComparisonOp JExpr JExpr
+  | BoolCompareRatTensor B.ComparisonOp JExpr JExpr JExpr JExpr
+  | BoolReduceAnd JExpr
+  | BoolReduceOr JExpr
+  | BoolIf JExpr JExpr JExpr
   | -- Rational tensors
     RatTensor ExtendedRatTensor
   | NegRatTensor JExpr
@@ -130,6 +143,9 @@ instance ToJSON JType where
 instance ToJSON JBinder where
   toJSON = genericToJSON jsonOptions
 
+instance ToJSON B.ComparisonOp where
+  toJSON = toJSON . show
+
 --------------------------------------------------------------------------------
 -- Conversion to JExpr
 --------------------------------------------------------------------------------
@@ -140,7 +156,7 @@ currentPass = "conversion to JSON"
 type MonadJSON m =
   ( MonadCompile m,
     MonadNameContext m,
-    MonadFreeContext LossBuiltin m
+    MonadFreeContext Builtin m
   )
 
 unsupportedError :: (MonadJSON m, Pretty a) => a -> m b
@@ -152,10 +168,10 @@ dependentTypesError b = developerError $ "Conversion of" <+> pretty b <+> "is no
 --------------------------------------------------------------------------------
 -- Programs and declarations
 
-convertProg :: (MonadJSON m) => S.Prog LossBuiltin -> m JProg
+convertProg :: (MonadJSON m) => S.Prog Builtin -> m JProg
 convertProg (S.Main decls) = Main <$> traverse convertDecl decls
 
-convertDecl :: (MonadJSON m) => S.Decl LossBuiltin -> m JDecl
+convertDecl :: (MonadJSON m) => S.Decl Builtin -> m JDecl
 convertDecl = \case
   S.DefAbstract {} -> developerError "Found abstract definition when converting to JSON"
   S.DefRecord {} -> developerError "Found record when converting to JSON"
@@ -169,12 +185,12 @@ convertDecl = \case
 
 convertType ::
   (MonadJSON m) =>
-  BoundEnv LossBuiltin ->
-  S.Expr LossBuiltin ->
+  BoundEnv Builtin ->
+  S.Expr Builtin ->
   m JType
 convertType env body = convertTypeValue $ Unforced env body
 
-convertTypeValue :: (MonadJSON m) => UnforcedType LossBuiltin -> m JType
+convertTypeValue :: (MonadJSON m) => UnforcedType Builtin -> m JType
 convertTypeValue expr = do
   showEntry expr
   forcedExpr <- forceThunk expr
@@ -196,47 +212,48 @@ convertTypeValue expr = do
   showExit result
   return result
 
-convertBuiltinType :: (MonadJSON m) => LossBuiltin -> UnforcedSpine LossBuiltin -> m JType
+convertBuiltinType :: (MonadJSON m) => Builtin -> UnforcedSpine Builtin -> m JType
 convertBuiltinType b spine = case b of
-  LossBuiltinType op -> case op of
-    L.UnitType -> unsupportedError b
-    L.IndexType -> convertIndexType spine
-    L.NatType -> convertNullaryOp b DimensionType spine
-    L.RatType -> convertNullaryOp b RatType spine
-    L.ListType -> convertListType spine
-    L.TensorType -> convertTensorType spine
-    L.VectorType -> convertVectorType spine
+  BuiltinType op -> case op of
+    B.UnitType -> unsupportedError b
+    B.BoolType -> convertNullaryOp b BoolType spine
+    B.IndexType -> convertIndexType spine
+    B.NatType -> convertNullaryOp b DimensionType spine
+    B.RatType -> convertNullaryOp b RatType spine
+    B.ListType -> convertListType spine
+    B.TensorType -> convertTensorType spine
+    B.VectorType -> convertVectorType spine
   _ -> dependentTypesError b
 
-convertIndexType :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JType
+convertIndexType :: (MonadJSON m) => UnforcedSpine Builtin -> m JType
 convertIndexType spine = case spine of
   (fmap argExpr -> [_t]) -> return DimensionIndexType
-  _ -> arityError L.IndexType 1 spine
+  _ -> arityError B.IndexType 1 spine
 
-convertTensorType :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JType
+convertTensorType :: (MonadJSON m) => UnforcedSpine Builtin -> m JType
 convertTensorType spine = case spine of
   (fmap argExpr -> [t, _ds]) -> TensorType <$> convertTypeValue t
-  _ -> arityError L.TensorType 2 spine
+  _ -> arityError B.TensorType 2 spine
 
-convertVectorType :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JType
+convertVectorType :: (MonadJSON m) => UnforcedSpine Builtin -> m JType
 convertVectorType spine = case spine of
   (fmap argExpr -> [t, _d]) -> VectorType <$> convertTypeValue t
-  _ -> arityError L.VectorType 2 spine
+  _ -> arityError B.VectorType 2 spine
 
-convertListType :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JType
+convertListType :: (MonadJSON m) => UnforcedSpine Builtin -> m JType
 convertListType spine = case spine of
   (fmap argExpr -> [_t]) -> return DimensionsType
-  _ -> arityError L.ListType 1 spine
+  _ -> arityError B.ListType 1 spine
 
 --------------------------------------------------------------------------------
 -- Expressions
 
-convertExpr :: (MonadJSON m) => BoundEnv LossBuiltin -> S.Expr LossBuiltin -> m JExpr
+convertExpr :: (MonadJSON m) => BoundEnv Builtin -> S.Expr Builtin -> m JExpr
 convertExpr env body = do
   let normBody = Unforced env body
   convertValue normBody
 
-convertValue :: (MonadJSON m) => Thunk LossBuiltin -> m JExpr
+convertValue :: (MonadJSON m) => Thunk Builtin -> m JExpr
 convertValue expr = do
   showEntry expr
   forcedValue <- forceThunk expr
@@ -258,7 +275,7 @@ convertValue expr = do
   showExit result
   return result
 
-convertBinder :: (MonadJSON m) => UnforcedBinder LossBuiltin -> m JBinder
+convertBinder :: (MonadJSON m) => UnforcedBinder Builtin -> m JBinder
 convertBinder binder = do
   let (name, p) = getNamedBinderInfo binder
   typ' <- convertTypeValue (typeOf binder)
@@ -266,9 +283,9 @@ convertBinder binder = do
 
 convertClosure ::
   (MonadJSON m) =>
-  (BoundEnv LossBuiltin -> S.Expr LossBuiltin -> m a) ->
-  UnforcedBinder LossBuiltin ->
-  Closure LossBuiltin ->
+  (BoundEnv Builtin -> S.Expr Builtin -> m a) ->
+  UnforcedBinder Builtin ->
+  Closure Builtin ->
   m a
 convertClosure f binder (Closure env body) = do
   lv <- getBinderDepth
@@ -277,51 +294,65 @@ convertClosure f binder (Closure env body) = do
     debugFriendly body
     f newEnv body
 
-convertBuiltin :: (MonadJSON m) => LossBuiltin -> UnforcedSpine LossBuiltin -> m JExpr
+convertBuiltin :: (MonadJSON m) => Builtin -> UnforcedSpine Builtin -> m JExpr
 convertBuiltin b spine = case b of
-  LossBuiltinType op -> resolutionError currentPass (pretty op)
-  LossBuiltinConstructor op -> case op of
-    L.Nil -> convertNil spine
-    L.Cons -> convertCons spine
-    L.UnitLiteral -> unsupportedError b
-    L.NatTensorLiteral _ -> unsupportedError b
-    L.IndexLiteral i -> convertNullaryOp b (DimensionIndex i) []
-    L.NatLiteral x -> convertNullaryOp b (Dimension x) spine
-    L.RatTensorLiteral t -> convertNullaryOp b (RatTensor t) spine
-    L.VectorLiteral -> convertVectorLiteral spine
-  LossBuiltinFunction op -> case op of
-    L.Neg L.NegRatTensor -> convertTensorOp1 b NegRatTensor spine
-    L.Add L.AddRatTensor -> convertTensorOp2 b AddRatTensor spine
-    L.Mul L.MulRatTensor -> convertTensorOp2 b MulRatTensor spine
-    L.Sub L.SubRatTensor -> convertTensorOp2 b SubRatTensor spine
-    L.Div L.DivRatTensor -> convertTensorOp2 b DivRatTensor spine
-    L.Min L.MinRatTensor -> convertTensorOp2 b MinRatTensor spine
-    L.Max L.MaxRatTensor -> convertTensorOp2 b MaxRatTensor spine
-    L.Pow L.PowRatTensor -> convertTensorOp2 b PowRatTensor spine
-    L.Log L.LogRatTensor -> convertTensorOp1 b LogRatTensor spine
-    L.Exp L.ExpRatTensor -> convertTensorOp1 b ExpRatTensor spine
-    L.ReduceAddRatTensor -> convertTensorReduction b ReduceAddRatTensor spine
-    L.ReduceMulRatTensor -> convertTensorReduction b ReduceMulRatTensor spine
-    L.ReduceMinRatTensor -> convertTensorReduction b ReduceMinRatTensor spine
-    L.ReduceMaxRatTensor -> convertTensorReduction b ReduceMaxRatTensor spine
-    L.AtTensor -> convertAtTensor spine
-    L.ForeachTensor -> convertForeachTensor spine
-    L.StackTensor -> convertStackTensor spine
-    L.ConstTensor -> convertConstTensor spine
-    L.Transpose -> convertTranspose convertValue spine
-    L.ForeachVector -> convertForeachVector spine
-    L.AtVector -> convertAtVector spine
+  BuiltinType op -> resolutionError currentPass (pretty op)
+  BuiltinConstructor op -> case op of
+    B.Nil -> convertNil spine
+    B.Cons -> convertCons spine
+    B.UnitLiteral -> unsupportedError b
+    B.BoolTensorLiteral t -> convertNullaryOp b (BoolTensor t) spine
+    B.NatTensorLiteral _ -> unsupportedError b
+    B.IndexLiteral i -> convertNullaryOp b (DimensionIndex i) []
+    B.NatLiteral x -> convertNullaryOp b (Dimension x) spine
+    B.RatTensorLiteral t -> convertNullaryOp b (RatTensor t) spine
+    B.VectorLiteral -> convertVectorLiteral spine
+  BuiltinFunction op -> case op of
+    B.Not -> convertTensorOp1 b BoolNot spine
+    B.And -> convertTensorOp2 b BoolAnd spine
+    B.Or -> convertTensorOp2 b BoolOr spine
+    B.Implies -> convertTensorOp2 b BoolImplies spine
+    B.QuantifyRatTensor {} -> developerError "QuantifyRatTensor should not have reached JSON conversion"
+    B.QuantifyRecord {} -> developerError "QuantifyRecord should not have reached JSON conversion"
+    B.If -> convertIf spine
+    B.CompareIndex cmp -> convertCompareIndex cmp spine
+    B.CompareNat cmp -> convertCompareNat cmp spine
+    B.CompareRatTensor cmp -> convertCompareRatTensor cmp spine
+    B.ReduceAndTensor -> convertTensorReduction b BoolReduceAnd spine
+    B.ReduceOrTensor -> convertTensorReduction b BoolReduceOr spine
+    B.Neg B.NegRatTensor -> convertTensorOp1 b NegRatTensor spine
+    B.Add B.AddRatTensor -> convertTensorOp2 b AddRatTensor spine
+    B.Mul B.MulRatTensor -> convertTensorOp2 b MulRatTensor spine
+    B.Sub B.SubRatTensor -> convertTensorOp2 b SubRatTensor spine
+    B.Div B.DivRatTensor -> convertTensorOp2 b DivRatTensor spine
+    B.Min B.MinRatTensor -> convertTensorOp2 b MinRatTensor spine
+    B.Max B.MaxRatTensor -> convertTensorOp2 b MaxRatTensor spine
+    B.Pow B.PowRatTensor -> convertTensorOp2 b PowRatTensor spine
+    B.Log B.LogRatTensor -> convertTensorOp1 b LogRatTensor spine
+    B.Exp B.ExpRatTensor -> convertTensorOp1 b ExpRatTensor spine
+    B.ReduceAddRatTensor -> convertTensorReduction b ReduceAddRatTensor spine
+    B.ReduceMulRatTensor -> convertTensorReduction b ReduceMulRatTensor spine
+    B.ReduceMinRatTensor -> convertTensorReduction b ReduceMinRatTensor spine
+    B.ReduceMaxRatTensor -> convertTensorReduction b ReduceMaxRatTensor spine
+    B.AtTensor -> convertAtTensor spine
+    B.ForeachTensor -> convertForeachTensor spine
+    B.StackTensor -> convertStackTensor spine
+    B.ConstTensor -> convertConstTensor spine
+    B.Transpose -> convertTranspose convertValue spine
+    B.ForeachVector -> convertForeachVector spine
+    B.AtVector -> convertAtVector spine
+    B.SearchRatTensor -> convertSearch spine
     -- Dimension operations, not yet converted
-    L.Add L.AddNat -> unsupportedError b
-    L.Mul L.MulNat -> unsupportedError b
-    L.MapList -> unsupportedError b
-    L.FoldList -> unsupportedError b
-    L.ReverseList -> unsupportedError b
-    L.AppendList -> unsupportedError b
-  L.LossBuiltinExtraFunction f -> case f of
-    L.SearchRatTensor name -> convertSearch name spine
+    B.Add B.AddNat -> unsupportedError b
+    B.Mul B.MulNat -> unsupportedError b
+    B.MapList -> unsupportedError b
+    B.FoldList -> unsupportedError b
+    B.ReverseList -> unsupportedError b
+    B.AppendList -> unsupportedError b
+    B.Iterate -> unsupportedError b
+  _ -> dependentTypesError b
 
-convertNullaryOp :: (MonadJSON m) => LossBuiltin -> a -> UnforcedSpine LossBuiltin -> m a
+convertNullaryOp :: (MonadJSON m) => Builtin -> a -> UnforcedSpine Builtin -> m a
 convertNullaryOp b fn = \case
   [] -> return fn
   spine -> arityError b 0 spine
@@ -330,29 +361,29 @@ convertNonNullaryOp ::
   (MonadJSON m, IsArgs args, Pretty fn) =>
   fn ->
   Arity ->
-  (args (Thunk LossBuiltin) -> m a) ->
-  UnforcedSpine LossBuiltin ->
+  (args (Thunk Builtin) -> m a) ->
+  UnforcedSpine Builtin ->
   m a
 convertNonNullaryOp op arity f spine =
   case getExpr accessSpine spine of
     Just args -> f args
     Nothing -> arityError op arity spine
 
-convertNil :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertNil = convertNonNullaryOp L.Nil 1 $
+convertNil :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertNil = convertNonNullaryOp B.Nil 1 $
   \NilArgs {} ->
     return DimensionNil
 
-convertCons :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertCons = convertNonNullaryOp L.Cons 4 $
+convertCons :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertCons = convertNonNullaryOp B.Cons 4 $
   \(ConsArgs _t v ds) ->
     DimensionCons <$> convertValue v <*> convertValue ds
 
 convertTensorOp1 ::
   (MonadJSON m) =>
-  LossBuiltin ->
+  Builtin ->
   (JExpr -> JExpr) ->
-  UnforcedSpine LossBuiltin ->
+  UnforcedSpine Builtin ->
   m JExpr
 convertTensorOp1 b fn = convertNonNullaryOp b 1 $
   \(TensorOp1Args _ x) ->
@@ -360,9 +391,9 @@ convertTensorOp1 b fn = convertNonNullaryOp b 1 $
 
 convertTensorOp2 ::
   (MonadJSON m) =>
-  LossBuiltin ->
+  Builtin ->
   (JExpr -> JExpr -> JExpr) ->
-  UnforcedSpine LossBuiltin ->
+  UnforcedSpine Builtin ->
   m JExpr
 convertTensorOp2 b fn = convertNonNullaryOp b 2 $
   \(TensorOp2Args _ x y) ->
@@ -370,9 +401,9 @@ convertTensorOp2 b fn = convertNonNullaryOp b 2 $
 
 convertTensorReduction ::
   (MonadJSON m) =>
-  LossBuiltin ->
+  Builtin ->
   (JExpr -> JExpr) ->
-  UnforcedSpine LossBuiltin ->
+  UnforcedSpine Builtin ->
   m JExpr
 convertTensorReduction b fn = convertNonNullaryOp b 1 $
   \(TensorReductionArgs _ xs) ->
@@ -380,60 +411,85 @@ convertTensorReduction b fn = convertNonNullaryOp b 1 $
 
 convertAtTensor ::
   (MonadJSON m) =>
-  UnforcedSpine LossBuiltin ->
+  UnforcedSpine Builtin ->
   m JExpr
-convertAtTensor = convertNonNullaryOp L.AtTensor 5 $
+convertAtTensor = convertNonNullaryOp B.AtTensor 5 $
   \(AtTensorArgs _t _d _ds xs i) ->
     AtTensor <$> convertValue xs <*> convertValue i
 
-convertStackTensor :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertStackTensor = convertNonNullaryOp L.StackTensor 4 $
+convertStackTensor :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertStackTensor = convertNonNullaryOp B.StackTensor 4 $
   \(StackTensorArgs _t _d _ds xs) ->
     StackTensor <$> traverse convertValue xs
 
-convertConstTensor :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertConstTensor = convertNonNullaryOp L.ConstTensor 4 $
+convertConstTensor :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertConstTensor = convertNonNullaryOp B.ConstTensor 4 $
   \(ConstTensorArgs _t v ds) ->
     ConstTensor <$> convertValue v <*> convertValue ds
 
-convertForeachTensor :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertForeachTensor = convertNonNullaryOp L.ForeachTensor 4 $
+convertForeachTensor :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertForeachTensor = convertNonNullaryOp B.ForeachTensor 4 $
   \(ForeachTensorArgs _t d _ds fn) ->
     ForeachTensor <$> convertValue d <*> convertValue fn
 
-convertVectorLiteral :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertVectorLiteral = convertNonNullaryOp L.VectorLiteral 4 $
+convertVectorLiteral :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertVectorLiteral = convertNonNullaryOp B.VectorLiteral 4 $
   \(VectorLitArgs _t _ xs) ->
     VectorLiteral <$> traverse convertValue xs
 
 convertAtVector ::
   (MonadJSON m) =>
-  UnforcedSpine LossBuiltin ->
+  UnforcedSpine Builtin ->
   m JExpr
-convertAtVector = convertNonNullaryOp L.AtVector 4 $
+convertAtVector = convertNonNullaryOp B.AtVector 4 $
   \(AtVectorArgs _t _d xs i) ->
     AtVector <$> convertValue xs <*> convertValue i
 
-convertForeachVector :: (MonadJSON m) => UnforcedSpine LossBuiltin -> m JExpr
-convertForeachVector = convertNonNullaryOp L.ForeachVector 4 $
+convertForeachVector :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertForeachVector = convertNonNullaryOp B.ForeachVector 4 $
   \(ForeachVectorArgs _t d fn) ->
     ForeachVector <$> convertValue d <*> convertValue fn
 
+convertIf :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertIf = convertNonNullaryOp B.If 4 $
+  \(IfArgs _t c x y) ->
+    BoolIf <$> convertValue c <*> convertValue x <*> convertValue y
+
+convertCompareIndex :: (MonadJSON m) => B.ComparisonOp -> UnforcedSpine Builtin -> m JExpr
+convertCompareIndex op = convertNonNullaryOp (B.CompareIndex op) 4 $
+  \(IndexComparisonArgs _n1 _n2 x y) ->
+    BoolCompareIndex op <$> convertValue x <*> convertValue y
+
+convertCompareNat :: (MonadJSON m) => B.ComparisonOp -> UnforcedSpine Builtin -> m JExpr
+convertCompareNat op = convertNonNullaryOp (B.CompareNat op) 2 $
+  \(Op2Args x y) ->
+    BoolCompareNat op <$> convertValue x <*> convertValue y
+
+convertCompareRatTensor :: (MonadJSON m) => B.ComparisonOp -> UnforcedSpine Builtin -> m JExpr
+convertCompareRatTensor op = convertNonNullaryOp (B.CompareRatTensor op) 4 $
+  \(TensorComparisonArgs pDims rDims x y) ->
+    BoolCompareRatTensor op <$> convertValue pDims <*> convertValue rDims <*> convertValue x <*> convertValue y
+
 convertTranspose ::
   (MonadJSON m) =>
-  (Thunk LossBuiltin -> m JExpr) ->
-  UnforcedSpine LossBuiltin ->
+  (Thunk Builtin -> m JExpr) ->
+  UnforcedSpine Builtin ->
   m JExpr
 convertTranspose convert spine = case getExpr accessSpine spine of
   Just (TransposeTensorArgs _t _ds xs) -> Transpose <$> convert xs
-  Nothing -> arityError L.Transpose 3 spine
+  Nothing -> arityError B.Transpose 3 spine
 
-convertSearch :: (MonadJSON m) => Name -> UnforcedSpine LossBuiltin -> m JExpr
-convertSearch name = convertNonNullaryOp (L.SearchRatTensor name) 4 $
-  \(SearchRatTensorArgs dims lowerBound upperBound fn) ->
+convertSearch :: (MonadJSON m) => UnforcedSpine Builtin -> m JExpr
+convertSearch = convertNonNullaryOp B.SearchRatTensor 4 $
+  \(SearchRatTensorArgs dims lowerBound upperBound fn) -> do
+    let name = case fn of
+          Forced (VLam binder _) -> getBinderName binder
+          Unforced _ (S.Lam _ binder _) -> getBinderName binder
+          _ -> developerError "Malformed search operation"
+
     SearchRatTensor name <$> convertValue dims <*> convertValue lowerBound <*> convertValue upperBound <*> convertValue fn
 
-arityError :: (MonadCompile m, Pretty fn) => fn -> Arity -> UnforcedSpine LossBuiltin -> m a
+arityError :: (MonadCompile m, Pretty fn) => fn -> Arity -> UnforcedSpine Builtin -> m a
 arityError fun arity explicitArgs =
   compilerDeveloperError $
     "Number of args is different from expected arity:"
@@ -453,7 +509,7 @@ arityError fun arity explicitArgs =
             <+> prettyVerbose explicitArgs
         )
 
-showEntry :: (MonadJSON m) => Thunk LossBuiltin -> m ()
+showEntry :: (MonadJSON m) => Thunk Builtin -> m ()
 showEntry e = do
   logDebug MaxDetail $ "json-enter:" <+> prettyVerbose e
   incrCallDepth
@@ -467,11 +523,11 @@ showExit _e = do
 -- Conversion back (for printing purposes)
 --------------------------------------------------------------------------------
 
-fromJProg :: JProg -> S.Prog LossBuiltin
+fromJProg :: JProg -> S.Prog Builtin
 fromJProg = \case
   Main decls -> S.Main (fmap fromJDecl decls)
 
-fromJDecl :: JDecl -> S.Decl LossBuiltin
+fromJDecl :: JDecl -> S.Decl Builtin
 fromJDecl = \case
   DefFunction p name typ body ->
     runFreshNameBoundContext $ do
@@ -481,28 +537,29 @@ fromJDecl = \case
       let sort = FunctionDecl 0 (Just AnnProperty)
       return $ S.DefFunction p ident sort typ' body'
 
-fromJType :: (MonadNameContext m) => JType -> m (S.Expr LossBuiltin)
+fromJType :: (MonadNameContext m) => JType -> m (S.Expr Builtin)
 fromJType = \case
   Pi input output -> do
     input' <- fromJType input
     let binder' = mkExplicitBinder input' Nothing
     S.Pi mempty binder' <$> fromJType output
-  RatType -> toType L.RatType []
-  TensorType t -> toType L.TensorType [t]
-  VectorType t -> toType L.VectorType [t]
-  DimensionType -> toType L.NatType []
-  DimensionsType -> toType L.ListType [DimensionType]
-  DimensionIndexType -> toType L.IndexType []
+  BoolType -> toType B.BoolType []
+  RatType -> toType B.RatType []
+  TensorType t -> toType B.TensorType [t]
+  VectorType t -> toType B.VectorType [t]
+  DimensionType -> toType B.NatType []
+  DimensionsType -> toType B.ListType [DimensionType]
+  DimensionIndexType -> toType B.IndexType []
   TypeVar name spine -> do
     nameCtx <- getNameContext
     let ix = maybe (developerError ("ill-scoped JExpr, no variable" <+> squotes (pretty name))) Ix (elemIndex (Just name) nameCtx)
     spine' <- traverse fromJExpr spine
     return $ normAppList (S.BoundVar mempty ix) (fmap explicit spine')
 
-toType :: (MonadNameContext m) => LossBuiltinType -> [JType] -> m (S.Expr LossBuiltin)
-toType op = toExpr fromJType (LossBuiltinType op)
+toType :: (MonadNameContext m) => BuiltinType -> [JType] -> m (S.Expr Builtin)
+toType op = toExpr fromJType (BuiltinType op)
 
-fromJExpr :: (MonadNameContext m) => JExpr -> m (S.Expr LossBuiltin)
+fromJExpr :: (MonadNameContext m) => JExpr -> m (S.Expr Builtin)
 fromJExpr = \case
   Lam binder body -> do
     binder' <- fromJBinder binder
@@ -513,50 +570,58 @@ fromJExpr = \case
     let ix = maybe (developerError ("ill-scoped JExpr, no variable" <+> squotes (pretty name))) Ix (elemIndex (Just name) nameCtx)
     spine' <- traverse fromJExpr spine
     return $ normAppList (S.BoundVar mempty ix) (fmap explicit spine')
-  RatTensor t -> toConstructor (L.RatTensorLiteral t) []
-  NegRatTensor e -> toFunction (L.Neg L.NegRatTensor) [e]
-  LogRatTensor e -> toFunction (L.Log L.LogRatTensor) [e]
-  ExpRatTensor e -> toFunction (L.Exp L.ExpRatTensor) [e]
-  AddRatTensor e1 e2 -> toFunction (L.Add L.AddRatTensor) [e1, e2]
-  SubRatTensor e1 e2 -> toFunction (L.Sub L.SubRatTensor) [e1, e2]
-  MulRatTensor e1 e2 -> toFunction (L.Mul L.MulRatTensor) [e1, e2]
-  DivRatTensor e1 e2 -> toFunction (L.Div L.DivRatTensor) [e1, e2]
-  MinRatTensor e1 e2 -> toFunction (L.Min L.MinRatTensor) [e1, e2]
-  MaxRatTensor e1 e2 -> toFunction (L.Max L.MaxRatTensor) [e1, e2]
-  PowRatTensor e1 e2 -> toFunction (L.Pow L.PowRatTensor) [e1, e2]
-  ReduceAddRatTensor xs -> toFunction L.ReduceAddRatTensor [xs]
-  ReduceMulRatTensor xs -> toFunction L.ReduceMulRatTensor [xs]
-  ReduceMinRatTensor xs -> toFunction L.ReduceMinRatTensor [xs]
-  ReduceMaxRatTensor xs -> toFunction L.ReduceMaxRatTensor [xs]
-  SearchRatTensor name dims lower upper lambda -> toExtraFunction (L.SearchRatTensor name) [dims, lower, upper, lambda]
-  Dimension d -> toConstructor (L.NatLiteral d) []
-  DimensionNil -> toConstructor L.Nil []
-  DimensionCons e1 e2 -> toConstructor L.Cons [e1, e2]
-  DimensionIndex i -> toConstructor (L.IndexLiteral i) []
-  AtTensor xs i -> toFunction L.AtTensor [xs, i]
-  ForeachTensor _n fn -> toFunction L.ForeachTensor [fn]
-  ConstTensor c ds -> toFunction L.ConstTensor [c, ds]
-  StackTensor xs -> toFunction L.StackTensor xs
-  Transpose xs -> toFunction L.Transpose [xs]
-  VectorLiteral xs -> toConstructor L.VectorLiteral xs
-  ForeachVector _n fn -> toFunction L.ForeachVector [fn]
-  AtVector xs i -> toFunction L.AtVector [xs, i]
+  BoolTensor t -> toConstructor (B.BoolTensorLiteral t) []
+  BoolNot e -> toFunction B.Not [e]
+  BoolAnd e1 e2 -> toFunction B.And [e1, e2]
+  BoolOr e1 e2 -> toFunction B.Or [e1, e2]
+  BoolImplies e1 e2 -> toFunction B.Implies [e1, e2]
+  BoolCompareIndex op e1 e2 -> toFunction (B.CompareIndex op) [e1, e2]
+  BoolCompareNat op e1 e2 -> toFunction (B.CompareNat op) [e1, e2]
+  BoolCompareRatTensor op pDims rDims e1 e2 -> toFunction (B.CompareRatTensor op) [pDims, rDims, e1, e2]
+  BoolReduceAnd xs -> toFunction B.ReduceAndTensor [xs]
+  BoolReduceOr xs -> toFunction B.ReduceOrTensor [xs]
+  BoolIf c e1 e2 -> toFunction B.If [c, e1, e2]
+  RatTensor t -> toConstructor (B.RatTensorLiteral t) []
+  NegRatTensor e -> toFunction (B.Neg B.NegRatTensor) [e]
+  LogRatTensor e -> toFunction (B.Log B.LogRatTensor) [e]
+  ExpRatTensor e -> toFunction (B.Exp B.ExpRatTensor) [e]
+  AddRatTensor e1 e2 -> toFunction (B.Add B.AddRatTensor) [e1, e2]
+  SubRatTensor e1 e2 -> toFunction (B.Sub B.SubRatTensor) [e1, e2]
+  MulRatTensor e1 e2 -> toFunction (B.Mul B.MulRatTensor) [e1, e2]
+  DivRatTensor e1 e2 -> toFunction (B.Div B.DivRatTensor) [e1, e2]
+  MinRatTensor e1 e2 -> toFunction (B.Min B.MinRatTensor) [e1, e2]
+  MaxRatTensor e1 e2 -> toFunction (B.Max B.MaxRatTensor) [e1, e2]
+  PowRatTensor e1 e2 -> toFunction (B.Pow B.PowRatTensor) [e1, e2]
+  ReduceAddRatTensor xs -> toFunction B.ReduceAddRatTensor [xs]
+  ReduceMulRatTensor xs -> toFunction B.ReduceMulRatTensor [xs]
+  ReduceMinRatTensor xs -> toFunction B.ReduceMinRatTensor [xs]
+  ReduceMaxRatTensor xs -> toFunction B.ReduceMaxRatTensor [xs]
+  SearchRatTensor _name dims lower upper lambda -> toFunction B.SearchRatTensor [dims, lower, upper, lambda]
+  Dimension d -> toConstructor (B.NatLiteral d) []
+  DimensionNil -> toConstructor B.Nil []
+  DimensionCons e1 e2 -> toConstructor B.Cons [e1, e2]
+  DimensionIndex i -> toConstructor (B.IndexLiteral i) []
+  AtTensor xs i -> toFunction B.AtTensor [xs, i]
+  ForeachTensor _n fn -> toFunction B.ForeachTensor [fn]
+  ConstTensor c ds -> toFunction B.ConstTensor [c, ds]
+  StackTensor xs -> toFunction B.StackTensor xs
+  Transpose xs -> toFunction B.Transpose [xs]
+  VectorLiteral xs -> toConstructor B.VectorLiteral xs
+  ForeachVector _n fn -> toFunction B.ForeachVector [fn]
+  AtVector xs i -> toFunction B.AtVector [xs, i]
 
-fromJBinder :: (MonadNameContext m) => JBinder -> m (S.Binder LossBuiltin)
+fromJBinder :: (MonadNameContext m) => JBinder -> m (S.Binder Builtin)
 fromJBinder (Binder p name typ) = do
   typ' <- fromJType typ
   return $ mkExplicitBinder typ' (Just (p, name))
 
-toExpr :: (MonadNameContext m) => (a -> m (S.Expr LossBuiltin)) -> LossBuiltin -> [a] -> m (S.Expr LossBuiltin)
+toExpr :: (MonadNameContext m) => (a -> m (S.Expr Builtin)) -> Builtin -> [a] -> m (S.Expr Builtin)
 toExpr f op args = do
   args' <- traverse f args
   return $ normAppList (S.Builtin mempty op) (fmap explicit args')
 
-toConstructor :: (MonadNameContext m) => LossBuiltinConstructor -> [JExpr] -> m (S.Expr LossBuiltin)
-toConstructor op = toExpr fromJExpr (LossBuiltinConstructor op)
+toConstructor :: (MonadNameContext m) => BuiltinConstructor -> [JExpr] -> m (S.Expr Builtin)
+toConstructor op = toExpr fromJExpr (BuiltinConstructor op)
 
-toFunction :: (MonadNameContext m) => LossBuiltinFunction -> [JExpr] -> m (S.Expr LossBuiltin)
-toFunction op = toExpr fromJExpr (LossBuiltinFunction op)
-
-toExtraFunction :: (MonadNameContext m) => LossBuiltinExtraFunction -> [JExpr] -> m (S.Expr LossBuiltin)
-toExtraFunction op = toExpr fromJExpr (LossBuiltinExtraFunction op)
+toFunction :: (MonadNameContext m) => BuiltinFunction -> [JExpr] -> m (S.Expr Builtin)
+toFunction op = toExpr fromJExpr (BuiltinFunction op)

--- a/vehicle/src/Vehicle/Backend/Loss/LogicCompilation.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/LogicCompilation.hs
@@ -368,6 +368,7 @@ isLiftableOp = \case
   ForeachVector -> False
   Iterate -> False
   Transpose -> False
+  SearchRatTensor {} -> False
 
 reduceOp :: BuiltinFunction -> Maybe BuiltinFunction
 reduceOp = \case
@@ -411,6 +412,7 @@ reduceOp = \case
   ForeachVector -> Nothing
   Iterate -> Nothing
   Transpose -> Nothing
+  SearchRatTensor {} -> Nothing
 
 type MonadCompileBody m =
   ( MonadLogger m,

--- a/vehicle/src/Vehicle/Backend/Loss/LossCompilation.hs
+++ b/vehicle/src/Vehicle/Backend/Loss/LossCompilation.hs
@@ -116,6 +116,7 @@ convertThunk quantifiers = go
         S.MapList -> mkFunction MapList
         S.ReverseList -> mkFunction ReverseList
         S.AppendList -> mkFunction AppendList
+        S.SearchRatTensor -> mkFunction SearchRatTensor
         S.If -> unsupportedOperation "if"
         S.Implies -> unexpected
         S.Iterate -> unexpected

--- a/vehicle/src/Vehicle/Compile.hs
+++ b/vehicle/src/Vehicle/Compile.hs
@@ -26,7 +26,7 @@ import Vehicle.Compile.Prelude as CompilePrelude
 import Vehicle.Compile.Print (prettyFriendly)
 import Vehicle.Compile.Type.Subsystem
 import Vehicle.Data.Builtin.Decidability.Type ()
-import Vehicle.Data.Builtin.Interface.Print (PrintableBuiltin)
+import Vehicle.Data.Builtin.Interface.Print (ConvertableBuiltin (..), PrintableBuiltin)
 import Vehicle.Data.Builtin.Standard
 import Vehicle.Prelude.Logging
 import Vehicle.TypeCheck (TypeCheckOptions (..), runCompileMonad, typeCheckUserProg)
@@ -164,11 +164,15 @@ compileToLossFunction LossOptions {..} typedProg outputAsJSON = do
   lossTensorProg <- convertToLossTensors differentiableLogicID requestedDecls typedProg
   hoistedProg <- hoistInferableParameters lossTensorProg
   functionalisedProg <- functionaliseResources hoistedProg
-  jsonProg <- convertToJSONProg functionalisedProg
+  builtinProg <- traverse (traverseBuiltinsM toStandardBuiltins) functionalisedProg
+  jsonProg <- convertToJSONProg builtinProg
   let outputText
         | outputAsJSON = prettyAsJSON jsonProg
         | otherwise = prettyFriendly (convertFromJSONProg jsonProg)
   writeResultToFile Nothing outputFile outputText
+  where
+    toStandardBuiltins p b args =
+      return $ normAppList (convertBuiltin p b :: Expr Builtin) args
 
 hoistInferableParameters ::
   (MonadCompile m, PrintableBuiltin builtin) =>

--- a/vehicle/src/Vehicle/Compile/Sugar/Resugar/External.hs
+++ b/vehicle/src/Vehicle/Compile/Sugar/Resugar/External.hs
@@ -280,6 +280,7 @@ delabBuiltinFunction fun args = case fun of
   V.ConstTensor -> delabApp (B.Const tokConst) args
   V.Iterate -> rawDelab
   V.Transpose -> delabApp (B.Transpose tokTranspose) args
+  V.SearchRatTensor {} -> rawDelab
   V.ReverseList -> rawDelab
   where
     rawDelab = cheatDelabPretty fun args

--- a/vehicle/src/Vehicle/Data/Builtin/Core.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Core.hs
@@ -125,6 +125,7 @@ data BuiltinFunction
   | Iterate
   | ForeachTensor
   | Transpose
+  | SearchRatTensor
   | -- Vector operations
     AtVector
   | ForeachVector
@@ -183,6 +184,7 @@ instance Pretty BuiltinFunction where
     StackTensor {} -> "stack"
     ConstTensor -> "const"
     Transpose -> "transpose"
+    SearchRatTensor -> "search"
 
 data BuiltinCast
   = -- Cast operations

--- a/vehicle/src/Vehicle/Data/Builtin/Decidability/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Decidability/Type.hs
@@ -263,6 +263,7 @@ convertToDecidabilityBuiltins p b args = return $
         Transpose -> sameFunction f
         StackTensor -> sameFunction f
         ConstTensor -> sameFunction f
+        SearchRatTensor {} -> sameFunction f
     BuiltinConstructor c -> do
       let original = normAppList (Builtin p (StandardBuiltinConstructor c)) args
       case c of

--- a/vehicle/src/Vehicle/Data/Builtin/Interface/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Interface/Type.hs
@@ -101,6 +101,12 @@ typeOfBuiltinFunction = \case
   ForeachVector -> typeOfForeachVector
   Iterate -> forAllTypes $ \t -> ((t ~> t) ~> t ~> t) ~> tNat ~> t
   Transpose -> typeOfTranspose
+  SearchRatTensor ->
+    forAllDims $ \dims ->
+      tRatTensor dims
+        ~> tRatTensor dims
+        ~> (tRatTensor dims ~> tRatTensor dimNil)
+        ~> tRatTensor dims
 
 typeOfBuiltinConstructor :: (HasStandardBuiltins builtin) => BuiltinConstructor -> DSLExpr builtin
 typeOfBuiltinConstructor = \case

--- a/vehicle/src/Vehicle/Data/Builtin/Linearity/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Linearity/Type.hs
@@ -94,6 +94,7 @@ typeOfBuiltinFunction p = \case
   ForeachVector -> typeOfForeach
   Iterate -> typeOfIterate
   Transpose -> typeOfOp1
+  SearchRatTensor {} -> developerError "SearchRatTensor not supported in linearity typing"
 
 typeOfConstructor :: BuiltinConstructor -> LinearityDSLExpr
 typeOfConstructor = \case

--- a/vehicle/src/Vehicle/Data/Builtin/Loss.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Loss.hs
@@ -15,7 +15,7 @@ import Vehicle.Data.Builtin.Standard.Core qualified as S
 import Vehicle.Data.Code.Interface
 import Vehicle.Data.Real
 import Vehicle.Data.Tensor (Tensor)
-import Vehicle.Prelude (Name, Pretty (..))
+import Vehicle.Prelude (Pretty (..))
 
 --------------------------------------------------------------------------------
 -- Builtin datatype
@@ -113,6 +113,7 @@ data LossBuiltinFunction
   | -- Vector
     ForeachVector
   | AtVector
+  | SearchRatTensor
   deriving (Eq, Ord, Show, Generic)
 
 lossToStandardBuiltinFunction :: LossBuiltinFunction -> S.BuiltinFunction
@@ -142,20 +143,10 @@ lossToStandardBuiltinFunction = \case
   AppendList -> S.AppendList
   ForeachVector -> S.ForeachVector
   AtVector -> S.AtVector
+  SearchRatTensor -> S.SearchRatTensor
 
 instance Pretty LossBuiltinFunction where
   pretty = pretty . lossToStandardBuiltinFunction
-
---------------------------------------------------------------------------------
--- Extra loss builtin functions
-
-newtype LossBuiltinExtraFunction
-  = SearchRatTensor Name
-  deriving (Show, Eq, Ord, Generic)
-
-instance Pretty LossBuiltinExtraFunction where
-  pretty = \case
-    SearchRatTensor name -> "search[" <> pretty name <> "]"
 
 --------------------------------------------------------------------------------
 -- Builtin datatype
@@ -166,7 +157,6 @@ data LossBuiltin
   = LossBuiltinFunction LossBuiltinFunction
   | LossBuiltinType LossBuiltinType
   | LossBuiltinConstructor LossBuiltinConstructor
-  | LossBuiltinExtraFunction LossBuiltinExtraFunction
   deriving (Show, Eq, Ord, Generic)
 
 instance Pretty LossBuiltin where
@@ -373,6 +363,7 @@ instance NormalisableBuiltin LossBuiltin where
       ForeachTensor -> Eval evalForeachTensor
       ForeachVector -> Eval evalForeachVector
       AtVector -> Eval evalAtVector
+      SearchRatTensor {} -> None
     _ -> None
 
   isTypeClassOp _ = False
@@ -391,16 +382,11 @@ instance ConvertableBuiltin LossBuiltinConstructor Builtin where
 instance ConvertableBuiltin LossBuiltinFunction Builtin where
   convertBuiltin p = convertBuiltin p . lossToStandardBuiltinFunction
 
-instance ConvertableBuiltin LossBuiltinExtraFunction Builtin where
-  convertBuiltin p b = case b of
-    SearchRatTensor {} -> cheatConvertBuiltin p $ pretty b
-
 instance ConvertableBuiltin LossBuiltin Builtin where
   convertBuiltin p b = case b of
     LossBuiltinType op -> convertBuiltin p op
     LossBuiltinConstructor op -> convertBuiltin p op
     LossBuiltinFunction op -> convertBuiltin p op
-    LossBuiltinExtraFunction op -> convertBuiltin p op
 
 instance PrintableBuiltin LossBuiltin where
   coercionArgs = const Nothing

--- a/vehicle/src/Vehicle/Data/Builtin/Polarity/Type.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Polarity/Type.hs
@@ -93,6 +93,7 @@ typeOfBuiltinFunction = \case
   ForeachVector -> typeOfForeach
   Iterate -> typeOfIterate
   Transpose -> forAllPolarities $ \pol -> pol ~> pol
+  SearchRatTensor {} -> developerError "SearchRatTensor not supported in polarity typing"
 
 typeOfConstructor :: BuiltinConstructor -> PolarityDSLExpr
 typeOfConstructor = \case

--- a/vehicle/src/Vehicle/Data/Builtin/Standard/Normalise.hs
+++ b/vehicle/src/Vehicle/Data/Builtin/Standard/Normalise.hs
@@ -54,6 +54,7 @@ instance Forced.NormalisableBuiltin Builtin where
       ForeachVector -> Forced.Eval Forced.evalForeachVector
       Iterate -> Forced.Eval Forced.evalIterate
       Transpose -> Forced.Eval Forced.evalTransposeTensor
+      SearchRatTensor {} -> Forced.None
       QuantifyRatTensor {} -> Forced.None
       QuantifyRecord {} -> Forced.None
     BuiltinCast c -> case c of

--- a/vehicle/tests/golden/errors/lossOutputs/unsupportedType/Loss.err.golden
+++ b/vehicle/tests/golden/errors/lossOutputs/unsupportedType/Loss.err.golden
@@ -1,1 +1,1 @@
-Error in file 'unknown' at Line 0, Columns 0-0: Loss functions do not yet support compilation of 'LossBuiltinType UnitType' .
+Error in file 'unknown' at Line 0, Columns 0-0: Loss functions do not yet support compilation of 'Unit' .

--- a/vehicle/tests/golden/features/constantInput/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/constantInput/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 spec : (Tensor Real -> Tensor Real) -> Tensor Real;
-spec = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x, 0.0] - 0.0))
+spec = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x, 0.0] - 0.0))

--- a/vehicle/tests/golden/features/foreach/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/foreach/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 safe : (Tensor Real -> Tensor Real) -> Tensor Real;
-safe = \ f -> const 1.0 nil / search[x] [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> max (const 0.0 nil) (f (x + (const 4.0 [2])) ! 0 - 0.0))
+safe = \ f -> const 1.0 nil / search [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> max (const 0.0 nil) (f (x + (const 4.0 [2])) ! 0 - 0.0))

--- a/vehicle/tests/golden/features/gaussianElim/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/gaussianElim/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 test1 : (Tensor Real -> Tensor Real) -> Tensor Real;
-test1 = \ f -> search[a] nil 0.0 1.0 (\ a -> reduceAdd (- (max (const 0.0 [1]) (f [a + 2.0] - (const 0.0 [1])) + max (const 0.0 [1]) ((const 0.0 [1]) - f [a + 2.0]))))
+test1 = \ f -> search nil 0.0 1.0 (\ a -> reduceAdd (- (max (const 0.0 [1]) (f [a + 2.0] - (const 0.0 [1])) + max (const 0.0 [1]) ((const 0.0 [1]) - f [a + 2.0]))))

--- a/vehicle/tests/golden/features/lossOutputs/DefaultOnlyProperty.vcl.golden
+++ b/vehicle/tests/golden/features/lossOutputs/DefaultOnlyProperty.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 belowOne : (Tensor Real -> Tensor Real) -> Tensor Real;
-belowOne = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))
+belowOne = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))

--- a/vehicle/tests/golden/features/lossOutputs/PropertyAndNonProperty.vcl.golden
+++ b/vehicle/tests/golden/features/lossOutputs/PropertyAndNonProperty.vcl.golden
@@ -4,4 +4,4 @@ predicted = \ f -> f (const 0.0 [4])
 
 @property;
 belowOne : (Tensor Real -> Tensor Real) -> Tensor Real;
-belowOne = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))
+belowOne = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (1.0 - f [x, x, x, x] ! 0))

--- a/vehicle/tests/golden/features/pruneDecls/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/pruneDecls/DL2Loss.vcl.golden
@@ -1,7 +1,7 @@
 @property;
 p1 : (Tensor Real -> Tensor Real) -> Tensor Real;
-p1 = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - (0.0 + 1.0)))
+p1 = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - (0.0 + 1.0)))
 
 @property;
 p2 : (Tensor Real -> Tensor Real) -> Tensor Real;
-p2 = \ g -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (g x - 0.0))
+p2 = \ g -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (g x - 0.0))

--- a/vehicle/tests/golden/features/quantifier/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/features/quantifier/DL2Loss.vcl.golden
@@ -1,7 +1,7 @@
 @property;
 expandedExpr : (Tensor Real -> Tensor Real) -> Tensor Real;
-expandedExpr = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (x - f x))
+expandedExpr = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (x - f x))
 
 @property;
 parallel : (Tensor Real -> Tensor Real) -> Tensor Real;
-parallel = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - 0.0)) + search[y] nil 0.0 1.0 (\ y -> max (const 0.0 nil) (5.0 - f y))
+parallel = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f x - 0.0)) + search nil 0.0 1.0 (\ y -> max (const 0.0 nil) (5.0 - f y))

--- a/vehicle/tests/golden/issues/issue1067/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1067/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 boundedRobust : (Tensor Real -> Tensor Real) -> Tensor Real;
-boundedRobust = \ f -> const 1.0 nil / search[x] [1] (const -1.0 [1]) (const 1.0 [1]) (\ x -> search[x_hat] [1] (const -1.0 [1]) (const 1.0 [1]) (\ x_hat -> reduceMul (max (const 0.0 [1]) (f x - f x_hat - - (const 1.0 [1]))) * reduceMul (max (const 0.0 [1]) ((const 1.0 [1]) - (f x - f x_hat)))))
+boundedRobust = \ f -> const 1.0 nil / search [1] (const -1.0 [1]) (const 1.0 [1]) (\ x -> search [1] (const -1.0 [1]) (const 1.0 [1]) (\ x_hat -> reduceMul (max (const 0.0 [1]) (f x - f x_hat - - (const 1.0 [1]))) * reduceMul (max (const 0.0 [1]) ((const 1.0 [1]) - (f x - f x_hat)))))

--- a/vehicle/tests/golden/issues/issue1086/Loss.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1086/Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 p : (Tensor Real -> Tensor Real) -> Tensor Real;
-p = \ f -> const 1.0 nil / search[x] [1] (const 0.0 [1]) (const 1.0 [1]) (\ x -> max (const 0.0 nil) (f x - 0.0))
+p = \ f -> const 1.0 nil / search [1] (const 0.0 [1]) (const 1.0 [1]) (\ x -> max (const 0.0 nil) (f x - 0.0))

--- a/vehicle/tests/golden/issues/issue1089/DL2Loss1.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1089/DL2Loss1.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 boundedByEpsilon : (Tensor Real -> Tensor Real) -> Tensor Real -> Tensor Real;
-boundedByEpsilon = \ net -> \ epsilon -> const 1.0 nil / search[x] [1] [-1.0 * epsilon] [-1.0 * (-1.0 * epsilon)] (\ x -> max (const 0.0 nil) (net x ! 0 - - epsilon) * max (const 0.0 nil) (epsilon - net x ! 0))
+boundedByEpsilon = \ net -> \ epsilon -> const 1.0 nil / search [1] [-1.0 * epsilon] [-1.0 * (-1.0 * epsilon)] (\ x -> max (const 0.0 nil) (net x ! 0 - - epsilon) * max (const 0.0 nil) (epsilon - net x ! 0))

--- a/vehicle/tests/golden/issues/issue1089/DL2Loss2.vcl.golden
+++ b/vehicle/tests/golden/issues/issue1089/DL2Loss2.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 boundedByEpsilonFactor : (Tensor Real -> Tensor Real) -> Tensor Real -> Tensor Real -> Tensor Real;
-boundedByEpsilonFactor = \ net -> \ epsilon -> \ factor -> const 1.0 nil / search[x] [1] [-1.0 * epsilon * factor] [-1.0 * (-1.0 * (epsilon * factor))] (\ x -> max (const 0.0 nil) (net x ! 0 - - (epsilon / factor)) * max (const 0.0 nil) (epsilon / factor - net x ! 0))
+boundedByEpsilonFactor = \ net -> \ epsilon -> \ factor -> const 1.0 nil / search [1] [-1.0 * epsilon * factor] [-1.0 * (-1.0 * (epsilon * factor))] (\ x -> max (const 0.0 nil) (net x ! 0 - - (epsilon / factor)) * max (const 0.0 nil) (epsilon / factor - net x ! 0))

--- a/vehicle/tests/golden/specifications/bounded/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/bounded/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 bounded : (Tensor Real -> Tensor Real) -> Tensor Real;
-bounded = \ f -> const 1.0 nil / search[x] nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x] ! 0 - 0.0) * max (const 0.0 nil) (1.0 - f [x] ! 0))
+bounded = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x -> max (const 0.0 nil) (f [x] ! 0 - 0.0) * max (const 0.0 nil) (1.0 - f [x] ! 0))

--- a/vehicle/tests/golden/specifications/increasing/VehicleLoss.vcl.golden
+++ b/vehicle/tests/golden/specifications/increasing/VehicleLoss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 increasing : (Tensor Real -> Tensor Real) -> Tensor Real;
-increasing = \ f -> - search[x] nil 0.0 1.0 (\ x -> f x - x)
+increasing = \ f -> - search nil 0.0 1.0 (\ x -> f x - x)

--- a/vehicle/tests/golden/specifications/monotonicity/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/monotonicity/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 monotonic : (Tensor Real -> Tensor Real) -> Tensor Real;
-monotonic = \ f -> const 1.0 nil / search[x1] nil 0.0 1.0 (\ x1 -> search[x2] nil (max 0.0 x1) 1.0 (\ x2 -> max (const 0.0 nil) (f x2 - f x1)))
+monotonic = \ f -> const 1.0 nil / search nil 0.0 1.0 (\ x1 -> search nil (max 0.0 x1) 1.0 (\ x2 -> max (const 0.0 nil) (f x2 - f x1)))

--- a/vehicle/tests/golden/specifications/reachability/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/reachability/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 reachable : (Tensor Real -> Tensor Real) -> Tensor Real;
-reachable = \ f -> search[x] [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> - (max (const 0.0 nil) (f x - 0.0) + max (const 0.0 nil) (0.0 - f x)))
+reachable = \ f -> search [2] (const 0.0 [2]) (const 1.0 [2]) (\ x -> - (max (const 0.0 nil) (f x - 0.0) + max (const 0.0 nil) (0.0 - f x)))

--- a/vehicle/tests/golden/specifications/windController/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/specifications/windController/DL2Loss.vcl.golden
@@ -1,3 +1,3 @@
 @property;
 safe : (Tensor Real -> Tensor Real) -> Tensor Real;
-safe = \ controller -> const 1.0 nil / search[x] [2] (const -3.25 [2]) (const 3.25 [2]) (\ x -> max (const 0.0 nil) (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1 - - 1.25) * max (const 0.0 nil) (1.25 - (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1)))
+safe = \ controller -> const 1.0 nil / search [2] (const -3.25 [2]) (const 3.25 [2]) (\ x -> max (const 0.0 nil) (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1 - - 1.25) * max (const 0.0 nil) (1.25 - (controller ((x + (const 4.0 [2])) / (const 8.0 [2])) ! 0 + 2.0 * x ! 0 - x ! 1)))

--- a/vehicle/tests/golden/warnings/boundsOnlyQuantifier/DL2Loss.vcl.golden
+++ b/vehicle/tests/golden/warnings/boundsOnlyQuantifier/DL2Loss.vcl.golden
@@ -1,7 +1,7 @@
 @property;
 prop1 : Tensor Real;
-prop1 = search[x] nil 0.0 1.0 (\ x -> 0.0)
+prop1 = search nil 0.0 1.0 (\ x -> 0.0)
 
 @property;
 prop2 : Tensor Real;
-prop2 = search[x] nil 0.5 1.5 (\ x -> 0.0) * search[x] nil 0.0 1.0 (\ x -> 0.0)
+prop2 = search nil 0.5 1.5 (\ x -> 0.0) * search nil 0.0 1.0 (\ x -> 0.0)


### PR DESCRIPTION
This preparatory step opens the way to:
- Exporting the original specification (without converting boolean operations to losses) to JSON so we can check whether a given assignment/counter-example is really valid. This will be especially useful for @kksnowy's work on attacking specifications. 
- Exporting the unnormalised specification to JSON rather than normalising it first as discussed with @ggustavs.

Once again @wenkokke was correct all those years ago :grin: 