### PR TITLE
Support specification/cache exclusivity for vehicle export

### DIFF
--- a/vehicle/src/Vehicle/CommandLine.hs
+++ b/vehicle/src/Vehicle/CommandLine.hs
@@ -353,9 +353,14 @@ exportParser :: Parser ExportOptions
 exportParser =
   ExportOptions
     <$> itpParser
-    <*> exportCacheParser
+    <*> optional specificationParser
+    <*> declarationParser
+    <*> networkParser
+    <*> datasetParser
+    <*> parameterParser
     <*> outputParser
     <*> modulePrefixOption
+    <*> optional exportCacheParser
     <*> compileConstReals
 
 exportParserInfo :: ParserInfo ModeOptions

--- a/vehicle/src/Vehicle/Export.hs
+++ b/vehicle/src/Vehicle/Export.hs
@@ -1,9 +1,11 @@
 module Vehicle.Export where
 
 import Control.Monad.IO.Class (MonadIO (..))
+import Data.Map qualified as Map
 import Vehicle.Backend.Prelude
 import Vehicle.Compile
-import Vehicle.Prelude.IO (MonadStdIO)
+import Vehicle.Prelude (DeclarationNames)
+import Vehicle.Prelude.IO (MonadStdIO, fatalError)
 import Vehicle.Prelude.Logging
 import Vehicle.Resource
 import Vehicle.Verify.Specification (SpecificationCacheIndex (..))
@@ -11,31 +13,68 @@ import Vehicle.Verify.Specification.IO
 
 data ExportOptions = ExportOptions
   { target :: InteractiveTheoremProverID,
-    verificationCache :: FilePath,
+    specification :: Maybe FilePath,
+    declarationsToCompile :: DeclarationNames,
+    networkLocations :: NetworkLocations,
+    datasetLocations :: DatasetLocations,
+    parameterValues :: ParameterValues,
     output :: Maybe FilePath,
     moduleName :: Maybe String,
+    verificationCache :: Maybe FilePath,
     constructiveReals :: Bool
   }
   deriving (Eq, Show)
 
 export :: (MonadStdIO IO) => LoggingSettings -> OutputAsJSON -> ExportOptions -> IO ()
 export loggingSettings outputAsJSON ExportOptions {..} = do
-  let cacheIndexFile = specificationCacheIndexFileName verificationCache
-  SpecificationCacheIndex {..} <- liftIO $ readSpecificationCacheIndex cacheIndexFile
-  let spec = filePath $ specificationSummary resourcesIntegrityInfo
-  let resources = reparseResources resourcesIntegrityInfo
+  itpOptions <-
+    case (specification, verificationCache) of
+      (Just spec, Nothing) ->
+        return $
+          mkITPOptions
+            spec
+            declarationsToCompile
+            networkLocations
+            datasetLocations
+            parameterValues
+            Nothing
+      (Nothing, Just _)
+        | not (null declarationsToCompile)
+            || not (Map.null networkLocations)
+            || not (Map.null datasetLocations)
+            || not (Map.null parameterValues) ->
+            fatalError
+              "`--declaration`, `--network`, `--dataset`, and `--parameter` may only be used with `--specification`, not `--cache`."
+      (Nothing, Just cache) -> do
+        let cacheIndexFile = specificationCacheIndexFileName cache
+        SpecificationCacheIndex {..} <- liftIO $ readSpecificationCacheIndex cacheIndexFile
+        let spec = filePath $ specificationSummary resourcesIntegrityInfo
+        let resources = reparseResources resourcesIntegrityInfo
+        return $
+          mkITPOptions
+            spec
+            (fmap fst properties)
+            (networks resources)
+            (datasets resources)
+            (parameters resources)
+            (Just cache)
+      (Nothing, Nothing) ->
+        fatalError "`vehicle export` requires exactly one of `--cache` or `--specification`."
+      (Just _, Just _) ->
+        fatalError "`--cache` and `--specification` are mutually exclusive; provide exactly one."
 
-  compile loggingSettings outputAsJSON $
-    ITPTarget $
+  compile loggingSettings outputAsJSON $ ITPTarget itpOptions
+  where
+    mkITPOptions spec decls networkLocs datasetLocs parameterVals cache =
       ITPOptions
         { itp = target,
           specification = spec,
-          declarationsToCompile = fmap fst properties,
-          networkLocations = networks resources,
-          datasetLocations = datasets resources,
-          parameterValues = parameters resources,
+          declarationsToCompile = decls,
+          networkLocations = networkLocs,
+          datasetLocations = datasetLocs,
+          parameterValues = parameterVals,
           outputFile = output,
           moduleName = moduleName,
-          verificationCache = Just verificationCache,
+          verificationCache = cache,
           constructiveReals = constructiveReals
         }

--- a/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
+++ b/vehicle/tests/unit/Vehicle/Test/Unit/Compile/CommandLine.hs
@@ -7,6 +7,7 @@ import Data.Map qualified as Map (fromList)
 import Options.Applicative (ParserResult (..), defaultPrefs, execParserPure)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+import Vehicle.Backend.Prelude (InteractiveTheoremProverID (..))
 import Vehicle.CommandLine
   ( GlobalOptions (..),
     ModeOptions (..),
@@ -14,6 +15,7 @@ import Vehicle.CommandLine
     commandLineOptionsParserInfo,
     defaultGlobalOptions,
   )
+import Vehicle.Export (ExportOptions (..))
 import Vehicle.List (ListOptions (..))
 import Vehicle.Prelude
   ( Pretty (pretty),
@@ -35,7 +37,8 @@ commandLineParserTests =
       checkModeTests,
       verifyTests,
       validateModeTests,
-      listModeTests
+      listModeTests,
+      exportModeTests
     ]
 
 noModeTests :: TestTree
@@ -122,6 +125,63 @@ validateModeTests =
                 Validate $
                   ValidateOptions
                     { verificationCache = "local/outputFolder"
+                    }
+          }
+    ]
+
+exportModeTests :: TestTree
+exportModeTests =
+  testGroup
+    "exportMode"
+    [ parserTest
+        "cache"
+        "vehicle export \
+        \--target Agda \
+        \--cache local/outputFolder"
+        $ Options
+          { globalOptions = defaultGlobalOptions,
+            modeOptions =
+              Just $
+                Export $
+                  ExportOptions
+                    { target = Agda,
+                      specification = Nothing,
+                      declarationsToCompile = mempty,
+                      networkLocations = mempty,
+                      datasetLocations = mempty,
+                      parameterValues = mempty,
+                      output = Nothing,
+                      moduleName = Nothing,
+                      verificationCache = Just "local/outputFolder",
+                      constructiveReals = False
+                    }
+          },
+      parserTest
+        "specification"
+        "vehicle export \
+        \--target Rocq \
+        \--specification test/spec.vcl \
+        \--declaration property \
+        \--network f:test/network.onnx \
+        \--dataset d:test/dataset.idx \
+        \--parameter p:1 \
+        \--output test/spec.v"
+        $ Options
+          { globalOptions = defaultGlobalOptions,
+            modeOptions =
+              Just $
+                Export $
+                  ExportOptions
+                    { target = Rocq,
+                      specification = Just "test/spec.vcl",
+                      declarationsToCompile = ["property"],
+                      networkLocations = Map.fromList [("f", "test/network.onnx")],
+                      datasetLocations = Map.fromList [("d", "test/dataset.idx")],
+                      parameterValues = Map.fromList [("p", "1")],
+                      output = Just "test/spec.v",
+                      moduleName = Nothing,
+                      verificationCache = Nothing,
+                      constructiveReals = False
                     }
           }
     ]


### PR DESCRIPTION
implements the `vehicle export` CLI behaviour discussed in #1196 

- require exactly one of `--cache` or `--specification`
- allow `--declaration`, `--network`, `--dataset`, and `--parameter` when
  exporting directly from a specification
- preserve the existing behaviour when exporting from a verification cache
- reject specification-specific resource arguments when `--cache` is used
- provide specific errors when both inputs or neither input are supplied
- add command-line parser tests for both export modes

Related to #1196