### PR TITLE
Cancel workflow if new commit pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
       - reopened
   merge_group:
 
+# Ensures that the old workflow gets cancelled if a new
+# version of the PR/branch commit gets pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ on:
       - reopened
   merge_group:
 
-# Ensures that the old workflow gets cancelled if a new
-# version of the PR/branch commit gets pushed.
+# Ensures that the previous workflow gets cancelled if a new
+# commit is pushed to the PR or branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Stops CI from consuming large amounts of GitHub resources if we are pushing a rapid sequence of commits.