### PR TITLE
Add Python tests to CI

### DIFF
--- a/.github/workflows/build-vehicle-python.yml
+++ b/.github/workflows/build-vehicle-python.yml
@@ -71,7 +71,7 @@ jobs:
           CIBW_BUILD: "*${{ matrix.os.plat }}*"
           CIBW_ARCHS: "${{ matrix.os.arch }}"
           CIBW_TEST_EXTRAS: "${{ matrix.os.test }}"
-          CIBW_TEST_COMMAND: "python -m pytest {project}/tests"
+          CIBW_TEST_COMMAND: "python -m pytest {package}/tests"
           CIBW_BEFORE_ALL_LINUX: "cabal update"
           MACOSX_DEPLOYMENT_TARGET: "${{ matrix.os.arch == 'x86_64' && '10.10' || '11.0' }}"
 

--- a/.github/workflows/build-vehicle-python.yml
+++ b/.github/workflows/build-vehicle-python.yml
@@ -71,6 +71,7 @@ jobs:
           CIBW_BUILD: "*${{ matrix.os.plat }}*"
           CIBW_ARCHS: "${{ matrix.os.arch }}"
           CIBW_TEST_EXTRAS: "${{ matrix.os.test }}"
+          CIBW_TEST_COMMAND: "python -m pytest {project}/tests"
           CIBW_BEFORE_ALL_LINUX: "cabal update"
           MACOSX_DEPLOYMENT_TARGET: "${{ matrix.os.arch == 'x86_64' && '10.10' || '11.0' }}"
 

--- a/vehicle-python/src/vehicle_lang/session/_functions.py
+++ b/vehicle-python/src/vehicle_lang/session/_functions.py
@@ -22,12 +22,10 @@ def check_output(
     """
     Execute a Vehicle command and capture its output.
 
-    Uses PTY-based output capture to handle C-level stdout from the Haskell RTS.
-
     :param args: The command-line arguments to pass to Vehicle.
     :return: A tuple of (exit_code, stdout, stderr, log_file_content).
     """
-    return Session().__enter__().check_output_pty(args)
+    return Session().__enter__().check_output(args)
 
 
 def execute_command(

--- a/vehicle-python/src/vehicle_lang/session/_session.py
+++ b/vehicle-python/src/vehicle_lang/session/_session.py
@@ -1,9 +1,8 @@
 import atexit
-import io
 import os
 import pty
 import sys
-from contextlib import AbstractContextManager, redirect_stderr, redirect_stdout
+from contextlib import AbstractContextManager
 from types import TracebackType
 from typing import ClassVar, Optional, Sequence, Type
 
@@ -66,28 +65,11 @@ class Session(SessionContextManager):
             raise VehicleSessionClosed()
 
     def check_output(
-        self,
-        args: Sequence[str],
-    ) -> tuple[int, Optional[str], Optional[str], Optional[str]]:
-        with redirect_stdout(io.StringIO()) as out:
-            with redirect_stderr(io.StringIO()) as err:
-                with temporary_files("log", prefix="vehicle") as (log,):
-                    exitCode = self.check_call(
-                        [
-                            f"--redirect-logs={log}",
-                            *args,
-                        ]
-                    )
-                    return (
-                        exitCode,
-                        out.getvalue() or None,
-                        err.getvalue() or None,
-                        log.read_text(),
-                    )
-
-    def check_output_pty(
         self, args: Sequence[str]
     ) -> tuple[int, Optional[str], Optional[str], Optional[str]]:
+        """
+        Uses PTY-based output capture to handle C-level stdout from the Haskell RTS.
+        """
         import select
         import threading
 


### PR DESCRIPTION
For some reason the Python tests are never actually on run on CI. This will keep me honest and hopefully avoid future breakages.