### PR TITLE
Avoid recompiling Vehicle twice on Haskell CI

### DIFF
--- a/.github/workflows/build-vehicle.yml
+++ b/.github/workflows/build-vehicle.yml
@@ -191,13 +191,9 @@ jobs:
             ${{ matrix.haskell.cabal.extra-args-test-golden }}
         shell: sh
 
-      - name: 🏗️ Install Vehicle
+      - name: 🏗️ Build the Vehicle .exe
         run: |
-          mkdir -p bin
-          cabal install                                             \
-            vehicle:exe:vehicle                                     \
-            --overwrite-policy=always                               \
-            --install-method=copy                                   \
-            --installdir=bin                                        \
-            --project-file=${{ matrix.haskell.cabal.project-file }} \
+          cabal build                                                \
+            vehicle:exe:vehicle                                      \
+            --project-file=${{ matrix.haskell.cabal.project-file }}  \
             ${{ matrix.haskell.cabal.extra-args }}


### PR DESCRIPTION
Still tests building the .exe. We don't seem to use the produced executable anywhere in CI so removing the instructions to build it in a particular place.